### PR TITLE
Add a reusable loading primary button

### DIFF
--- a/met-web/src/components/comments/admin/review/CommentReview.tsx
+++ b/met-web/src/components/comments/admin/review/CommentReview.tsx
@@ -164,9 +164,8 @@ const CommentReview = () => {
 
                 <Grid item xs={12}>
                     <Stack direction="row" spacing={2}>
-                        <PrimaryButton disabled={isSaving} onClick={handleSave}>
+                        <PrimaryButton loading={isSaving} onClick={handleSave}>
                             {'Save & Continue'}
-                            {isSaving && <CircularProgress color="inherit" sx={{ marginLeft: 1 }} size={20} />}
                         </PrimaryButton>
                         <SecondaryButton onClick={() => navigate(-1)}>Cancel</SecondaryButton>
                     </Stack>

--- a/met-web/src/components/comments/admin/review/CommentReview.tsx
+++ b/met-web/src/components/comments/admin/review/CommentReview.tsx
@@ -1,14 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import {
-    Grid,
-    FormControl,
-    RadioGroup,
-    FormControlLabel,
-    Radio,
-    Stack,
-    CircularProgress,
-    FormLabel,
-} from '@mui/material';
+import { Grid, FormControl, RadioGroup, FormControlLabel, Radio, Stack, FormLabel } from '@mui/material';
 import { Comment, createDefaultComment } from 'models/comment';
 import { getComment, ReviewComment } from 'services/commentService';
 import { useAppDispatch } from 'hooks';

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -12,12 +12,13 @@ import { styled } from '@mui/system';
 import EditIcon from '@mui/icons-material/Edit';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import { Palette } from 'styles/Theme';
+import LoadingButton from '@mui/lab/LoadingButton';
 
 export const RoundedButton = styled(MuiButton)(() => ({
     borderRadius: '23px',
 }));
 
-export const StyledPrimaryButton = styled(MuiButton)(() => ({
+export const StyledPrimaryButton = styled(LoadingButton)(() => ({
     backgroundColor: Palette.primary.main,
     color: '#fff',
     '&:hover': {
@@ -48,7 +49,11 @@ export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNo
 );
 
 export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledPrimaryButton {...rest} variant="contained">
+    <StyledPrimaryButton
+        {...rest}
+        variant="contained"
+        loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
+    >
         {children}
     </StyledPrimaryButton>
 );

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from 'react';
-import { Typography, Grid, TextField, CircularProgress, Stack } from '@mui/material';
+import { Typography, Grid, TextField, Stack } from '@mui/material';
 import { MetPaper, MetLabel, PrimaryButton, SecondaryButton } from '../../common';
 import RichTextEditor from './RichTextEditor';
 import { ActionContext } from './ActionContext';

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -314,10 +314,9 @@ const EngagementForm = () => {
                                     sx={{ marginRight: 1 }}
                                     data-testid="engagement-form/create-engagement-button"
                                     onClick={() => handleCreateEngagement()}
-                                    disabled={isSaving}
+                                    loading={isSaving}
                                 >
                                     Create Engagement Draft
-                                    {isSaving && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                                 </PrimaryButton>
                             ) : (
                                 <PrimaryButton
@@ -325,9 +324,9 @@ const EngagementForm = () => {
                                     sx={{ marginRight: 1 }}
                                     onClick={() => handleUpdateEngagement()}
                                     disabled={isSaving}
+                                    loading={isSaving}
                                 >
                                     Update Engagement
-                                    {isSaving && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                                 </PrimaryButton>
                             )}
                             <SecondaryButton

--- a/met-web/src/components/engagement/view/EmailPanel.tsx
+++ b/met-web/src/components/engagement/view/EmailPanel.tsx
@@ -8,7 +8,6 @@ import {
     FormControlLabel,
     FormHelperText,
     Stack,
-    CircularProgress,
     useMediaQuery,
     Theme,
 } from '@mui/material';

--- a/met-web/src/components/engagement/view/EmailPanel.tsx
+++ b/met-web/src/components/engagement/view/EmailPanel.tsx
@@ -147,9 +147,8 @@ const EmailPanel = ({ email, checkEmail, handleClose, updateEmail, isSaving }: E
                     <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} width="100%" justifyContent="flex-end">
                         {isSmallScreen ? (
                             <>
-                                <PrimaryButton type="submit" variant={'contained'} disabled={isSaving}>
+                                <PrimaryButton type="submit" variant={'contained'} loading={isSaving}>
                                     Submit
-                                    {isSaving && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                                 </PrimaryButton>
                                 <SecondaryButton onClick={handleClose} disabled={isSaving}>
                                     Cancel
@@ -160,9 +159,8 @@ const EmailPanel = ({ email, checkEmail, handleClose, updateEmail, isSaving }: E
                                 <SecondaryButton onClick={handleClose} disabled={isSaving}>
                                     Cancel
                                 </SecondaryButton>
-                                <PrimaryButton type="submit" variant={'contained'} disabled={isSaving}>
+                                <PrimaryButton type="submit" variant={'contained'} loading={isSaving}>
                                     Submit
-                                    {isSaving && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                                 </PrimaryButton>
                             </>
                         )}

--- a/met-web/src/components/engagement/view/PreviewBanner.tsx
+++ b/met-web/src/components/engagement/view/PreviewBanner.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { ActionContext } from './ActionContext';
-import { Box, CircularProgress, Grid, Skeleton, Typography, Stack, useMediaQuery, Theme } from '@mui/material';
+import { Box, Grid, Skeleton, Typography, Stack, useMediaQuery, Theme } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { ConditionalComponent, PrimaryButton, SecondaryButton } from 'components/common';

--- a/met-web/src/components/engagement/view/PreviewBanner.tsx
+++ b/met-web/src/components/engagement/view/PreviewBanner.tsx
@@ -132,7 +132,7 @@ export const PreviewBanner = () => {
                             <PrimaryButton
                                 sx={{ marginLeft: '1em' }}
                                 onClick={() => handlePublishEngagement()}
-                                disabled={isPublishing}
+                                loading={isPublishing}
                             >
                                 Publish
                             </PrimaryButton>

--- a/met-web/src/components/engagement/view/PreviewBanner.tsx
+++ b/met-web/src/components/engagement/view/PreviewBanner.tsx
@@ -129,9 +129,12 @@ export const PreviewBanner = () => {
                         </SecondaryButton>
 
                         <ConditionalComponent condition={isDraft}>
-                            <PrimaryButton sx={{ marginLeft: '1em' }} onClick={() => handlePublishEngagement()}>
+                            <PrimaryButton
+                                sx={{ marginLeft: '1em' }}
+                                onClick={() => handlePublishEngagement()}
+                                disabled={isPublishing}
+                            >
                                 Publish
-                                {isPublishing && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                             </PrimaryButton>
                         </ConditionalComponent>
                         <ConditionalComponent condition={!isDraft}>

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Grid, Stack, Typography, Divider, TextField, IconButton } from '@mui/material';
+import { Grid, Stack, Typography, Divider, TextField, IconButton, CircularProgress } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormBuilder from 'components/Form/FormBuilder';
 import BorderColorIcon from '@mui/icons-material/BorderColor';
@@ -23,6 +23,7 @@ const SurveyFormBuilder = () => {
     const [loading, setLoading] = useState(true);
     const [isNameFocused, setIsNamedFocused] = useState(false);
     const [name, setName] = useState(savedSurvey ? savedSurvey.name : '');
+    const [isSaving, setIsSaving] = useState(false);
 
     const hasEngagement = Boolean(savedSurvey?.engagement);
     const isEngagementDraft = savedSurvey?.engagement?.status_id === EngagementStatus.Draft;
@@ -89,6 +90,7 @@ const SurveyFormBuilder = () => {
         }
 
         try {
+            setIsSaving(true);
             await putSurvey({
                 id: String(surveyId),
                 form_json: formData,
@@ -100,7 +102,6 @@ const SurveyFormBuilder = () => {
                     text: 'The survey was successfully built',
                 }),
             );
-
             if (savedSurvey.engagement?.id) {
                 navigate(`/engagement/form/${savedSurvey.engagement.id}`);
                 return;
@@ -108,6 +109,7 @@ const SurveyFormBuilder = () => {
 
             navigate('/survey/listing');
         } catch (error) {
+            setIsSaving(false);
             dispatch(
                 openNotification({
                     severity: 'error',
@@ -178,7 +180,11 @@ const SurveyFormBuilder = () => {
             </Grid>
             <Grid item xs={12}>
                 <Stack direction="row" spacing={2}>
-                    <PrimaryButton disabled={!formData || hasPublishedEngagement} onClick={handleSaveForm}>
+                    <PrimaryButton
+                        disabled={!formData || hasPublishedEngagement}
+                        loading={isSaving}
+                        onClick={handleSaveForm}
+                    >
                         {'Save & Continue'}
                     </PrimaryButton>
                     <SecondaryButton onClick={() => navigate('/survey/listing')}>Cancel</SecondaryButton>

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Grid, Stack, Typography, Divider, TextField, IconButton, CircularProgress } from '@mui/material';
+import { Grid, Stack, Typography, Divider, TextField, IconButton } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormBuilder from 'components/Form/FormBuilder';
 import BorderColorIcon from '@mui/icons-material/BorderColor';

--- a/met-web/src/components/survey/create/CreateOptions.tsx
+++ b/met-web/src/components/survey/create/CreateOptions.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Grid, TextField, Stack, CircularProgress } from '@mui/material';
+import { Grid, TextField, Stack } from '@mui/material';
 import { CreateSurveyContext } from './CreateSurveyContext';
 import { useNavigate } from 'react-router-dom';
 import { hasKey } from 'utils';

--- a/met-web/src/components/survey/create/CreateOptions.tsx
+++ b/met-web/src/components/survey/create/CreateOptions.tsx
@@ -98,9 +98,8 @@ export const CreateOptions = () => {
             </Grid>
             <Grid item xs={12}>
                 <Stack direction="row" spacing={2}>
-                    <PrimaryButton onClick={handleSaveClick} disabled={isSaving}>
+                    <PrimaryButton onClick={handleSaveClick} loading={isSaving}>
                         {'Save & Continue'}
-                        {isSaving && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                     </PrimaryButton>
                     <SecondaryButton onClick={() => navigate(-1)}>Cancel</SecondaryButton>
                 </Stack>

--- a/met-web/src/components/survey/create/LinkOptions.tsx
+++ b/met-web/src/components/survey/create/LinkOptions.tsx
@@ -97,9 +97,8 @@ const LinkOptions = () => {
             </Grid>
             <Grid item xs={12}>
                 <Stack direction="row" spacing={2}>
-                    <PrimaryButton onClick={handleSave}>
+                    <PrimaryButton onClick={handleSave} loading={isSaving}>
                         {'Save & Continue'}
-                        {isSaving && <CircularProgress color="inherit" sx={{ marginLeft: 1 }} size={20} />}
                     </PrimaryButton>
                     <SecondaryButton onClick={() => navigate(-1)}>Cancel</SecondaryButton>
                 </Stack>

--- a/met-web/src/components/survey/create/LinkOptions.tsx
+++ b/met-web/src/components/survey/create/LinkOptions.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Grid, TextField, Stack, CircularProgress, Autocomplete } from '@mui/material';
+import { Grid, TextField, Stack, Autocomplete } from '@mui/material';
 import { CreateSurveyContext } from './CreateSurveyContext';
 import { useNavigate } from 'react-router-dom';
 import { fetchSurveys, linkSurvey } from 'services/surveyService/form';

--- a/met-web/src/components/survey/submit/SurveyForm.tsx
+++ b/met-web/src/components/survey/submit/SurveyForm.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Skeleton, Grid, Stack, CircularProgress } from '@mui/material';
+import { Skeleton, Grid, Stack } from '@mui/material';
 import { ActionContext } from './ActionContext';
 import FormSubmit from 'components/Form/FormSubmit';
 import { FormSubmissionData } from 'components/Form/types';

--- a/met-web/src/components/survey/submit/SurveyForm.tsx
+++ b/met-web/src/components/survey/submit/SurveyForm.tsx
@@ -38,11 +38,11 @@ export const SurveyForm = ({ handleClose }: SurveyFormProps) => {
                 <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} width="100%" justifyContent="flex-end">
                     <SecondaryButton onClick={() => handleClose()}>Cancel</SecondaryButton>
                     <PrimaryButton
-                        disabled={!isValid || isLoggedIn || isSubmitting}
+                        disabled={!isValid || isLoggedIn}
                         onClick={() => handleSubmit(submissionData)}
+                        loading={isSubmitting}
                     >
                         Submit Survey
-                        {isSubmitting && <CircularProgress sx={{ marginLeft: 1 }} size={20} />}
                     </PrimaryButton>
                 </Stack>
             </Grid>


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/533

*Description of changes:*

- Add missing loading animation to action buttons
- Replace primary button with MUI Lab LoadingButton


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
