### PR TITLE
Add server side pagination for engagements, surveys and comments table

### DIFF
--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -33,24 +33,25 @@ class Comment(db.Model):
         return db.session.query(Comment).join(CommentStatus).join(Survey).filter(Comment.id == comment_id).first()
 
     @classmethod
-    def get_comments_by_survey_id_paginated(cls, survey_id, page = 1, size = 10, sort_key = 'id', sort_order = 'asc', search_text= ''):
+    def get_comments_by_survey_id_paginated(cls, survey_id, page=1, size=10,
+                                            sort_key='id', sort_order='asc', search_text=''):
         """Get comments paginated."""
         query = db.session.query(Comment)\
             .join(CommentStatus)\
             .join(Survey)\
             .filter(Comment.survey_id == survey_id)\
-                
+
         if search_text:
             # Remove all non-digit characters from search text
             query = query.filter(cast(Comment.id, TEXT).like('%' + search_text + '%'))
-            
+
         sort = asc(text(sort_key)) if sort_order == "asc" else desc(text(sort_key))
         return query.order_by(sort).paginate(page=page, per_page=size)
 
     @classmethod
-    def get_accepted_comments_by_survey_id_where_engagement_closed_paginated(cls, survey_id, page = 1, size = 10):
+    def get_accepted_comments_by_survey_id_where_engagement_closed_paginated(cls, survey_id, page=1, size=10):
         """Get comments for closed engagements."""
-        now = datetime.now()            
+        now = datetime.now()
         query = db.session.query(Comment)\
             .join(CommentStatus)\
             .join(Survey)\
@@ -61,7 +62,7 @@ class Comment(db.Model):
                     Engagement.end_date < now,
                     CommentStatus.id == Status.Approved.value
                 ))\
-            
+
         return query.order_by(Comment.id.desc()).paginate(page=page, per_page=size)
 
     @staticmethod

--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -3,7 +3,7 @@
 Manages the comment
 """
 from datetime import datetime
-from sqlalchemy import and_, desc, asc
+from sqlalchemy import and_, desc, asc, cast, TEXT
 from sqlalchemy.sql import text
 from sqlalchemy.sql.schema import ForeignKey
 from met_api.constants.comment_status import Status
@@ -41,7 +41,8 @@ class Comment(db.Model):
             .filter(Comment.survey_id == survey_id)\
                 
         if search_text:
-            query = query.filter(Comment.id.like('%' + search_text + '%'))
+            # Remove all non-digit characters from search text
+            query = query.filter(cast(Comment.id, TEXT).like('%' + search_text + '%'))
             
         sort = asc(text(sort_key)) if sort_order == "asc" else desc(text(sort_key))
         return query.order_by(sort).paginate(page=page, per_page=size)

--- a/met-api/src/met_api/models/engagement.py
+++ b/met-api/src/met_api/models/engagement.py
@@ -53,6 +53,16 @@ class Engagement(db.Model):
         return engagements_schema.dump(data)
 
     @classmethod
+    def get_engagements_paginated(cls, page, size, statuses = []):
+        """Get engagements paginated."""
+        query = db.session.query(Engagement).join(EngagementStatus)
+        
+        if len(statuses) > 0:
+            query.filter(Engagement.status_id.in_(statuses))
+            
+        return query.order_by(Engagement.id.asc()).paginate(page=page, per_page=size)
+
+    @classmethod
     def get_engagements_by_status(cls, status_id):
         """Get all engagements by a list of status."""
         engagements_schema = EngagementSchema(many=True)

--- a/met-api/src/met_api/models/engagement.py
+++ b/met-api/src/met_api/models/engagement.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import List
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.sql.schema import ForeignKey
+from sqlalchemy import desc, asc
 
 from met_api.constants.engagement_status import Status
 from met_api.constants.user import SYSTEM_USER
@@ -53,14 +54,16 @@ class Engagement(db.Model):
         return engagements_schema.dump(data)
 
     @classmethod
-    def get_engagements_paginated(cls, page, size, statuses = []):
+    def get_engagements_paginated(cls, page = 1, size = 10, sort_key = 'name', sort_order = 'asc', statuses = []):
         """Get engagements paginated."""
         query = db.session.query(Engagement).join(EngagementStatus)
         
         if len(statuses) > 0:
             query.filter(Engagement.status_id.in_(statuses))
-            
-        return query.order_by(Engagement.id.asc()).paginate(page=page, per_page=size)
+        
+        sort = asc(sort_key) if sort_order == "desc" else desc(sort_key)
+        
+        return query.order_by(sort).paginate(page=page, per_page=size)
 
     @classmethod
     def get_engagements_by_status(cls, status_id):

--- a/met-api/src/met_api/models/engagement.py
+++ b/met-api/src/met_api/models/engagement.py
@@ -53,7 +53,7 @@ class Engagement(db.Model):
         return engagements_schema.dump(data)
 
     @classmethod
-    def get_engagements_paginated(cls, page = 1, size = 10, sort_key = 'name', sort_order = 'asc', search_text= '', statuses = []):
+    def get_engagements_paginated(cls, page=1, size=10, sort_key='name', sort_order='asc', search_text='', statuses=[]):
         """Get engagements paginated."""
         query = db.session.query(Engagement).join(EngagementStatus)
 

--- a/met-api/src/met_api/models/engagement.py
+++ b/met-api/src/met_api/models/engagement.py
@@ -6,13 +6,12 @@ from datetime import datetime
 from typing import List
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.sql.schema import ForeignKey
+from sqlalchemy.sql import text
 from sqlalchemy import desc, asc
-
 from met_api.constants.engagement_status import Status
 from met_api.constants.user import SYSTEM_USER
 from met_api.schemas.engagement import EngagementSchema
 from met_api.utils.datetime import local_datetime
-
 from .db import db
 from .default_method_result import DefaultMethodResult
 from .engagement_status import EngagementStatus
@@ -54,15 +53,17 @@ class Engagement(db.Model):
         return engagements_schema.dump(data)
 
     @classmethod
-    def get_engagements_paginated(cls, page = 1, size = 10, sort_key = 'name', sort_order = 'asc', statuses = []):
+    def get_engagements_paginated(cls, page = 1, size = 10, sort_key = 'name', sort_order = 'asc', search_text= '', statuses = []):
         """Get engagements paginated."""
         query = db.session.query(Engagement).join(EngagementStatus)
-        
+
         if len(statuses) > 0:
-            query.filter(Engagement.status_id.in_(statuses))
-        
-        sort = asc(sort_key) if sort_order == "desc" else desc(sort_key)
-        
+            query = query.filter(Engagement.status_id.in_(statuses))
+
+        if search_text:
+            query = query.filter(Engagement.name.like('%' + search_text + '%'))
+
+        sort = asc(text(sort_key)) if sort_order == "asc" else desc(text(sort_key))
         return query.order_by(sort).paginate(page=page, per_page=size)
 
     @classmethod

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -70,12 +70,12 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         return survey_schema.dump(surveys)
 
     @classmethod
-    def get_surveys_paginated(cls, page = 1, size = 10, sort_key = 'name', sort_order = 'asc', search_text= '', unlinked = False):
+    def get_surveys_paginated(cls, page=1, size=10, sort_key='name', sort_order='asc', search_text='', unlinked=False):
         """Get surveys paginated."""
         query = db.session.query(Survey).join(Engagement, isouter=True).join(EngagementStatus, isouter=True)
 
         if unlinked:
-            query = query.filter(Survey.engagement_id == None)
+            query = query.filter(Survey.engagement_id is None)
 
         if search_text:
             query = query.filter(Survey.name.like('%' + search_text + '%'))

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -4,10 +4,9 @@ Manages the Survey
 """
 from datetime import datetime
 from typing import List
