### PR TITLE
Add comment info modal

### DIFF
--- a/met-web/src/components/engagement/dashboard/report/CommentInfoModal.tsx
+++ b/met-web/src/components/engagement/dashboard/report/CommentInfoModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Modal, Grid, Typography } from '@mui/material';
+import { modalStyle, SecondaryButton } from 'components/common';
+
+interface CommentInfoModalProps {
+    modalOpen: boolean;
+    handleCloseModal: () => void;
+}
+const CommentInfoModal = ({ modalOpen, handleCloseModal }: CommentInfoModalProps) => {
+    const handleClose = () => {
+        handleCloseModal();
+    };
+
+    return (
+        <Modal open={modalOpen} onClose={handleClose}>
+            <Grid
+                container
+                direction="row"
+                justifyContent="flex-start"
+                alignItems="space-between"
+                sx={{ ...modalStyle, overflow: 'auto' }}
+                rowSpacing={2}
+            >
+                <Grid container item xs={12}>
+                    <Grid item xs={12}>
+                        <Typography variant="h4" sx={{ fontWeight: 'bold', mb: 1 }}>
+                            View Comments
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                            The comments will only be available to view after the engagement period is over and the
+                            engagement is closed.
+                        </Typography>
+                    </Grid>
+                </Grid>
+                <Grid item xs={12} container direction={{ xs: 'column', sm: 'row' }} justifyContent="flex-end">
+                    <SecondaryButton onClick={handleClose}>Cancel</SecondaryButton>
+                </Grid>
+            </Grid>
+        </Modal>
+    );
+};
+
+export default CommentInfoModal;

--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -10,6 +10,7 @@ import { getEngagement } from 'services/engagementService';
 import { getErrorMessage } from 'utils';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { useAppDispatch } from 'hooks';
+import CommentInfoModal from './CommentInfoModal';
 
 export type EngagementParams = {
     engagementId: string;
@@ -23,6 +24,7 @@ export const EngagementDashboard = () => {
 
     const [engagement, setEngagement] = useState<Engagement>(createDefaultEngagement());
     const [isEngagementLoading, setEngagementLoading] = useState(true);
+    const [commentInfoModalIsOpen, setCommentInfoModalIsOpen] = useState(false);
 
     const failIfInvalidEngagement = (engagementToValidate: Engagement) => {
         // submission status e.g. of pending or draft will have id less than of Open
@@ -56,6 +58,15 @@ export const EngagementDashboard = () => {
         };
         fetchEngagement();
     }, [engagementId]);
+
+    const handleReadComments = () => {
+        if (engagement.submission_status === SubmissionStatus.Closed) {
+            navigate(`/engagement/${engagement.id}/comments`);
+            return;
+        }
+
+        setCommentInfoModalIsOpen(true);
+    };
 
     if (isEngagementLoading) {
         return <Skeleton variant="rectangular" width="100%" height="60m" />;
@@ -103,9 +114,7 @@ export const EngagementDashboard = () => {
                             >
                                 <PrimaryButton
                                     data-testid="SurveyBlock/take-me-to-survey-button"
-                                    disabled={engagement.submission_status != SubmissionStatus.Closed}
-                                    component={Link}
-                                    to={`/engagement/${engagement.id}/comments`}
+                                    onClick={handleReadComments}
                                 >
                                     Read Comments
                                 </PrimaryButton>
@@ -120,6 +129,10 @@ export const EngagementDashboard = () => {
                     </MetPaper>
                 </Grid>
             </Grid>
+            <CommentInfoModal
+                modalOpen={commentInfoModalIsOpen}
+                handleCloseModal={() => setCommentInfoModalIsOpen(false)}
+            />
         </Grid>
     );
 };

--- a/met-web/src/components/engagement/form/EngagementFormModal.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormModal.tsx
@@ -13,12 +13,7 @@ const EngagementFormModal = () => {
     };
 
     return (
-        <Modal
-            open={modalOpen}
-            onClose={handleClose}
-            aria-labelledby="modal-modal-title"
-            aria-describedby="modal-modal-description"
-        >
+        <Modal open={modalOpen} onClose={handleClose}>
             <Grid
                 container
                 direction="row"


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/494

*Description of changes:*

- When engagement is still open and read comments is clicked a modal will appear explaining why user cannot view comments at that point


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).