### PR TITLE
Fix Rich Text editor copying over background and font family

### DIFF
--- a/met-web/src/components/engagement/form/RichTextEditor.tsx
+++ b/met-web/src/components/engagement/form/RichTextEditor.tsx
@@ -48,6 +48,7 @@ const RichTextEditor = ({
                         spellCheck
                         editorState={editorState}
                         onEditorStateChange={handleChange}
+                        handlePastedText={() => false}
                         editorStyle={{
                             height: '10em',
                             padding: '1em',


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/490

*Description of changes:*

- Add handlePastedText={() => false} as prop to the Editor component following https://github.com/jpuri/react-draft-wysiwyg/issues/498


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