-from sqlalchemy import ForeignKey, and_
+from sqlalchemy import ForeignKey, and_, desc, asc
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import text
-from sqlalchemy import desc, asc
 from met_api.constants.engagement_status import Status
 from met_api.models.engagement_status import EngagementStatus
 from met_api.models.engagement import Engagement

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from typing import List
 from sqlalchemy import ForeignKey, and_
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import text
+from sqlalchemy import desc, asc
 from met_api.constants.engagement_status import Status
 from met_api.models.engagement_status import EngagementStatus
 from met_api.models.engagement import Engagement
@@ -67,6 +69,20 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         survey_schema = SurveySchema(many=True)
         surveys = db.session.query(Survey).filter_by(engagement_id=None).all()
         return survey_schema.dump(surveys)
+
+    @classmethod
+    def get_surveys_paginated(cls, page = 1, size = 10, sort_key = 'name', sort_order = 'asc', search_text= '', unlinked = False):
+        """Get surveys paginated."""
+        query = db.session.query(Survey).join(Engagement, isouter=True).join(EngagementStatus, isouter=True)
+
+        if unlinked:
+            query = query.filter(Survey.engagement_id == None)
+
+        if search_text:
+            query = query.filter(Survey.name.like('%' + search_text + '%'))
+
+        sort = asc(text(sort_key)) if sort_order == "asc" else desc(text(sort_key))
+        return query.order_by(sort).paginate(page=page, per_page=size)
 
     @classmethod
     def create_survey(cls, survey: SurveySchema) -> DefaultMethodResult:

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -90,7 +90,7 @@ class Comments(Resource):
                     args.get('sort_key', None, str),
                     args.get('sort_order', None, str),
                     args.get('search_text', '', str),
-                )
+            )
             return ActionResult.success(result=comment_records)
         except ValueError as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -24,7 +24,7 @@ from met_api.utils.token_info import TokenInfo
 from met_api.utils.util import allowedorigins, cors_preflight
 
 
-API = Namespace('comment', description='Endpoints for Comments Management')
+API = Namespace('comments', description='Endpoints for Comments Management')
 """Custom exception messages
 """
 
@@ -69,7 +69,7 @@ class Comment(Resource):
 
 
 @cors_preflight('GET, POST, PUT, OPTIONS')
-@API.route('/survey/<survey_id>/comments')
+@API.route('/survey/<survey_id>')
 class Comments(Resource):
     """Resource for managing multiple comments."""
 
@@ -77,10 +77,22 @@ class Comments(Resource):
     @cross_origin(origins=allowedorigins())
     @auth.optional
     def get(survey_id):
-        """Fetch all comments."""
+        """Get comments page"""
         try:
             user_id = TokenInfo.get_id()
-            comment_records = CommentService().get_comments_by_survey_id(user_id, survey_id)
+            args = request.args
+            comment_records = CommentService()\
+                .get_comments_paginated(
+                    user_id,
+                    survey_id,
+                    args.get('page', None, int),
+                    args.get('size', None, int),
+                    args.get('sort_key', None, str),
+                    args.get('sort_order', None, str),
+                    args.get('search_text', '', str),
+                )
             return ActionResult.success(result=comment_records)
         except ValueError as err:
             return ActionResult.error(str(err))
+        except Exception as err:
+            print(str(err))

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -73,12 +73,15 @@ class Engagements(Resource):
                     user_id, args.get('page', None, int),
                     args.get('size', None, int),
                     args.get('sort_key', None, str),
-                    args.get('sort_order', None, str)
+                    args.get('sort_order', None, str),
+                    args.get('search_text', '', str)
                 )
             
             return ActionResult.success(result=engagement_records)
         except ValueError as err:
             return ActionResult.error(str(err))
+        except Exception as err:
+            print(str(err))
 
     @staticmethod
     # @TRACER.trace()

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -67,7 +67,7 @@ class Engagements(Resource):
         try:
             args = request.args
             user_id = TokenInfo.get_id()
-            
+
             engagement_records = EngagementService()\
                 .get_engagements_paginated(
                     user_id, args.get('page', None, int),
@@ -75,8 +75,8 @@ class Engagements(Resource):
                     args.get('sort_key', None, str),
                     args.get('sort_order', None, str),
                     args.get('search_text', '', str)
-                )
-            
+            )
+
             return ActionResult.success(result=engagement_records)
         except ValueError as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -69,7 +69,12 @@ class Engagements(Resource):
             user_id = TokenInfo.get_id()
             
             engagement_records = EngagementService()\
-                .get_engagements_paginated(user_id, args.get('page', 1, int), args.get('size', 10, int))
+                .get_engagements_paginated(
+                    user_id, args.get('page', None, int),
+                    args.get('size', None, int),
+                    args.get('sort_key', None, str),
+                    args.get('sort_order', None, str)
+                )
             
             return ActionResult.success(result=engagement_records)
         except ValueError as err:

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -25,7 +25,7 @@ from met_api.utils.token_info import TokenInfo
 from met_api.utils.util import allowedorigins, cors_preflight
 
 
-API = Namespace('engagement', description='Endpoints for Engagements Management')
+API = Namespace('engagements', description='Endpoints for Engagements Management')
 """Custom exception messages
 """
 
@@ -57,16 +57,20 @@ class Engagement(Resource):
 @cors_preflight('GET, POST, PUT, OPTIONS')
 @API.route('/')
 class Engagements(Resource):
-    """Resource for managing all engagements."""
+    """Resource for managing engagements."""
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
     @auth.optional
     def get():
-        """Fetch all engagements."""
+        """Fetch engagements."""
         try:
+            args = request.args
             user_id = TokenInfo.get_id()
