### PR TITLE
Show the engagement name in the dashboard

### DIFF
--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -101,7 +101,9 @@ export const EngagementDashboard = () => {
                             rowSpacing={2}
                         >
                             <Grid item xs={12} sm={6}>
-                                <Typography variant={'h4'}>What we heard - {engagement.name}</Typography>
+                                <Typography variant={'h4'}>
+                                    What we heard - {engagement ? engagement.name : ''}
+                                </Typography>
                             </Grid>
                             <Grid
                                 item

--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -101,7 +101,7 @@ export const EngagementDashboard = () => {
                             rowSpacing={2}
                         >
                             <Grid item xs={12} sm={6}>
-                                <Typography variant={'h4'}>What we heard</Typography>
+                                <Typography variant={'h4'}>What we heard - {engagement.name}</Typography>
                             </Grid>
                             <Grid
                                 item

--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -101,9 +101,7 @@ export const EngagementDashboard = () => {
                             rowSpacing={2}
                         >
                             <Grid item xs={12} sm={6}>
-                                <Typography variant={'h4'}>
-                                    What we heard - {engagement ? engagement.name : ''}
-                                </Typography>
+                                <Typography variant={'h4'}>What we heard - {engagement.name}</Typography>
                             </Grid>
                             <Grid
                                 item


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/527

*Description of changes:*
Added the engagement name to the what we heard report.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
