### PR TITLE
Add error dispatches for engagement uploading

### DIFF
--- a/met-web/src/components/engagement/view/ActionContext.tsx
+++ b/met-web/src/components/engagement/view/ActionContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getEngagement } from '../../../services/engagementService';
 import { Engagement } from '../../../models/engagement';
+import { useAppDispatch } from 'hooks';
+import { openNotification } from 'services/notificationService/notificationSlice';
 
 export interface EngagementViewContext {
     savedEngagement: Engagement;
@@ -37,6 +39,7 @@ export const ActionContext = createContext<EngagementViewContext>({
 export const ActionProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
     const { engagementId } = useParams<EngagementParams>();
     const navigate = useNavigate();
+    const dispatch = useAppDispatch();
 
     const [savedEngagement, setSavedEngagement] = useState<Engagement>({
         id: 0,
@@ -72,6 +75,12 @@ export const ActionProvider = ({ children }: { children: JSX.Element | JSX.Eleme
             (errorMessage: string) => {
                 //TODO engagement created success message in notification module
                 console.log(errorMessage);
+                dispatch(
+                    openNotification({
+                        severity: 'error',
+                        text: 'Error occurred while fetching Engagement information',
+                    }),
+                );
                 navigate('/');
             },
         );

--- a/met-web/src/components/imageUpload/index.tsx
+++ b/met-web/src/components/imageUpload/index.tsx
@@ -27,6 +27,7 @@ const ImageUpload = ({ handleAddFile, savedImageUrl = '' }: ImageUploadProps) =>
                     style={{
                         border: '1px dashed #606060',
                         height: '10em',
+                        padding: '0',
                     }}
                 >
                     <img

--- a/met-web/src/components/layout/Header/LoggedOutHeader.tsx
+++ b/met-web/src/components/layout/Header/LoggedOutHeader.tsx
@@ -6,9 +6,13 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import UserService from 'services/userService';
 import { useMediaQuery, Theme } from '@mui/material';
+import { useLocation } from 'react-router-dom';
 
 const LoggedOutHeader = () => {
     const isMediumScreen: boolean = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
+    const location = useLocation();
+    const loginPage = location.pathname === '/';
+    console.log('location', location.pathname);
     return (
         <Box sx={{ flexGrow: 1 }}>
             <AppBar position="static">
@@ -21,11 +25,11 @@ const LoggedOutHeader = () => {
                             width: { xs: '7em', md: '15em' },
                             marginRight: { xs: '1em', md: '3em' },
                         }}
-                        alt="The house from the offer."
+                        alt="BC Logo."
                         src="https://www2.gov.bc.ca/StaticWebResources/static/gov3/images/gov_bc_logo.svg"
                     />
                     <Typography variant={isMediumScreen ? 'h3' : 'h6'} component="div" sx={{ flexGrow: 1 }}>
-                        Login to MET
+                        {loginPage ? 'Login to MET' : 'MET'}
                     </Typography>
                     <Button color="inherit" onClick={() => UserService.doLogin()}>
                         Login

--- a/met-web/src/services/notificationService/notificationSlice.tsx
+++ b/met-web/src/services/notificationService/notificationSlice.tsx
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { NotificationState } from './types';
+import { NotificationState, OpenNotificationProps } from './types';
 
 const initialState: NotificationState = {
     open: false,
@@ -11,8 +11,8 @@ export const notificationSlice = createSlice({
     name: 'notification',
     initialState,
     reducers: {
-        openNotification: (state: NotificationState, action: PayloadAction<NotificationState>) => {
-            state.open = action.payload.open;
+        openNotification: (state: NotificationState, action: PayloadAction<OpenNotificationProps>) => {
+            state.open = true;
             state.severity = action.payload.severity;
             state.text = action.payload.text;
         },

--- a/met-web/src/services/notificationService/types.ts
+++ b/met-web/src/services/notificationService/types.ts
@@ -4,4 +4,9 @@ export interface NotificationState {
     text: string;
 }
 
+export interface OpenNotificationProps {
+    severity: AlertColor;
+    text: string;
+}
+
 export type AlertColor = 'success' | 'info' | 'warning' | 'error';

--- a/met-web/src/services/objectStorageService/index.ts
+++ b/met-web/src/services/objectStorageService/index.ts
@@ -24,14 +24,12 @@ const getFile = async (headerDetails: ObjectStorageHeaderDetails) => {
 };
 
 const saveFile = async (headerDetails: ObjectStorageHeaderDetails, file: File) => {
-    console.log('B');
     try {
         return await http.OSSPutRequest(headerDetails.filepath, file, {
             amzDate: headerDetails.amzdate,
             authHeader: headerDetails.authheader,
         });
     } catch (error) {
-        console.log('B.error', error);
         return Promise.reject(error);
     }
 };
@@ -45,6 +43,7 @@ export const downloadDocument = async (file: ObjectStorageFileDetails) => {
         return await getFile(response.data.result[0]);
     } catch (error) {
         console.log(error);
+        return Promise.reject(error);
     }
 };
 
@@ -57,6 +56,7 @@ export const saveDocument = async (file: File, fileDetails: ObjectStorageFileDet
         await saveFile(fileDetailsResponse.data.result[0], file);
         return fileDetailsResponse.data.result[0];
     } catch (error) {
-        console.log('A.error', error);
+        console.log(error);
+        return Promise.reject(error);
     }
 };

--- a/met-web/src/utils/index.ts
+++ b/met-web/src/utils/index.ts
@@ -1,3 +1,8 @@
 export function hasKey<O>(obj: O, key: PropertyKey): key is keyof O {
     return key in obj;
 }
+
+export function getErrorMessage(error: unknown) {
+    if (error instanceof Error) return error.message;
+    return String(error);
+}


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/262

*Description of changes:*

- Trigger alert message for failed banner image upload
- For logged out header only show title "Login To Met" on landing page
- remove padding for banner image display in engagement form

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