-            engagement_records = EngagementService().get_all_engagements(user_id)
+            
+            engagement_records = EngagementService()\
+                .get_engagements_paginated(user_id, args.get('page', 1, int), args.get('size', 10, int))
+            
             return ActionResult.success(result=engagement_records)
         except ValueError as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -100,7 +100,7 @@ class Surveys(Resource):
                     args.get('sort_order', None, str),
                     args.get('search_text', '', str),
                     args.get('unlinked', False, bool)
-                )
+            )
             return ActionResult.success(result=survey_records)
         except ValueError as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -26,7 +26,7 @@ from met_api.utils.token_info import TokenInfo
 from met_api.utils.util import allowedorigins, cors_preflight
 
 
-API = Namespace('survey', description='Endpoints for Survey Management')
+API = Namespace('surveys', description='Endpoints for Survey Management')
 """Custom exception messages
 """
 
@@ -91,7 +91,16 @@ class Surveys(Resource):
         """Fetch surveys."""
         try:
             args = request.args
-            survey_records = SurveyService().get_surveys(unlinked=args.get('unlinked', False))
+            
+            survey_records = SurveyService()\
+                .get_surveys_paginated(
+                    args.get('page', None, int),
+                    args.get('size', None, int),
+                    args.get('sort_key', None, str),
+                    args.get('sort_order', None, str),
+                    args.get('search_text', '', str),
+                    args.get('unlinked', False, bool)
+                )            
             return ActionResult.success(result=survey_records)
         except ValueError as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -91,7 +91,7 @@ class Surveys(Resource):
         """Fetch surveys."""
         try:
             args = request.args
-            
+
             survey_records = SurveyService()\
                 .get_surveys_paginated(
                     args.get('page', None, int),
@@ -100,7 +100,7 @@ class Surveys(Resource):
                     args.get('sort_order', None, str),
                     args.get('search_text', '', str),
                     args.get('unlinked', False, bool)
-                )            
+                )
             return ActionResult.success(result=survey_records)
         except ValueError as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -38,9 +38,10 @@ class CommentService:
         """Get comments paginated."""
         if not user_id:
             comment_schema = CommentSchema(many=True, only=('text', 'submission_date', 'survey'))
-            comments_page = Comment.get_accepted_comments_by_survey_id_where_engagement_closed_paginated(survey_id, page, size)
+            comments_page = Comment.get_accepted_comments_by_survey_id_where_engagement_closed_paginated(
+                survey_id, page, size)
         else:
