### PR TITLE
Add terms and conditions text to email verification modal

### DIFF
--- a/met-web/src/components/engagement/view/EmailPanel.tsx
+++ b/met-web/src/components/engagement/view/EmailPanel.tsx
@@ -45,15 +45,15 @@ const EmailPanel = ({ email, checkEmail, handleClose, updateEmail, isSaving }: E
     };
 
     return (
-        <Grid
-            container
-            direction="row"
-            sx={{ ...modalStyle }}
-            alignItems="flex-start"
-            justifyContent="flex-start"
-            rowSpacing={2}
-        >
-            <form onSubmit={(e) => handleSubmit(e)}>
+        <form onSubmit={(e) => handleSubmit(e)}>
+            <Grid
+                container
+                direction="row"
+                sx={{ ...modalStyle }}
+                alignItems="flex-start"
+                justifyContent="flex-start"
+                rowSpacing={2}
+            >
                 <Grid item xs={12}>
                     <Typography variant="h4" sx={{ mb: 2, fontWeight: 'bold' }}>
                         Verify your email address
@@ -61,27 +61,31 @@ const EmailPanel = ({ email, checkEmail, handleClose, updateEmail, isSaving }: E
                 </Grid>
 
                 <Grid item xs={12}>
-                    <Typography>
+                    <Typography variant="body1">
                         To provide you with the best experience possible. We require you to validate your email address.
                     </Typography>
                 </Grid>
 
                 <Grid item xs={12}>
-                    <Typography>
+                    <Typography variant="body1">
                         You will receive a link to access the survey at the email address you provide.
                     </Typography>
                 </Grid>
 
                 <Grid item xs={12}>
                     <Typography
-                        variant="subtitle2"
-                        sx={{ p: '1em', borderLeft: 8, borderColor: '#003366', backgroundColor: '#F2F2F2' }}
+                        variant="body2"
+                        sx={{ p: '1em', borderLeft: 8, borderColor: '#003366', backgroundColor: '#F2F2F2', mt: '2em' }}
                     >
-                        "On the other hand, we denounce with righteous indignation and dislike men who are so beguiled
-                        and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot
-                        foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail
-                        in their duty through weakness of will, which is the same as saying through shrinking from toil
-                        and pain.
+                        {`
+                            Personal information (your email address) is collected under section 26(c) and 26(e) of the Freedom of Information\
+                            and Protection of Privacy Act, to keep you updated on current engagements and to notify you of future opportunities to participate.
+                        `}
+                        <br />
+                        <br />
+                        {
+                            'If you have any questions about the collection, use and disclosure of your personal information, please contact <TBC>'
+                        }
                     </Typography>
                 </Grid>
                 <Grid
@@ -142,8 +146,8 @@ const EmailPanel = ({ email, checkEmail, handleClose, updateEmail, isSaving }: E
                         </Button>
                     </Stack>
                 </Grid>
-            </form>
-        </Grid>
+            </Grid>
+        </form>
     );
 };
 

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -80,6 +80,14 @@ export const BaseTheme = createTheme({
             fontWeight: 500,
             fontSize: '1.15rem',
         },
+        body1: {
+            fontWeight: 500,
+            fontSize: '16px',
+        },
+        body2: {
+            fontWeight: 500,
+            fontSize: '0.8rem',
+        },
         button: {
             fontWeight: 700,
             fontSize: '1.2rem',


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/414

*Description of changes:*

- Add terms and conditions to email verification modal
- Add spacing and update text sizing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
