### PR TITLE
Fixed created_date and updated_date for survey

### DIFF
--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -74,8 +74,8 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         new_survey = Survey(
             name=survey.get('name', None),
             form_json=survey.get('form_json', None),
-            created_date=survey.get('created_date', None),
-            updated_date=survey.get('updated_date', None),
+            created_date=datetime.now(),
+            updated_date=datetime.now(),
             created_by=survey.get('created_by', None),
             updated_by=survey.get('updated_by', None),
             engagement_id=survey.get('engagement_id', None),
@@ -90,7 +90,7 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         """Update survey."""
         update_fields = dict(
             form_json=survey.get('form_json', None),
-            updated_date=survey.get('updated_date', None),
+            updated_date=datetime.now(),
             updated_by=survey.get('updated_by', None),
         )
         survey_id = survey.get('id', None)

--- a/met-cron/src/met_cron/services/survey_etl_service.py
+++ b/met-cron/src/met_cron/services/survey_etl_service.py
@@ -51,7 +51,7 @@ class SurveyEtlService:  # pylint: disable=too-few-public-methods
     def _get_updated_surveys():
         time_delta_in_minutes: int = int(current_app.config.get('TIME_DELTA_IN_MINUTES'))
         time_delta = datetime.utcnow() - timedelta(minutes=time_delta_in_minutes)
-        new_surveys = db.session.query(MetSurveyModel).filter(MetSurveyModel.created_date > time_delta).all()
+        new_surveys = db.session.query(MetSurveyModel).filter(MetSurveyModel.updated_date > time_delta).all()
         return new_surveys
 
     @staticmethod


### PR DESCRIPTION
Fixed Survey ETL to be based on updated_date
Fixed created_date and updated_date for survey

*Issue #:*
https://github.com/bcgov/met-public/issues/<Put the github issue number here>

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
