### PR TITLE
Add settings tab for create engagement page

### DIFF
--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { Typography, Grid, TextField, CircularProgress } from '@mui/material';
-import { MetPaper, MidScreenLoader, MetLabel, PrimaryButton, SecondaryButton } from '../../common';
+import { MetPaper, MetLabel, PrimaryButton, SecondaryButton } from '../../common';
 import RichTextEditor from './RichTextEditor';
 import { ActionContext } from './ActionContext';
 import { formatDate } from '../../common/dateHelper';

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -1,20 +1,12 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { Typography, Grid, TextField, CircularProgress } from '@mui/material';
-import {
-    MetPaper,
-    MidScreenLoader,
-    MetPageGridContainer,
-    MetLabel,
-    PrimaryButton,
-    SecondaryButton,
-} from '../../common';
+import { MetPaper, MidScreenLoader, MetLabel, PrimaryButton, SecondaryButton } from '../../common';
 import RichTextEditor from './RichTextEditor';
 import { ActionContext } from './ActionContext';
 import { formatDate } from '../../common/dateHelper';
 import ImageUpload from 'components/imageUpload';
 import { useNavigate } from 'react-router-dom';
 import { AddSurveyBlock } from './AddSurveyBlock';
-import EngagementFormModal from './EngagementFormModal';
 
 const EngagementForm = () => {
     const {
@@ -23,7 +15,6 @@ const EngagementForm = () => {
         isSaving,
         savedEngagement,
         engagementId,
-        loadingSavedEngagement,
         handleAddBannerImage,
     } = useContext(ActionContext);
 
@@ -178,15 +169,8 @@ const EngagementForm = () => {
         window.scrollTo(0, 0);
     };
 
-    if (loadingSavedEngagement) {
-        return <MidScreenLoader />;
-    }
-
     return (
-        <MetPageGridContainer container direction="row" justifyContent="flex-start" alignItems="flex-start" spacing={2}>
-            <Grid item xs={12}>
-                <Typography variant="h4">Engagement Details</Typography>
-            </Grid>
+        <>
             <Grid item lg={8} xs={12}>
                 <MetPaper elevation={1}>
                     <Grid
@@ -354,8 +338,7 @@ const EngagementForm = () => {
                     </Grid>
                 </MetPaper>
             </Grid>
-            <EngagementFormModal />
-        </MetPageGridContainer>
+        </>
     );
 };
 

--- a/met-web/src/components/engagement/form/EngagementFormTabs.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import TabContext from '@mui/lab/TabContext';
+import EngagementForm from './EngagementForm';
+import EngagementSettings from './EngagementSettings';
+import { EngagementFormTab, EngagementFormTabList, EngagementFormTabPanel } from './StyledFormComponents';
+
+const EngagementFormTabs = () => {
+    const [value, setValue] = React.useState('details');
+
+    return (
+        <Box sx={{ width: '100%', typography: 'body1' }}>
+            <TabContext value={value}>
+                <Box sx={{ marginBottom: '0.25em' }}>
+                    <EngagementFormTabList
+                        onChange={(_event: React.SyntheticEvent, newValue: string) => setValue(newValue)}
+                        TabIndicatorProps={{
+                            style: { transition: 'none', display: 'none' },
+                        }}
+                    >
+                        <EngagementFormTab label="Engagement Details" value="details" />
+                        <EngagementFormTab label="Settings" value="settings" />
+                    </EngagementFormTabList>
+                </Box>
+                <EngagementFormTabPanel value="details">
+                    <EngagementForm />
+                </EngagementFormTabPanel>
+                <EngagementFormTabPanel value="settings">
+                    <EngagementSettings />
+                </EngagementFormTabPanel>
+            </TabContext>
+        </Box>
+    );
+};
+
+export default EngagementFormTabs;

--- a/met-web/src/components/engagement/form/EngagementFormWrapper.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormWrapper.tsx
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { MetPageGridContainer, MidScreenLoader } from 'components/common';
+import EngagementFormTabs from './EngagementFormTabs';
+import EngagementFormModal from './EngagementFormModal';
+import { ActionContext } from './ActionContext';
+
+const EngagementFormWrapper = () => {
+    const { loadingSavedEngagement } = useContext(ActionContext);
+
+    if (loadingSavedEngagement) {
+        return <MidScreenLoader />;
+    }
+
+    return (
+        <MetPageGridContainer container direction="row" justifyContent="flex-start" alignItems="flex-start" spacing={2}>
+            <EngagementFormTabs />
+            <EngagementFormModal />
+        </MetPageGridContainer>
+    );
+};
+
+export default EngagementFormWrapper;

--- a/met-web/src/components/engagement/form/EngagementSettings.tsx
+++ b/met-web/src/components/engagement/form/EngagementSettings.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useContext } from 'react';
+import { Grid, InputAdornment, TextField, Tooltip, Typography } from '@mui/material';
+import { MetLabel, MetPaper, PrimaryButton } from '../../common';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import { ActionContext } from './ActionContext';
+import { useAppDispatch } from 'hooks';
+import { openNotification } from 'services/notificationService/notificationSlice';
+
+const EngagementSettings = () => {
+    const { savedEngagement } = useContext(ActionContext);
+    const dispatch = useAppDispatch();
+
+    const newEngagement = !savedEngagement.id || isNaN(Number(savedEngagement.id));
+    const engagementUrl = newEngagement
+        ? 'Link will appear when the engagement is saved'
+        : `${window.location.origin}/engagement/view/${savedEngagement.id}`;
+
+    const [copyTooltip, setCopyTooltip] = useState(false);
+
+    const handleTooltipClose = () => {
+        setCopyTooltip(false);
+    };
+
+    const handleCopyUrl = () => {
+        if (newEngagement) {
+            dispatch(
+                openNotification({
+                    severity: 'error',
+                    text: 'Engagement link can only be copied after the engagement is saved',
+                }),
+            );
+            return;
+        }
+        setCopyTooltip(true);
+        navigator.clipboard.writeText(engagementUrl);
+    };
+
+    return (
+        <Grid item lg={8} xs={12}>
+            <MetPaper elevation={1}>
+                <Grid
+                    container
+                    direction="row"
+                    justifyContent="flex-start"
+                    alignItems="flex-start"
+                    spacing={1}
+                    sx={{ padding: '2em' }}
+                >
+                    <Grid item xs={12}>
+                        <MetLabel>Engagement Link</MetLabel>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Typography variant="body1">
+                            This is the link to the public engagement and will only be accessible once the engagement is
+                            published.
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ClickAwayListener onClickAway={handleTooltipClose}>
+                            <Tooltip
+                                title="Link copied!"
+                                PopperProps={{
+                                    disablePortal: true,
+                                }}
+                                onClose={handleTooltipClose}
+                                open={copyTooltip}
+                                disableFocusListener
+                                disableHoverListener
+                                disableTouchListener
+                                placement="right"
+                            >
+                                <TextField
+                                    id="engagement-name"
+                                    variant="outlined"
+                                    label=" "
+                                    InputLabelProps={{
+                                        shrink: false,
+                                    }}
+                                    fullWidth
+                                    value={engagementUrl}
+                                    disabled
+                                    sx={{
+                                        '.MuiInputBase-input': {
+                                            cursor: 'pointer',
+                                            marginRight: 0,
+                                            padding: '0 0 0 1em',
+                                        },
+                                        '.MuiInputBase-root': {
+                                            padding: 0,
+                                        },
+                                    }}
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end" sx={{ height: '100%', maxHeight: '100%' }}>
+                                                <PrimaryButton
+                                                    variant="contained"
+                                                    disableElevation
+                                                    onClick={handleCopyUrl}
+                                                >
+                                                    <ContentCopyIcon />
+                                                </PrimaryButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
+                                />
+                            </Tooltip>
+                        </ClickAwayListener>
+                    </Grid>
+                </Grid>
+            </MetPaper>
+        </Grid>
+    );
+};
+
+export default EngagementSettings;

--- a/met-web/src/components/engagement/form/StyledFormComponents.tsx
+++ b/met-web/src/components/engagement/form/StyledFormComponents.tsx
@@ -1,0 +1,21 @@
+import TabList from '@mui/lab/TabList';
+import Tab from '@mui/material/Tab';
+import TabPanel from '@mui/lab/TabPanel';
+import { styled } from '@mui/system';
+
+export const EngagementFormTab = styled(Tab)(() => ({
+    height: '0.5em',
+    minHeight: 0,
+}));
+
+export const EngagementFormTabList = styled(TabList)(() => ({
+    transition: 'none',
+    '& button': { border: '1px solid transparent', borderBottom: 'none' },
+    '& button.Mui-selected': { border: '1px solid #606060', borderBottom: 'none' },
+    paddingLeft: '1em',
+    minHeight: 0,
+}));
+
+export const EngagementFormTabPanel = styled(TabPanel)(() => ({
+    padding: 0,
+}));

--- a/met-web/src/components/engagement/form/index.tsx
+++ b/met-web/src/components/engagement/form/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import EngagementForm from './EngagementForm';
 import { ActionProvider } from './ActionContext';
+import EngagementFormWrapper from './EngagementFormWrapper';
 
 const Engagement = () => {
     return (
         <ActionProvider>
-            <EngagementForm />
+            <EngagementFormWrapper />
         </ActionProvider>
     );
 };


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/457

*Description of changes:*

- Add tab panel for engagement details and settings
- Add engagement settings tab
- Add copy engagement view url in settings tab

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