-            comment_schema = CommentSchema(many=True) 
+            comment_schema = CommentSchema(many=True)
             comments_page = Comment.get_comments_by_survey_id_paginated(
                 survey_id,
                 page,

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -27,11 +27,32 @@ class CommentService:
         if not user_id:
             comment_schema = CommentSchema(many=True, only=('text', 'submission_date', 'survey'))
             return comment_schema.dump(
-                Comment.get_accepted_comments_by_survey_id_where_engagement_closed(survey_id)
+                Comment.get_accepted_comments_by_survey_id_where_engagement_closed_paginated(survey_id)
             )
 
         comment_schema = CommentSchema(many=True)
-        return comment_schema.dump(Comment.get_comments_by_survey_id(survey_id))
+        return comment_schema.dump(Comment.get_comments_by_survey_id_paginated(survey_id))
+
+    @classmethod
+    def get_comments_paginated(cls, user_id, survey_id, page, size, sort_key, sort_order, search_text=''):
+        """Get comments paginated."""
+        if not user_id:
+            comment_schema = CommentSchema(many=True, only=('text', 'submission_date', 'survey'))
+            comments_page = Comment.get_accepted_comments_by_survey_id_where_engagement_closed_paginated(survey_id, page, size)
+        else:
+            comment_schema = CommentSchema(many=True) 
+            comments_page = Comment.get_comments_by_survey_id_paginated(
+                survey_id,
+                page,
+                size,
+                sort_key,
+                sort_order,
+                search_text,
+            )
+        return {
+            'items': comment_schema.dump(comments_page.items),
+            'total': comments_page.total
+        }
 
     @classmethod
     def create_comments(cls, comments: list):

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -44,7 +44,7 @@ class EngagementService:
         return engagements
 
     @staticmethod
-    def get_engagements_paginated(user_id, page, size, sort_key = 'name', sort_order = 'asc', search_text=''):
+    def get_engagements_paginated(user_id, page, size, sort_key='name', sort_order='asc', search_text=''):
         """Get engagements paginated."""
         engagements_page = Engagement.get_engagements_paginated(
             page,
@@ -56,7 +56,7 @@ class EngagementService:
         )
         engagements_schema = EngagementSchema(many=True)
         engagements = engagements_schema.dump(engagements_page.items)
-        
+
         return {
             'items': engagements,
             'total': engagements_page.total

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -36,11 +36,30 @@ class EngagementService:
         """Get all engagements."""
         if user_id:
             # authenticated users have access to any engagement status
-            engagements = Engagement.get_all_engagements()
+            engagements = Engagement.get_engagements_paginated
         else:
             engagements = Engagement.get_engagements_by_status([Status.Published.value, Status.Closed.value])
 
         return engagements
+
+    @staticmethod
+    def get_engagements_paginated(user_id, page, size):
+        """Get engagements paginated."""
+        if user_id:
+            # authenticated users have access to any engagement status
+            engagements_page = Engagement.get_engagements_paginated(page, size)
+        else:
+            engagements_page = Engagement.get_engagements_paginated(page, size, statuses=[Status.Published.value])
+        
+        engagements_schema = EngagementSchema(many=True)
+        {
+            'items': engagements_schema.dump(engagements_page.items),
+            'total': engagements_page.total
+        }
+        return {
+            'items': engagements_schema.dump(engagements_page.items),
+            'total': engagements_page.total
+        }
 
     @staticmethod
     def close_engagements_due():

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -43,19 +43,15 @@ class EngagementService:
         return engagements
 
     @staticmethod
-    def get_engagements_paginated(user_id, page, size):
+    def get_engagements_paginated(user_id, page, size, sort_key, sort_order):
         """Get engagements paginated."""
         if user_id:
             # authenticated users have access to any engagement status
-            engagements_page = Engagement.get_engagements_paginated(page, size)
+            engagements_page = Engagement.get_engagements_paginated(page, size, sort_key, sort_order)
         else:
-            engagements_page = Engagement.get_engagements_paginated(page, size, statuses=[Status.Published.value])
+            engagements_page = Engagement.get_engagements_paginated(page, size, sort_key, sort_order, statuses=[Status.Published.value])
         
         engagements_schema = EngagementSchema(many=True)
-        {
-            'items': engagements_schema.dump(engagements_page.items),
-            'total': engagements_page.total
-        }
         return {
             'items': engagements_schema.dump(engagements_page.items),
             'total': engagements_page.total

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -50,7 +50,7 @@ class SurveyService:
     def get_unlinked(cls):
         """Get all surveys."""
         db_data = Survey.get_all_unlinked_surveys()
-        return db_data   
+        return db_data
 
     @staticmethod
     def get_surveys_paginated(page, size, sort_key = 'name', sort_order = 'asc', search_text='', unlinked=False):

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -53,7 +53,7 @@ class SurveyService:
         return db_data
 
     @staticmethod
-    def get_surveys_paginated(page, size, sort_key = 'name', sort_order = 'asc', search_text='', unlinked=False):
+    def get_surveys_paginated(page, size, sort_key='name', sort_order='asc', search_text='', unlinked=False):
         """Get engagements paginated."""
         surveys_page = Survey.get_surveys_paginated(
             page,
@@ -64,12 +64,12 @@ class SurveyService:
             unlinked,
         )
         surveys_schema = SurveySchema(many=True)
-        
+
         return {
             'items': surveys_schema.dump(surveys_page.items),
             'total': surveys_page.total
         }
-        
+
     @classmethod
     def create(cls, data: SurveySchema):
         """Create survey."""

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -50,8 +50,26 @@ class SurveyService:
     def get_unlinked(cls):
         """Get all surveys."""
         db_data = Survey.get_all_unlinked_surveys()
-        return db_data
+        return db_data   
 
+    @staticmethod
+    def get_surveys_paginated(page, size, sort_key = 'name', sort_order = 'asc', search_text='', unlinked=False):
+        """Get engagements paginated."""
+        surveys_page = Survey.get_surveys_paginated(
+            page,
+            size,
+            sort_key,
+            sort_order,
+            search_text,
+            unlinked,
+        )
+        surveys_schema = SurveySchema(many=True)
+        
+        return {
+            'items': surveys_schema.dump(surveys_page.items),
+            'total': surveys_page.total
+        }
+        
     @classmethod
     def create(cls, data: SurveySchema):
         """Create survey."""

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -2,10 +2,10 @@ import { AppConfig } from 'config';
 
 const Endpoints = {
     Engagement: {
-        GET_ALL: `${AppConfig.apiUrl}/engagement/`,
-        CREATE: `${AppConfig.apiUrl}/engagement/`,
-        UPDATE: `${AppConfig.apiUrl}/engagement/`,
-        GET: `${AppConfig.apiUrl}/engagement/engagement_id`,
+        GET_LIST: `${AppConfig.apiUrl}/engagements/`,
+        CREATE: `${AppConfig.apiUrl}/engagements/`,
+        UPDATE: `${AppConfig.apiUrl}/engagements/`,
+        GET: `${AppConfig.apiUrl}/engagements/engagement_id`,
     },
     User: {
         CREATE_UPDATE: `${AppConfig.apiUrl}/user/`,

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -14,12 +14,12 @@ const Endpoints = {
         OSS_HEADER: `${AppConfig.apiUrl}/document/`,
     },
     Survey: {
-        GET_ALL: `${AppConfig.apiUrl}/survey/`,
-        CREATE: `${AppConfig.apiUrl}/survey/`,
-        UPDATE: `${AppConfig.apiUrl}/survey/`,
-        LINK_TO_ENGAGEMENT: `${AppConfig.apiUrl}/survey/survey_id/link/engagement/engagement_id`,
-        UNLINK_FROM_ENGAGEMENT: `${AppConfig.apiUrl}/survey/survey_id/unlink/engagement/engagement_id`,
-        GET: `${AppConfig.apiUrl}/survey/survey_id`,
+        GET_LIST: `${AppConfig.apiUrl}/surveys/`,
+        CREATE: `${AppConfig.apiUrl}/surveys/`,
+        UPDATE: `${AppConfig.apiUrl}/surveys/`,
+        LINK_TO_ENGAGEMENT: `${AppConfig.apiUrl}/surveys/survey_id/link/engagement/engagement_id`,
+        UNLINK_FROM_ENGAGEMENT: `${AppConfig.apiUrl}/surveys/survey_id/unlink/engagement/engagement_id`,
+        GET: `${AppConfig.apiUrl}/surveys/survey_id`,
     },
     SurveySubmission: {
         CREATE: `${AppConfig.apiUrl}/submission/`,

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -25,9 +25,9 @@ const Endpoints = {
         CREATE: `${AppConfig.apiUrl}/submission/`,
     },
     Comment: {
-        GET_ALL: `${AppConfig.apiUrl}/comment/survey/survey_id/comments`,
-        REVIEW: `${AppConfig.apiUrl}/comment/comment_id `,
-        GET: `${AppConfig.apiUrl}/comment/comment_id`,
+        GET_LIST: `${AppConfig.apiUrl}/comments/survey/survey_id`,
+        REVIEW: `${AppConfig.apiUrl}/comments/comment_id `,
+        GET: `${AppConfig.apiUrl}/comments/comment_id`,
     },
     EmailVerification: {
         GET: `${AppConfig.apiUrl}/email_verification/verification_token`,

--- a/met-web/src/components/LandingPage/LandingPage.tsx
+++ b/met-web/src/components/LandingPage/LandingPage.tsx
@@ -32,7 +32,7 @@ const LandingPage = () => {
     const [pageInfo, setPageInfo] = useState<PageInfo>({
         total: 0,
     });
-    const [tableLoading, setTableLoading] = useState(false);
+    const [tableLoading, setTableLoading] = useState(true);
 
     const dispatch = useAppDispatch();
 

--- a/met-web/src/components/comments/admin/reviewListing/index.tsx
+++ b/met-web/src/components/comments/admin/reviewListing/index.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import { Link, useParams } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton, MetHeader1 } from 'components/common';
 import { Comment } from 'models/comment';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, Pagination } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import TextField from '@mui/material/TextField';
@@ -21,6 +21,13 @@ const CommentListing = () => {
     });
     const [searchText, setSearchText] = useState('');
     const [comments, setComments] = useState<Comment[]>([]);
+    const [page, setPage] = useState(1);
+    const [size, setSize] = useState(10);
+    const [pagination, setPagination] = useState<Pagination>({
+        page: 0,
+        size: 10,
+        total: 0,
+    });
 
     const { surveyId } = useParams();
 
@@ -138,6 +145,9 @@ const CommentListing = () => {
                     rows={comments}
                     defaultSort={'id'}
                     noRowBorder={true}
+                    handlePageChange={(newPage: number) => setPage(newPage)}
+                    handleSizeChange={(newSize: number) => setSize(newSize)}
+                    handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments/all`}>
                     Read All Comments

--- a/met-web/src/components/comments/admin/reviewListing/index.tsx
+++ b/met-web/src/components/comments/admin/reviewListing/index.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import { Link, useParams } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton, MetHeader1 } from 'components/common';
 import { Comment } from 'models/comment';
-import { HeadCell, Pagination } from 'components/common/Table/types';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import TextField from '@mui/material/TextField';
@@ -23,12 +23,15 @@ const CommentListing = () => {
     const [comments, setComments] = useState<Comment[]>([]);
     const [page, setPage] = useState(1);
     const [size, setSize] = useState(10);
-    const [pagination, setPagination] = useState<Pagination>({
+    const [paginationOptions, setPagination] = useState<PaginationOptions<Comment>>({
         page: 0,
         size: 10,
+        sort_key: 'id',
+        sort_order: 'asc',
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>({
         total: 0,
     });
-
     const { surveyId } = useParams();
 
     const dispatch = useAppDispatch();
@@ -140,14 +143,12 @@ const CommentListing = () => {
                     <strong>{`${comments[0]?.survey || ''} Comments`}</strong>
                 </MetHeader1>
                 <MetTable
-                    filter={searchFilter}
                     headCells={headCells}
                     rows={comments}
-                    defaultSort={'id'}
                     noRowBorder={true}
-                    handlePageChange={(newPage: number) => setPage(newPage)}
-                    handleSizeChange={(newSize: number) => setSize(newSize)}
-                    handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
+                    handleChangePagination={(pagination: PaginationOptions<Comment>) => setPagination(pagination)}
+                    paginationOptions={paginationOptions}
+                    pageInfo={pageInfo}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments/all`}>
                     Read All Comments

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -3,7 +3,7 @@ import MetTable from 'components/common/Table';
 import { Link, useParams } from 'react-router-dom';
 import { ConditionalComponent, MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Comment } from 'models/comment';
-import { HeadCell, Pagination } from 'components/common/Table/types';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { Link as MuiLink, Typography, Grid, Stack, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useAppDispatch } from 'hooks';
@@ -21,9 +21,13 @@ const CommentTextListing = () => {
     const [searchText, setSearchText] = useState('');
     const [page, setPage] = useState(1);
     const [size, setSize] = useState(10);
-    const [pagination, setPagination] = useState<Pagination>({
+    const [paginationOptions, setPagination] = useState<PaginationOptions<Comment>>({
         page: 0,
         size: 10,
+        sort_key: 'id',
+        sort_order: 'asc',
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>({
         total: 0,
     });
 
@@ -136,15 +140,13 @@ const CommentTextListing = () => {
             </Grid>
             <Grid item sm={12} lg={10}>
                 <MetTable
-                    filter={searchFilter}
                     hideHeader={true}
                     headCells={headCells}
                     rows={comments}
-                    defaultSort={'id'}
                     noRowBorder={true}
-                    handlePageChange={(newPage: number) => setPage(newPage)}
-                    handleSizeChange={(newSize: number) => setSize(newSize)}
-                    handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
+                    handleChangePagination={(pagination: PaginationOptions<Comment>) => setPagination(pagination)}
+                    paginationOptions={paginationOptions}
+                    pageInfo={pageInfo}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments`}>
                     Return to Comments List

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -9,8 +9,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { CommentStatusChip } from '../../status';
-import { fetchComments } from 'services/commentService';
 import { CommentStatus } from 'constants/commentStatus';
+import { getCommentsPage } from 'services/commentService';
 
 const CommentTextListing = () => {
     const [comments, setComments] = useState<Comment[]>([]);
@@ -19,39 +19,53 @@ const CommentTextListing = () => {
         value: '',
     });
     const [searchText, setSearchText] = useState('');
-    const [page, setPage] = useState(1);
-    const [size, setSize] = useState(10);
     const [paginationOptions, setPagination] = useState<PaginationOptions<Comment>>({
-        page: 0,
+        page: 1,
         size: 10,
         sort_key: 'id',
-        sort_order: 'asc',
+        nested_sort_key: 'comment.id',
+        sort_order: 'desc',
     });
     const [pageInfo, setPageInfo] = useState<PageInfo>({
         total: 0,
     });
+    const [tableLoading, setTableLoading] = useState(true);
 
     const dispatch = useAppDispatch();
     const { surveyId } = useParams();
 
-    const callFetchComments = async () => {
+    const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
+
+    const callGetComments = async () => {
         try {
             if (isNaN(Number(surveyId))) {
                 dispatch(openNotification({ severity: 'error', text: 'Invalid surveyId' }));
             }
 
-            const fetchedComments = await fetchComments({
+            setTableLoading(true);
+            const response = await getCommentsPage({
                 survey_id: Number(surveyId),
+                page,
+                size,
+                sort_key: nested_sort_key || sort_key,
+                sort_order,
+                search_text: searchFilter.value,
             });
-            setComments(fetchedComments);
+            setComments(response.items);
+            setPageInfo({
+                total: response.total,
+            });
+            setTableLoading(false);
         } catch (error) {
+            console.log(error);
             dispatch(openNotification({ severity: 'error', text: 'Error occurred while fetching comments' }));
+            setTableLoading(false);
         }
     };
 
     useEffect(() => {
-        callFetchComments();
-    }, []);
+        callGetComments();
+    }, [paginationOptions, surveyId, searchFilter]);
 
     const handleSearchBarClick = (filter: string) => {
         setSearchFilter({
@@ -147,6 +161,7 @@ const CommentTextListing = () => {
                     handleChangePagination={(pagination: PaginationOptions<Comment>) => setPagination(pagination)}
                     paginationOptions={paginationOptions}
                     pageInfo={pageInfo}
+                    loading={tableLoading}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments`}>
                     Return to Comments List

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -3,7 +3,7 @@ import MetTable from 'components/common/Table';
 import { Link, useParams } from 'react-router-dom';
 import { ConditionalComponent, MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Comment } from 'models/comment';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, Pagination } from 'components/common/Table/types';
 import { Link as MuiLink, Typography, Grid, Stack, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useAppDispatch } from 'hooks';
@@ -19,6 +19,13 @@ const CommentTextListing = () => {
         value: '',
     });
     const [searchText, setSearchText] = useState('');
+    const [page, setPage] = useState(1);
+    const [size, setSize] = useState(10);
+    const [pagination, setPagination] = useState<Pagination>({
+        page: 0,
+        size: 10,
+        total: 0,
+    });
 
     const dispatch = useAppDispatch();
     const { surveyId } = useParams();
@@ -135,6 +142,9 @@ const CommentTextListing = () => {
                     rows={comments}
                     defaultSort={'id'}
                     noRowBorder={true}
+                    handlePageChange={(newPage: number) => setPage(newPage)}
+                    handleSizeChange={(newSize: number) => setSize(newSize)}
+                    handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments`}>
                     Return to Comments List

--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -131,7 +131,7 @@ function MetTable<T>({
                             />
                         </ConditionalComponent>
 
-                        <TableBody sx={{ position: 'relative' }}>
+                        <TableBody sx={{ position: 'relative', minHeight: 53 }}>
                             <ConditionalComponent condition={loading}>
                                 <Box
                                     sx={{
@@ -142,6 +142,13 @@ function MetTable<T>({
                                 >
                                     <LinearProgress />
                                 </Box>
+                            </ConditionalComponent>
+                            <ConditionalComponent condition={rows.length === 0}>
+                                <TableRow>
+                                    <TableCell colSpan={headCells.length} align="center">
+                                        {loading ? '' : 'No rows to display'}
+                                    </TableCell>
+                                </TableRow>
                             </ConditionalComponent>
                             {rows.map((row, rowIndex) => {
                                 return (

--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -18,8 +18,8 @@ type Order = 'asc' | 'desc';
 
 interface MetTableHeadProps<T> {
     onRequestSort: (event: React.MouseEvent<unknown>, property: keyof T, headCellIndex: number) => void;
-    order: Order;
-    orderBy: keyof T;
+    order?: Order;
+    orderBy?: keyof T;
     rowCount: number;
     headCells: HeadCell<T>[];
     loading: boolean;

--- a/met-web/src/components/common/Table/types.ts
+++ b/met-web/src/components/common/Table/types.ts
@@ -8,3 +8,9 @@ export interface HeadCell<T> {
     customStyle?: React.CSSProperties;
     align?: 'right' | 'left' | 'inherit' | 'center' | 'justify';
 }
+
+export interface Pagination {
+    page: number;
+    size: number;
+    total: number;
+}

--- a/met-web/src/components/common/Table/types.ts
+++ b/met-web/src/components/common/Table/types.ts
@@ -13,9 +13,9 @@ export interface HeadCell<T> {
 export interface PaginationOptions<T> {
     page: number;
     size: number;
-    sort_key: keyof T;
+    sort_key?: keyof T;
     nested_sort_key?: string | null;
-    sort_order: 'asc' | 'desc';
+    sort_order?: 'asc' | 'desc';
 }
 
 export interface PageInfo {

--- a/met-web/src/components/common/Table/types.ts
+++ b/met-web/src/components/common/Table/types.ts
@@ -1,6 +1,7 @@
 export interface HeadCell<T> {
     disablePadding: boolean;
     key: keyof T;
+    nestedSortKey?: string;
     label: string;
     numeric: boolean;
     allowSort: boolean;
@@ -9,8 +10,14 @@ export interface HeadCell<T> {
     align?: 'right' | 'left' | 'inherit' | 'center' | 'justify';
 }
 
-export interface Pagination {
+export interface PaginationOptions<T> {
     page: number;
     size: number;
+    sort_key: keyof T;
+    nested_sort_key?: string | null;
+    sort_order: 'asc' | 'desc';
+}
+
+export interface PageInfo {
     total: number;
 }

--- a/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
@@ -1,23 +1,13 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import MetTable from 'components/common/Table';
 import { Comment } from 'models/comment';
-import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
+import { HeadCell } from 'components/common/Table/types';
 import { Skeleton, Typography } from '@mui/material';
 import { CommentViewContext } from './CommentViewContext';
 
 const CommentTable = () => {
-    const { isCommentsListLoading, comments } = useContext(CommentViewContext);
-    const [page, setPage] = useState(1);
-    const [size, setSize] = useState(10);
-    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Comment>>({
-        page: 0,
-        size: 10,
-        sort_key: 'id',
-        sort_order: 'asc',
-    });
-    const [pageInfo, setPageInfo] = useState<PageInfo>({
-        total: 0,
-    });
+    const { isCommentsListLoading, comments, paginationOptions, pageInfo, handleChangePagination, tableLoading } =
+        useContext(CommentViewContext);
 
     const headCells: HeadCell<Comment>[] = [
         {
@@ -46,26 +36,15 @@ const CommentTable = () => {
 
     return (
         <>
-            {/* <MetTable
-                rows={comments}
-                headCells={headCells}
-                hideHeader={true}
-                handlePageChange={(newPage: number) => setPage(newPage)}
-                handleSizeChange={(newSize: number) => setSize(newSize)}
-                handleChangePagination={(pagination: PaginationOptions<Comment>) => setPaginationOptions(pagination)}
-                paginationOptions={paginationOptions}
-            /> */}
-
             <MetTable
                 headCells={headCells}
                 rows={comments}
                 noRowBorder={true}
                 hideHeader={true}
-                handleChangePagination={(paginationOptions: PaginationOptions<Comment>) =>
-                    setPaginationOptions(paginationOptions)
-                }
+                handleChangePagination={handleChangePagination}
                 paginationOptions={paginationOptions}
                 pageInfo={pageInfo}
+                loading={tableLoading}
             />
         </>
     );

--- a/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
@@ -1,12 +1,20 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import MetTable from 'components/common/Table';
 import { Comment } from 'models/comment';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, Pagination } from 'components/common/Table/types';
 import { Skeleton, Typography } from '@mui/material';
 import { CommentViewContext } from './CommentViewContext';
 
 const CommentTable = () => {
     const { isCommentsListLoading, comments } = useContext(CommentViewContext);
+    const [page, setPage] = useState(1);
+    const [size, setSize] = useState(10);
+    const [pagination, setPagination] = useState<Pagination>({
+        page: 0,
+        size: 10,
+        total: 0,
+    });
+
     const headCells: HeadCell<Comment>[] = [
         {
             key: 'text',
@@ -32,7 +40,17 @@ const CommentTable = () => {
         return <Skeleton variant="rectangular" width="100%" height="60m" />;
     }
 
-    return <MetTable hideHeader={true} headCells={headCells} rows={comments} defaultSort={'submission_date'} />;
+    return (
+        <MetTable
+            hideHeader={true}
+            headCells={headCells}
+            rows={comments}
+            defaultSort={'submission_date'}
+            handlePageChange={(newPage: number) => setPage(newPage)}
+            handleSizeChange={(newSize: number) => setSize(newSize)}
+            handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
+        />
+    );
 };
 
 export default CommentTable;

--- a/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import MetTable from 'components/common/Table';
 import { Comment } from 'models/comment';
-import { HeadCell, Pagination } from 'components/common/Table/types';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { Skeleton, Typography } from '@mui/material';
 import { CommentViewContext } from './CommentViewContext';
 
@@ -9,9 +9,13 @@ const CommentTable = () => {
     const { isCommentsListLoading, comments } = useContext(CommentViewContext);
     const [page, setPage] = useState(1);
     const [size, setSize] = useState(10);
-    const [pagination, setPagination] = useState<Pagination>({
+    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Comment>>({
         page: 0,
         size: 10,
+        sort_key: 'id',
+        sort_order: 'asc',
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>({
         total: 0,
     });
 
@@ -41,15 +45,29 @@ const CommentTable = () => {
     }
 
     return (
-        <MetTable
-            hideHeader={true}
-            headCells={headCells}
-            rows={comments}
-            defaultSort={'submission_date'}
-            handlePageChange={(newPage: number) => setPage(newPage)}
-            handleSizeChange={(newSize: number) => setSize(newSize)}
-            handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
-        />
+        <>
+            {/* <MetTable
+                rows={comments}
+                headCells={headCells}
+                hideHeader={true}
+                handlePageChange={(newPage: number) => setPage(newPage)}
+                handleSizeChange={(newSize: number) => setSize(newSize)}
+                handleChangePagination={(pagination: PaginationOptions<Comment>) => setPaginationOptions(pagination)}
+                paginationOptions={paginationOptions}
+            /> */}
+
+            <MetTable
+                headCells={headCells}
+                rows={comments}
+                noRowBorder={true}
+                hideHeader={true}
+                handleChangePagination={(paginationOptions: PaginationOptions<Comment>) =>
+                    setPaginationOptions(paginationOptions)
+                }
+                paginationOptions={paginationOptions}
+                pageInfo={pageInfo}
+            />
+        </>
     );
 };
 

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -6,25 +6,43 @@ import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
 import { SubmissionStatus } from 'constants/engagementStatus';
 import { getErrorMessage } from 'utils';
-import { fetchComments } from 'services/commentService';
+import { getCommentsPage } from 'services/commentService';
 import { Comment } from 'models/comment';
+import { PageInfo, PaginationOptions } from 'components/common/Table/types';
 
 export interface EngagementCommentContextProps {
     engagement: Engagement | null;
     comments: Comment[];
     isEngagementLoading: boolean;
     isCommentsListLoading: boolean;
+    paginationOptions: PaginationOptions<Comment>;
+    pageInfo: PageInfo;
+    handleChangePagination: (_paginationOptions: PaginationOptions<Comment>) => void;
+    tableLoading: boolean;
 }
 
 export type EngagementParams = {
     engagementId: string;
 };
 
+const initialPaginationOptions = {
+    page: 0,
+    size: 10,
+};
+const initialTableLoading = {
+    total: 0,
+};
 export const CommentViewContext = createContext<EngagementCommentContextProps>({
     engagement: null,
     isEngagementLoading: true,
     isCommentsListLoading: true,
     comments: [],
+    paginationOptions: { page: 0, size: 10 },
+    pageInfo: { total: 0 },
+    handleChangePagination: (_paginationOptions: PaginationOptions<Comment>) => {
+        throw new Error('Unimplemented');
+    },
+    tableLoading: false,
 });
 
 export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
@@ -36,6 +54,11 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
     const [isEngagementLoading, setEngagementLoading] = useState(true);
     const [isCommentsListLoading, setIsCommentsListLoading] = useState(true);
     const [comments, setComments] = useState<Comment[]>([]);
+    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Comment>>(initialPaginationOptions);
+    const [pageInfo, setPageInfo] = useState<PageInfo>(initialTableLoading);
+    const [tableLoading, setTableLoading] = useState(true);
+
+    const { page, size } = paginationOptions;
 
     const validateEngagement = (engagementToValidate: Engagement) => {
         const isClosed = engagementToValidate?.submission_status === SubmissionStatus.Closed;
@@ -75,12 +98,20 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
             if (isNaN(Number(surveyId))) {
                 throw new Error('Invalid survey id');
             }
-
-            const fetchedComments = await fetchComments({
+            setTableLoading(true);
+            const response = await getCommentsPage({
                 survey_id: Number(surveyId),
+                page,
+                size,
             });
-            setComments(fetchedComments);
-            setIsCommentsListLoading(false);
+            setComments(response.items);
+            setPageInfo({
+                total: response.total,
+            });
+            setTableLoading(false);
+            if (isCommentsListLoading) {
+                setIsCommentsListLoading(false);
+            }
         } catch (error) {
             dispatch(
                 openNotification({
@@ -88,15 +119,19 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                     text: getErrorMessage(error) || 'Error occurred while fetching comments',
                 }),
             );
-            navigate('/');
+            setTableLoading(false);
         }
+    };
+
+    const handleChangePagination = (paginationOptions: PaginationOptions<Comment>) => {
+        setPaginationOptions(paginationOptions);
     };
 
     useEffect(() => {
         if (engagement) {
             callFetchComments();
         }
-    }, [engagement]);
+    }, [engagement, paginationOptions]);
 
     return (
         <CommentViewContext.Provider
@@ -105,6 +140,10 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                 isEngagementLoading,
                 comments,
                 isCommentsListLoading,
+                paginationOptions,
+                pageInfo,
+                handleChangePagination,
+                tableLoading,
             }}
         >
             {children}

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -26,7 +26,7 @@ export type EngagementParams = {
 };
 
 const initialPaginationOptions = {
-    page: 0,
+    page: 1,
     size: 10,
 };
 const initialTableLoading = {

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import { Link } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Survey } from 'models/survey';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, Pagination } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import TextField from '@mui/material/TextField';
@@ -22,6 +22,13 @@ const SurveyListing = () => {
     });
     const [searchText, setSearchText] = useState('');
     const [surveys, setSurveys] = useState<Survey[]>([]);
+    const [page, setPage] = useState(1);
+    const [size, setSize] = useState(10);
+    const [pagination, setPagination] = useState<Pagination>({
+        page: 0,
+        size: 10,
+        total: 0,
+    });
     const dispatch = useAppDispatch();
 
     const callFetchSurveys = async () => {
@@ -184,6 +191,9 @@ const SurveyListing = () => {
                     rows={surveys}
                     defaultSort={'created_date'}
                     noRowBorder={true}
+                    handlePageChange={(newPage: number) => setPage(newPage)}
+                    handleSizeChange={(newSize: number) => setSize(newSize)}
+                    handleChangePagination={(pagination: Pagination) => setPagination(pagination)}
                 />
             </Grid>
         </MetPageGridContainer>

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -33,7 +33,7 @@ const SurveyListing = () => {
         total: 0,
     });
 
-    const [tableLoading, setTableLoading] = useState(false);
+    const [tableLoading, setTableLoading] = useState(true);
 
     const dispatch = useAppDispatch();
 

--- a/met-web/src/services/commentService/index.tsx
+++ b/met-web/src/services/commentService/index.tsx
@@ -3,14 +3,41 @@ import { Comment } from 'models/comment';
 import Endpoints from 'apiManager/endpoints';
 
 import { replaceUrl } from 'helper';
+import { Page } from 'services/type';
 
 interface FetchCommentParams {
     survey_id: number;
 }
 export const fetchComments = async ({ survey_id }: FetchCommentParams): Promise<Comment[]> => {
-    const url = replaceUrl(Endpoints.Comment.GET_ALL, 'survey_id', String(survey_id));
+    const url = replaceUrl(Endpoints.Comment.GET_LIST, 'survey_id', String(survey_id));
     const responseData = await http.GetRequest<Comment[]>(url);
     return responseData.data.result ?? [];
+};
+
+interface GetCommentsParams {
+    survey_id: number;
+    page?: number;
+    size?: number;
+    sort_key?: string;
+    sort_order?: 'asc' | 'desc';
+    search_text?: string;
+}
+export const getCommentsPage = async ({
+    survey_id,
+    page,
+    size,
+    sort_key,
+    sort_order,
+    search_text,
+}: GetCommentsParams): Promise<Page<Comment>> => {
+    const url = replaceUrl(Endpoints.Comment.GET_LIST, 'survey_id', String(survey_id));
+    const responseData = await http.GetRequest<Page<Comment>>(url, { page, size, sort_key, sort_order, search_text });
+    return (
+        responseData.data.result ?? {
+            items: [],
+            total: 0,
+        }
+    );
 };
 
 export const getComment = async (commentId: number): Promise<Comment> => {

--- a/met-web/src/services/engagementService/index.ts
+++ b/met-web/src/services/engagementService/index.ts
@@ -7,10 +7,29 @@ import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
 
 export const fetchAll = async (dispatch: Dispatch<AnyAction>): Promise<Engagement[]> => {
-    const responseData = await http.GetRequest<Engagement[]>(Endpoints.Engagement.GET_ALL);
+    const responseData = await http.GetRequest<Engagement[]>(Endpoints.Engagement.GET_LIST);
     const engagements = responseData.data.result ?? [];
     dispatch(setEngagements(engagements));
     return engagements;
+};
+
+interface GetEngagementsParams {
+    page?: number;
+    size?: number;
+}
+
+interface Page<T> {
+    items: T[];
+    total: number;
+}
+export const getEngagements = async (params: GetEngagementsParams = {}): Promise<Page<Engagement>> => {
+    const responseData = await http.GetRequest<Page<Engagement>>(Endpoints.Engagement.GET_LIST, params);
+    return (
+        responseData.data.result ?? {
+            items: [],
+            total: 0,
+        }
+    );
 };
 
 export const getEngagement = async (engagementId: number): Promise<Engagement> => {

--- a/met-web/src/services/engagementService/index.ts
+++ b/met-web/src/services/engagementService/index.ts
@@ -5,6 +5,7 @@ import { Engagement } from 'models/engagement';
 import { PostEngagementRequest, PutEngagementRequest } from './types';
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
+import { Page } from 'services/type';
 
 export const fetchAll = async (dispatch: Dispatch<AnyAction>): Promise<Engagement[]> => {
     const responseData = await http.GetRequest<Engagement[]>(Endpoints.Engagement.GET_LIST);
@@ -16,11 +17,9 @@ export const fetchAll = async (dispatch: Dispatch<AnyAction>): Promise<Engagemen
 interface GetEngagementsParams {
     page?: number;
     size?: number;
-}
-
-interface Page<T> {
-    items: T[];
-    total: number;
+    sort_key?: string;
+    sort_order?: 'asc' | 'desc';
+    search_text?: string;
 }
 export const getEngagements = async (params: GetEngagementsParams = {}): Promise<Page<Engagement>> => {
     const responseData = await http.GetRequest<Page<Engagement>>(Endpoints.Engagement.GET_LIST, params);

--- a/met-web/src/services/surveyService/form/index.ts
+++ b/met-web/src/services/surveyService/form/index.ts
@@ -2,13 +2,31 @@ import http from 'apiManager/httpRequestHandler';
 import { Survey } from 'models/survey';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
+import { Page } from 'services/type';
 
 interface FetchSurveyParams {
     unlinked?: boolean;
 }
 export const fetchSurveys = async (params: FetchSurveyParams = {}): Promise<Survey[]> => {
-    const responseData = await http.GetRequest<Survey[]>(Endpoints.Survey.GET_ALL, params);
+    const responseData = await http.GetRequest<Survey[]>(Endpoints.Survey.GET_LIST, params);
     return responseData.data.result ?? [];
+};
+
+interface GetSurveysParams {
+    page?: number;
+    size?: number;
+    sort_key?: string;
+    sort_order?: 'asc' | 'desc';
+    search_text?: string;
+}
+export const getSurveysPage = async (params: GetSurveysParams = {}): Promise<Page<Survey>> => {
+    const responseData = await http.GetRequest<Page<Survey>>(Endpoints.Survey.GET_LIST, params);
+    return (
+        responseData.data.result ?? {
+            items: [],
+            total: 0,
+        }
+    );
 };
 
 export const getSurvey = async (surveyId: number): Promise<Survey> => {

--- a/met-web/src/services/type.ts
+++ b/met-web/src/services/type.ts
@@ -1,0 +1,4 @@
+export interface Page<T> {
+    items: T[];
+    total: number;
+}

--- a/met-web/src/services/userService/index.ts
+++ b/met-web/src/services/userService/index.ts
@@ -64,31 +64,6 @@ const refreshToken = (dispatch: Dispatch<Action>) => {
     }, 60000);
 };
 
-// eslint-disable-next-line
-const authenticateAnonymouslyOnFormio = () => {
-    const user = AppConfig.formio.anonymousUser;
-    const roles = [AppConfig.formio.anonymousId];
-    authenticateFormio(user, roles);
-};
-
-const authenticateFormio = async (user: string, roles: string[]) => {
-    const FORMIO_TOKEN = jwt.sign(
-        {
-            external: true,
-            form: {
-                _id: AppConfig.formio.userResourceFormId, // form.io form Id of user resource
-            },
-            user: {
-                _id: user, // keep it like that
-                roles: roles,
-            },
-        },
-        AppConfig.formio.jwtSecret,
-    ); // TODO Move JWT secret key to COME From ENV
-
-    localStorage.setItem('formioToken', FORMIO_TOKEN);
-};
-
 /**
  * Logout function
  */

--- a/met-web/src/services/userService/index.ts
+++ b/met-web/src/services/userService/index.ts
@@ -1,7 +1,6 @@
 import { _kc } from 'constants/tenantConstants';
 import { userToken, userDetails, userAuthorization, userAuthentication } from './userSlice';
 import { Action, AnyAction, Dispatch } from 'redux';
-import jwt from 'jsonwebtoken';
 import { UserDetail } from './types';
 import { AppConfig } from 'config';
 import Endpoints from 'apiManager/endpoints';


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/561

*Description of changes:*

- Use paginate for queries in the back-end
- Make MetTable function with server-side pagination


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
