### PR TITLE
Make METTable and listing pages use server side pagination

### DIFF
--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -2,10 +2,10 @@ import { AppConfig } from 'config';
 
 const Endpoints = {
     Engagement: {
-        GET_ALL: `${AppConfig.apiUrl}/engagement/`,
-        CREATE: `${AppConfig.apiUrl}/engagement/`,
-        UPDATE: `${AppConfig.apiUrl}/engagement/`,
-        GET: `${AppConfig.apiUrl}/engagement/engagement_id`,
+        GET_LIST: `${AppConfig.apiUrl}/engagements/`,
+        CREATE: `${AppConfig.apiUrl}/engagements/`,
+        UPDATE: `${AppConfig.apiUrl}/engagements/`,
+        GET: `${AppConfig.apiUrl}/engagements/engagement_id`,
     },
     User: {
         CREATE_UPDATE: `${AppConfig.apiUrl}/user/`,
@@ -14,20 +14,20 @@ const Endpoints = {
         OSS_HEADER: `${AppConfig.apiUrl}/document/`,
     },
     Survey: {
-        GET_ALL: `${AppConfig.apiUrl}/survey/`,
-        CREATE: `${AppConfig.apiUrl}/survey/`,
-        UPDATE: `${AppConfig.apiUrl}/survey/`,
-        LINK_TO_ENGAGEMENT: `${AppConfig.apiUrl}/survey/survey_id/link/engagement/engagement_id`,
-        UNLINK_FROM_ENGAGEMENT: `${AppConfig.apiUrl}/survey/survey_id/unlink/engagement/engagement_id`,
-        GET: `${AppConfig.apiUrl}/survey/survey_id`,
+        GET_LIST: `${AppConfig.apiUrl}/surveys/`,
+        CREATE: `${AppConfig.apiUrl}/surveys/`,
+        UPDATE: `${AppConfig.apiUrl}/surveys/`,
+        LINK_TO_ENGAGEMENT: `${AppConfig.apiUrl}/surveys/survey_id/link/engagement/engagement_id`,
+        UNLINK_FROM_ENGAGEMENT: `${AppConfig.apiUrl}/surveys/survey_id/unlink/engagement/engagement_id`,
+        GET: `${AppConfig.apiUrl}/surveys/survey_id`,
     },
     SurveySubmission: {
         CREATE: `${AppConfig.apiUrl}/submission/`,
     },
     Comment: {
-        GET_ALL: `${AppConfig.apiUrl}/comment/survey/survey_id/comments`,
-        REVIEW: `${AppConfig.apiUrl}/comment/comment_id `,
-        GET: `${AppConfig.apiUrl}/comment/comment_id`,
+        GET_LIST: `${AppConfig.apiUrl}/comments/survey/survey_id`,
+        REVIEW: `${AppConfig.apiUrl}/comments/comment_id `,
+        GET: `${AppConfig.apiUrl}/comments/comment_id`,
     },
     EmailVerification: {
         GET: `${AppConfig.apiUrl}/email_verification/verification_token`,

--- a/met-web/src/components/LandingPage/LandingPage.tsx
+++ b/met-web/src/components/LandingPage/LandingPage.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton } from '../common';
 import { Engagement } from 'models/engagement';
 import { useAppDispatch } from 'hooks';
-import { HeadCell, PageInfo, PaginationOptions } from '../common/Table/types';
+import { createDefaultPageInfo, HeadCell, PageInfo, PaginationOptions } from '../common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import { getEngagements } from 'services/engagementService';
@@ -29,9 +29,7 @@ const LandingPage = () => {
         sort_order: 'asc',
     });
 
-    const [pageInfo, setPageInfo] = useState<PageInfo>({
-        total: 0,
-    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>(createDefaultPageInfo());
     const [tableLoading, setTableLoading] = useState(true);
 
     const dispatch = useAppDispatch();

--- a/met-web/src/components/LandingPage/LandingPage.tsx
+++ b/met-web/src/components/LandingPage/LandingPage.tsx
@@ -39,10 +39,10 @@ const LandingPage = () => {
     const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
 
     useEffect(() => {
-        callGetEngagements();
+        loadEngagements();
     }, [paginationOptions, searchFilter]);
 
-    const callGetEngagements = async () => {
+    const loadEngagements = async () => {
         try {
             setTableLoading(true);
             const response = await getEngagements({

--- a/met-web/src/components/comments/admin/reviewListing/index.tsx
+++ b/met-web/src/components/comments/admin/reviewListing/index.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import { Link, useParams } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton, MetHeader1 } from 'components/common';
 import { Comment } from 'models/comment';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import TextField from '@mui/material/TextField';
@@ -12,7 +12,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import Stack from '@mui/material/Stack';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { fetchComments } from 'services/commentService';
+import { getCommentsPage } from 'services/commentService';
 
 const CommentListing = () => {
     const [searchFilter, setSearchFilter] = useState({
@@ -21,29 +21,53 @@ const CommentListing = () => {
     });
     const [searchText, setSearchText] = useState('');
     const [comments, setComments] = useState<Comment[]>([]);
-
+    const [paginationOptions, setPagination] = useState<PaginationOptions<Comment>>({
+        page: 1,
+        size: 10,
+        sort_key: 'id',
+        nested_sort_key: 'comment.id',
+        sort_order: 'desc',
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>({
+        total: 0,
+    });
+    const [tableLoading, setTableLoading] = useState(true);
     const { surveyId } = useParams();
 
     const dispatch = useAppDispatch();
 
-    const callFetchComments = async () => {
+    const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
+
+    const callGetComments = async () => {
         try {
             if (isNaN(Number(surveyId))) {
                 dispatch(openNotification({ severity: 'error', text: 'Invalid surveyId' }));
             }
 
-            const fetchedComments = await fetchComments({
+            setTableLoading(true);
+            const response = await getCommentsPage({
                 survey_id: Number(surveyId),
+                page,
+                size,
+                sort_key: nested_sort_key || sort_key,
+                sort_order,
+                search_text: searchFilter.value,
             });
-            setComments(fetchedComments);
+            setComments(response.items);
+            setPageInfo({
+                total: response.total,
+            });
+            setTableLoading(false);
         } catch (error) {
+            console.log(error);
             dispatch(openNotification({ severity: 'error', text: 'Error occurred while fetching comments' }));
+            setTableLoading(false);
         }
     };
 
     useEffect(() => {
-        callFetchComments();
-    }, [surveyId]);
+        callGetComments();
+    }, [surveyId, paginationOptions, searchFilter]);
 
     const handleSearchBarClick = (filter: string) => {
         setSearchFilter({
@@ -55,6 +79,7 @@ const CommentListing = () => {
     const headCells: HeadCell<Comment>[] = [
         {
             key: 'id',
+            nestedSortKey: 'comment.id',
             numeric: true,
             disablePadding: false,
             label: 'ID',
@@ -133,11 +158,13 @@ const CommentListing = () => {
                     <strong>{`${comments[0]?.survey || ''} Comments`}</strong>
                 </MetHeader1>
                 <MetTable
-                    filter={searchFilter}
                     headCells={headCells}
                     rows={comments}
-                    defaultSort={'id'}
                     noRowBorder={true}
+                    handleChangePagination={(pagination: PaginationOptions<Comment>) => setPagination(pagination)}
+                    paginationOptions={paginationOptions}
+                    pageInfo={pageInfo}
+                    loading={tableLoading}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments/all`}>
                     Read All Comments

--- a/met-web/src/components/comments/admin/reviewListing/index.tsx
+++ b/met-web/src/components/comments/admin/reviewListing/index.tsx
@@ -38,7 +38,7 @@ const CommentListing = () => {
 
     const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
 
-    const callGetComments = async () => {
+    const loadComments = async () => {
         try {
             if (isNaN(Number(surveyId))) {
                 dispatch(openNotification({ severity: 'error', text: 'Invalid surveyId' }));
@@ -66,7 +66,7 @@ const CommentListing = () => {
     };
 
     useEffect(() => {
-        callGetComments();
+        loadComments();
     }, [surveyId, paginationOptions, searchFilter]);
 
     const handleSearchBarClick = (filter: string) => {

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -36,7 +36,7 @@ const CommentTextListing = () => {
 
     const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
 
-    const callGetComments = async () => {
+    const loadComments = async () => {
         try {
             if (isNaN(Number(surveyId))) {
                 dispatch(openNotification({ severity: 'error', text: 'Invalid surveyId' }));
@@ -64,7 +64,7 @@ const CommentTextListing = () => {
     };
 
     useEffect(() => {
-        callGetComments();
+        loadComments();
     }, [paginationOptions, surveyId, searchFilter]);
 
     const handleSearchBarClick = (filter: string) => {

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -3,14 +3,14 @@ import MetTable from 'components/common/Table';
 import { Link, useParams } from 'react-router-dom';
 import { ConditionalComponent, MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Comment } from 'models/comment';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { Link as MuiLink, Typography, Grid, Stack, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { CommentStatusChip } from '../../status';
-import { fetchComments } from 'services/commentService';
 import { CommentStatus } from 'constants/commentStatus';
+import { getCommentsPage } from 'services/commentService';
 
 const CommentTextListing = () => {
     const [comments, setComments] = useState<Comment[]>([]);
@@ -19,28 +19,53 @@ const CommentTextListing = () => {
         value: '',
     });
     const [searchText, setSearchText] = useState('');
+    const [paginationOptions, setPagination] = useState<PaginationOptions<Comment>>({
+        page: 1,
+        size: 10,
+        sort_key: 'id',
+        nested_sort_key: 'comment.id',
+        sort_order: 'desc',
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>({
+        total: 0,
+    });
+    const [tableLoading, setTableLoading] = useState(true);
 
     const dispatch = useAppDispatch();
     const { surveyId } = useParams();
 
-    const callFetchComments = async () => {
+    const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
+
+    const callGetComments = async () => {
         try {
             if (isNaN(Number(surveyId))) {
                 dispatch(openNotification({ severity: 'error', text: 'Invalid surveyId' }));
             }
 
-            const fetchedComments = await fetchComments({
+            setTableLoading(true);
+            const response = await getCommentsPage({
                 survey_id: Number(surveyId),
+                page,
+                size,
+                sort_key: nested_sort_key || sort_key,
+                sort_order,
+                search_text: searchFilter.value,
             });
-            setComments(fetchedComments);
+            setComments(response.items);
+            setPageInfo({
+                total: response.total,
+            });
+            setTableLoading(false);
         } catch (error) {
+            console.log(error);
             dispatch(openNotification({ severity: 'error', text: 'Error occurred while fetching comments' }));
+            setTableLoading(false);
         }
     };
 
     useEffect(() => {
-        callFetchComments();
-    }, []);
+        callGetComments();
+    }, [paginationOptions, surveyId, searchFilter]);
 
     const handleSearchBarClick = (filter: string) => {
         setSearchFilter({
@@ -129,12 +154,14 @@ const CommentTextListing = () => {
             </Grid>
             <Grid item sm={12} lg={10}>
                 <MetTable
-                    filter={searchFilter}
                     hideHeader={true}
                     headCells={headCells}
                     rows={comments}
-                    defaultSort={'id'}
                     noRowBorder={true}
+                    handleChangePagination={(pagination: PaginationOptions<Comment>) => setPagination(pagination)}
+                    paginationOptions={paginationOptions}
+                    pageInfo={pageInfo}
+                    loading={tableLoading}
                 />
                 <PrimaryButton component={Link} to={`/survey/${comments[0]?.survey_id || 0}/comments`}>
                     Return to Comments List

--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -192,7 +192,7 @@ function MetTable<T>({
                 <TablePagination
                     rowsPerPageOptions={[5, 10, 25]}
                     component="div"
-                    count={Number(total)}
+                    count={total}
                     rowsPerPage={size}
                     page={page - 1}
                     onPageChange={handleChangePage}

--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -10,56 +10,24 @@ import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import Paper from '@mui/material/Paper';
 import { visuallyHidden } from '@mui/utils';
-import { HeadCell } from 'components/common/Table/types';
-import { hasKey } from 'utils';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { ConditionalComponent } from '..';
-
-function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
-    if (b[orderBy] < a[orderBy]) {
-        return -1;
-    }
-    if (b[orderBy] > a[orderBy]) {
-        return 1;
-    }
-    return 0;
-}
+import { LinearProgress } from '@mui/material';
 
 type Order = 'asc' | 'desc';
 
-// eslint-disable-next-line
-function getComparator<T>(order: Order, orderBy: keyof T): (a: T, b: T) => number {
-    return order === 'desc'
-        ? (a, b) => descendingComparator(a, b, orderBy)
-        : (a, b) => -descendingComparator(a, b, orderBy);
-}
-
-// This method is created for cross-browser compatibility, if you don't
-// need to support IE11, you can use Array.prototype.sort() directly
-function stableSort<T>(array: readonly T[], comparator: (a: T, b: T) => number) {
-    const stabilizedThis = array.map((el, index) => [el, index] as [T, number]);
-    stabilizedThis.sort((a, b) => {
-        const order = comparator(a[0], b[0]);
-        if (order !== 0) {
-            return order;
-        }
-        return a[1] - b[1];
-    });
-    return stabilizedThis.map((el) => el[0]);
-}
-
 interface MetTableHeadProps<T> {
-    onRequestSort: (event: React.MouseEvent<unknown>, property: keyof T) => void;
-    order: Order;
-    orderBy: keyof T;
+    onRequestSort: (event: React.MouseEvent<unknown>, property: keyof T, headCellIndex: number) => void;
+    order?: Order;
+    orderBy?: keyof T;
     rowCount: number;
     headCells: HeadCell<T>[];
+    loading: boolean;
 }
 
-function MetTableHead<T>(props: MetTableHeadProps<T>) {
-    const { order, orderBy, onRequestSort, headCells } = props;
-
-    const createSortHandler = (property: keyof T) => (event: React.MouseEvent<unknown>) => {
-        onRequestSort(event, property);
+function MetTableHead<T>({ order, orderBy, onRequestSort, headCells, loading }: MetTableHeadProps<T>) {
+    const createSortHandler = (property: keyof T, headCellIndex: number) => (event: React.MouseEvent<unknown>) => {
+        onRequestSort(event, property, headCellIndex);
     };
 
     return (
@@ -73,10 +41,10 @@ function MetTableHead<T>(props: MetTableHeadProps<T>) {
                         sx={{ borderBottom: '1.5px solid gray', fontWeight: 'bold' }}
                     >
                         <TableSortLabel
-                            disabled={!headCell.allowSort}
+                            disabled={!headCell.allowSort || loading}
                             active={orderBy === headCell.key}
                             direction={orderBy === headCell.key ? order : 'asc'}
-                            onClick={createSortHandler(headCell.key)}
+                            onClick={createSortHandler(headCell.key, index)}
                         >
                             {headCell.label}
                             {orderBy === headCell.key && (
@@ -93,63 +61,59 @@ function MetTableHead<T>(props: MetTableHeadProps<T>) {
 }
 
 interface MetTableProps<T> {
-    filter?: {
-        key: string;
-        value: string;
-    };
     headCells: HeadCell<T>[];
-    defaultSort: keyof T;
     rows: T[];
     hideHeader?: boolean;
     noRowBorder?: boolean;
+    handleChangePagination: (pagination: PaginationOptions<T>) => void;
+    loading?: boolean;
+    paginationOptions: PaginationOptions<T>;
+    pageInfo: PageInfo;
 }
 function MetTable<T>({
     hideHeader = false,
-    filter = { key: '', value: '' },
     headCells = [],
-    defaultSort,
     rows = [],
     noRowBorder = false,
+    handleChangePagination,
+    loading = false,
+    paginationOptions,
+    pageInfo,
 }: MetTableProps<T>) {
-    const [filteredRows, setFilteredRows] = useState<T[]>(rows);
-    const [order, setOrder] = useState<Order>('desc');
-    const [orderBy, setOrderBy] = useState(defaultSort);
-    const [page, setPage] = useState(0);
-    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const { page, size, sort_key, sort_order } = paginationOptions;
+    const { total } = pageInfo;
 
-    useEffect(() => {
-        if (!filter.key || !filter.value) {
-            setFilteredRows(rows);
-            return;
-        }
+    const order = sort_order;
+    const orderBy = sort_key;
 
-        const rowsFilteredResults = rows.filter((row: T) => {
-            if (!hasKey(row, filter.key)) {
-                return false;
-            }
-            // filter by rows who have the specified field in filter.key matching the search filter value
-            return String(row[filter.key]).toLowerCase().match(`${filter.value.toLowerCase()}.*`);
-        });
-        setFilteredRows(rowsFilteredResults);
-    }, [rows, filter]);
-
-    const handleRequestSort = (_event: React.MouseEvent<unknown>, property: keyof T) => {
+    const handleRequestSort = (_event: React.MouseEvent<unknown>, property: keyof T, headCellIndex: number) => {
         const isAsc = orderBy === property && order === 'asc';
-        setOrder(isAsc ? 'desc' : 'asc');
-        setOrderBy(property);
+        handleChangePagination({
+            ...paginationOptions,
+            sort_key: property,
+            nested_sort_key: headCells[headCellIndex].nestedSortKey,
+            sort_order: isAsc ? 'desc' : 'asc',
+        });
     };
 
     const handleChangePage = (_event: unknown, newPage: number) => {
-        setPage(newPage);
+        handleChangePagination({
+            ...paginationOptions,
+            page: newPage + 1,
+        });
     };
 
     const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setRowsPerPage(parseInt(event.target.value, 10));
-        setPage(0);
+        const newSize = parseInt(event.target.value, 10);
+        handleChangePagination({
+            ...paginationOptions,
+            page: 1,
+            size: newSize,
+        });
     };
 
     // Avoid a layout jump when reaching the last page with empty filteredRows.
-    const emptyRows = page > 0 ? Math.max(0, (1 + page) * rowsPerPage - filteredRows.length) : 0;
+    const emptyRows = page > 1 ? Math.max(0, page * size - total) : 0;
 
     return (
         <Box>
@@ -161,41 +125,65 @@ function MetTable<T>({
                                 order={order}
                                 orderBy={orderBy}
                                 onRequestSort={handleRequestSort}
-                                rowCount={filteredRows.length}
+                                rowCount={rows.length}
                                 headCells={headCells}
+                                loading={loading}
                             />
                         </ConditionalComponent>
 
-                        <TableBody>
-                            {stableSort<T>(filteredRows, getComparator<T>(order, orderBy))
-                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                                .map((row, rowIndex) => {
-                                    return (
-                                        <TableRow hover tabIndex={-1} key={`row-${rowIndex}`}>
-                                            {headCells.map((cell, cellIndex) => (
-                                                <TableCell
-                                                    align={cell.align}
-                                                    key={`row-${rowIndex}-${cellIndex}`}
-                                                    style={cell.customStyle || {}}
-                                                    sx={[
-                                                        noRowBorder && {
-                                                            border: 'none',
-                                                        },
-                                                    ]}
-                                                >
-                                                    {cell.getValue ? cell.getValue(row) : String(row[cell.key])}
-                                                </TableCell>
-                                            ))}
-                                        </TableRow>
-                                    );
-                                })}
+                        <TableBody sx={{ position: 'relative', minHeight: 53 }}>
+                            <ConditionalComponent condition={loading}>
+                                <Box
+                                    sx={{
+                                        position: 'absolute',
+                                        width: '100%',
+                                        height: '100%',
+                                    }}
+                                >
+                                    <LinearProgress />
+                                </Box>
+                            </ConditionalComponent>
+                            <ConditionalComponent condition={rows.length === 0}>
+                                <TableRow>
+                                    <TableCell colSpan={headCells.length} align="center">
+                                        {loading ? '' : 'No rows to display'}
+                                    </TableCell>
+                                </TableRow>
+                            </ConditionalComponent>
+                            {rows.map((row, rowIndex) => {
+                                return (
+                                    <TableRow hover tabIndex={-1} key={`row-${rowIndex}`}>
+                                        {headCells.map((cell, cellIndex) => (
+                                            <TableCell
+                                                align={cell.align}
+                                                key={`row-${rowIndex}-${cellIndex}`}
+                                                style={cell.customStyle || {}}
+                                                sx={[
+                                                    noRowBorder && {
+                                                        border: 'none',
+                                                    },
+                                                ]}
+                                            >
+                                                {cell.getValue ? cell.getValue(row) : String(row[cell.key])}
+                                            </TableCell>
+                                        ))}
+                                    </TableRow>
+                                );
+                            })}
                             {emptyRows > 0 && (
                                 <TableRow
                                     style={{
                                         height: 53 * emptyRows,
                                     }}
                                 >
-                                    <TableCell colSpan={headCells.length} />
+                                    <TableCell
+                                        colSpan={headCells.length}
+                                        sx={[
+                                            noRowBorder && {
+                                                border: 'none',
+                                            },
+                                        ]}
+                                    />
                                 </TableRow>
                             )}
                         </TableBody>
@@ -204,9 +192,9 @@ function MetTable<T>({
                 <TablePagination
                     rowsPerPageOptions={[5, 10, 25]}
                     component="div"
-                    count={filteredRows.length}
-                    rowsPerPage={rowsPerPage}
-                    page={page}
+                    count={Number(total)}
+                    rowsPerPage={size}
+                    page={page - 1}
                     onPageChange={handleChangePage}
                     onRowsPerPageChange={handleChangeRowsPerPage}
                 />

--- a/met-web/src/components/common/Table/types.ts
+++ b/met-web/src/components/common/Table/types.ts
@@ -21,3 +21,9 @@ export interface PaginationOptions<T> {
 export interface PageInfo {
     total: number;
 }
+
+export const createDefaultPageInfo = (): PageInfo => {
+    return {
+        total: 0,
+    };
+};

--- a/met-web/src/components/common/Table/types.ts
+++ b/met-web/src/components/common/Table/types.ts
@@ -1,10 +1,23 @@
 export interface HeadCell<T> {
     disablePadding: boolean;
     key: keyof T;
+    nestedSortKey?: string;
     label: string;
     numeric: boolean;
     allowSort: boolean;
     getValue?: (row: T) => string | number | JSX.Element;
     customStyle?: React.CSSProperties;
     align?: 'right' | 'left' | 'inherit' | 'center' | 'justify';
+}
+
+export interface PaginationOptions<T> {
+    page: number;
+    size: number;
+    sort_key?: keyof T;
+    nested_sort_key?: string | null;
+    sort_order?: 'asc' | 'desc';
+}
+
+export interface PageInfo {
+    total: number;
 }

--- a/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
@@ -6,7 +6,9 @@ import { Skeleton, Typography } from '@mui/material';
 import { CommentViewContext } from './CommentViewContext';
 
 const CommentTable = () => {
-    const { isCommentsListLoading, comments } = useContext(CommentViewContext);
+    const { isCommentsListLoading, comments, paginationOptions, pageInfo, handleChangePagination, tableLoading } =
+        useContext(CommentViewContext);
+
     const headCells: HeadCell<Comment>[] = [
         {
             key: 'text',
@@ -32,7 +34,20 @@ const CommentTable = () => {
         return <Skeleton variant="rectangular" width="100%" height="60m" />;
     }
 
-    return <MetTable hideHeader={true} headCells={headCells} rows={comments} defaultSort={'submission_date'} />;
+    return (
+        <>
+            <MetTable
+                headCells={headCells}
+                rows={comments}
+                noRowBorder={true}
+                hideHeader={true}
+                handleChangePagination={handleChangePagination}
+                paginationOptions={paginationOptions}
+                pageInfo={pageInfo}
+                loading={tableLoading}
+            />
+        </>
+    );
 };
 
 export default CommentTable;

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -92,7 +92,7 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
         fetchEngagement();
     }, [engagementId]);
 
-    const callFetchComments = async () => {
+    const loadComments = async () => {
         try {
             const surveyId = engagement?.surveys[0]?.id;
             if (isNaN(Number(surveyId))) {
@@ -129,7 +129,7 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
 
     useEffect(() => {
         if (engagement) {
-            callFetchComments();
+            loadComments();
         }
     }, [engagement, paginationOptions]);
 

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -8,7 +8,7 @@ import { SubmissionStatus } from 'constants/engagementStatus';
 import { getErrorMessage } from 'utils';
 import { getCommentsPage } from 'services/commentService';
 import { Comment } from 'models/comment';
-import { PageInfo, PaginationOptions } from 'components/common/Table/types';
+import { createDefaultPageInfo, PageInfo, PaginationOptions } from 'components/common/Table/types';
 
 export interface EngagementCommentContextProps {
     engagement: Engagement | null;
@@ -54,8 +54,11 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
     const [isEngagementLoading, setEngagementLoading] = useState(true);
     const [isCommentsListLoading, setIsCommentsListLoading] = useState(true);
     const [comments, setComments] = useState<Comment[]>([]);
-    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Comment>>(initialPaginationOptions);
-    const [pageInfo, setPageInfo] = useState<PageInfo>(initialTableLoading);
+    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Comment>>({
+        page: 1,
+        size: 10,
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>(createDefaultPageInfo());
     const [tableLoading, setTableLoading] = useState(true);
 
     const { page, size } = paginationOptions;

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -25,13 +25,6 @@ export type EngagementParams = {
     engagementId: string;
 };
 
-const initialPaginationOptions = {
-    page: 1,
-    size: 10,
-};
-const initialTableLoading = {
-    total: 0,
-};
 export const CommentViewContext = createContext<EngagementCommentContextProps>({
     engagement: null,
     isEngagementLoading: true,

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -6,25 +6,43 @@ import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
 import { SubmissionStatus } from 'constants/engagementStatus';
 import { getErrorMessage } from 'utils';
-import { fetchComments } from 'services/commentService';
+import { getCommentsPage } from 'services/commentService';
 import { Comment } from 'models/comment';
+import { PageInfo, PaginationOptions } from 'components/common/Table/types';
 
 export interface EngagementCommentContextProps {
     engagement: Engagement | null;
     comments: Comment[];
     isEngagementLoading: boolean;
     isCommentsListLoading: boolean;
+    paginationOptions: PaginationOptions<Comment>;
+    pageInfo: PageInfo;
+    handleChangePagination: (_paginationOptions: PaginationOptions<Comment>) => void;
+    tableLoading: boolean;
 }
 
 export type EngagementParams = {
     engagementId: string;
 };
 
+const initialPaginationOptions = {
+    page: 1,
+    size: 10,
+};
+const initialTableLoading = {
+    total: 0,
+};
 export const CommentViewContext = createContext<EngagementCommentContextProps>({
     engagement: null,
     isEngagementLoading: true,
     isCommentsListLoading: true,
     comments: [],
+    paginationOptions: { page: 0, size: 10 },
+    pageInfo: { total: 0 },
+    handleChangePagination: (_paginationOptions: PaginationOptions<Comment>) => {
+        throw new Error('Unimplemented');
+    },
+    tableLoading: false,
 });
 
 export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
@@ -36,6 +54,11 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
     const [isEngagementLoading, setEngagementLoading] = useState(true);
     const [isCommentsListLoading, setIsCommentsListLoading] = useState(true);
     const [comments, setComments] = useState<Comment[]>([]);
+    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Comment>>(initialPaginationOptions);
+    const [pageInfo, setPageInfo] = useState<PageInfo>(initialTableLoading);
+    const [tableLoading, setTableLoading] = useState(true);
+
+    const { page, size } = paginationOptions;
 
     const validateEngagement = (engagementToValidate: Engagement) => {
         const isClosed = engagementToValidate?.submission_status === SubmissionStatus.Closed;
@@ -75,12 +98,20 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
             if (isNaN(Number(surveyId))) {
                 throw new Error('Invalid survey id');
             }
-
-            const fetchedComments = await fetchComments({
+            setTableLoading(true);
+            const response = await getCommentsPage({
                 survey_id: Number(surveyId),
+                page,
+                size,
             });
-            setComments(fetchedComments);
-            setIsCommentsListLoading(false);
+            setComments(response.items);
+            setPageInfo({
+                total: response.total,
+            });
+            setTableLoading(false);
+            if (isCommentsListLoading) {
+                setIsCommentsListLoading(false);
+            }
         } catch (error) {
             dispatch(
                 openNotification({
@@ -88,15 +119,19 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                     text: getErrorMessage(error) || 'Error occurred while fetching comments',
                 }),
             );
-            navigate('/');
+            setTableLoading(false);
         }
+    };
+
+    const handleChangePagination = (paginationOptions: PaginationOptions<Comment>) => {
+        setPaginationOptions(paginationOptions);
     };
 
     useEffect(() => {
         if (engagement) {
             callFetchComments();
         }
-    }, [engagement]);
+    }, [engagement, paginationOptions]);
 
     return (
         <CommentViewContext.Provider
@@ -105,6 +140,10 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                 isEngagementLoading,
                 comments,
                 isCommentsListLoading,
+                paginationOptions,
+                pageInfo,
+                handleChangePagination,
+                tableLoading,
             }}
         >
             {children}

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -4,13 +4,13 @@ import Grid from '@mui/material/Grid';
 import { Link } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Survey } from 'models/survey';
-import { HeadCell } from 'components/common/Table/types';
+import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import TextField from '@mui/material/TextField';
 import SearchIcon from '@mui/icons-material/Search';
 import Stack from '@mui/material/Stack';
-import { fetchSurveys } from 'services/surveyService/form';
+import { getSurveysPage } from 'services/surveyService/form';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { EngagementStatus } from 'constants/engagementStatus';
@@ -22,30 +22,59 @@ const SurveyListing = () => {
     });
     const [searchText, setSearchText] = useState('');
     const [surveys, setSurveys] = useState<Survey[]>([]);
+    const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Survey>>({
+        page: 1,
+        size: 10,
+        sort_key: 'name',
+        nested_sort_key: 'survey.name',
+        sort_order: 'asc',
+    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>({
+        total: 0,
+    });
+
+    const [tableLoading, setTableLoading] = useState(true);
+
     const dispatch = useAppDispatch();
 
-    const callFetchSurveys = async () => {
+    const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
+
+    const callGetSurveysPage = async () => {
         try {
-            const fetchedSurveys = await fetchSurveys();
-            setSurveys(fetchedSurveys);
+            setTableLoading(true);
+            const response = await getSurveysPage({
+                page,
+                size,
+                sort_key: nested_sort_key || sort_key,
+                sort_order,
+                search_text: searchFilter.value,
+            });
+            setSurveys(response.items);
+            setPageInfo({
+                total: response.total,
+            });
+            setTableLoading(false);
         } catch (error) {
             dispatch(openNotification({ severity: 'error', text: 'Error occurred while fetching surveys' }));
+            setTableLoading(false);
         }
     };
-    useEffect(() => {
-        callFetchSurveys();
-    }, []);
 
-    const handleSearchBarClick = (engagementNameFilter: string) => {
+    useEffect(() => {
+        callGetSurveysPage();
+    }, [paginationOptions, searchFilter]);
+
+    const handleSearchBarClick = (surveyNameFilter: string) => {
         setSearchFilter({
             ...searchFilter,
-            value: engagementNameFilter,
+            value: surveyNameFilter,
         });
     };
 
     const headCells: HeadCell<Survey>[] = [
         {
             key: 'name',
+            nestedSortKey: 'survey.name',
             numeric: false,
             disablePadding: true,
             label: 'Survey Name',
@@ -58,6 +87,7 @@ const SurveyListing = () => {
         },
         {
             key: 'created_date',
+            nestedSortKey: 'survey.created_date',
             numeric: true,
             disablePadding: false,
             label: 'Date Created',
@@ -66,6 +96,7 @@ const SurveyListing = () => {
         },
         {
             key: 'engagement',
+            nestedSortKey: 'engagement.published_date',
             numeric: true,
             disablePadding: false,
             label: 'Date Published',
@@ -74,6 +105,7 @@ const SurveyListing = () => {
         },
         {
             key: 'engagement',
+            nestedSortKey: 'engagement.name',
             numeric: true,
             disablePadding: false,
             label: 'Engagement Name',
@@ -95,7 +127,7 @@ const SurveyListing = () => {
             numeric: true,
             disablePadding: false,
             label: 'Responses',
-            allowSort: true,
+            allowSort: false,
             getValue: (row: Survey) => {
                 if (!row.comments_meta_data.total) {
                     return 0;
@@ -112,6 +144,7 @@ const SurveyListing = () => {
         },
         {
             key: 'engagement',
+            nestedSortKey: 'engagement.status_id',
             numeric: true,
             disablePadding: false,
             label: 'Status',
@@ -121,6 +154,7 @@ const SurveyListing = () => {
         },
         {
             key: 'id',
+            nestedSortKey: 'survey.id',
             numeric: true,
             disablePadding: false,
             label: 'Reporting',
@@ -179,11 +213,15 @@ const SurveyListing = () => {
 
             <Grid item xs={12} lg={10}>
                 <MetTable
-                    filter={searchFilter}
                     headCells={headCells}
                     rows={surveys}
-                    defaultSort={'created_date'}
                     noRowBorder={true}
+                    handleChangePagination={(paginationOptions: PaginationOptions<Survey>) =>
+                        setPaginationOptions(paginationOptions)
+                    }
+                    paginationOptions={paginationOptions}
+                    loading={tableLoading}
+                    pageInfo={pageInfo}
                 />
             </Grid>
         </MetPageGridContainer>

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -39,7 +39,7 @@ const SurveyListing = () => {
 
     const { page, size, sort_key, nested_sort_key, sort_order } = paginationOptions;
 
-    const callGetSurveysPage = async () => {
+    const loadSurveys = async () => {
         try {
             setTableLoading(true);
             const response = await getSurveysPage({
@@ -61,7 +61,7 @@ const SurveyListing = () => {
     };
 
     useEffect(() => {
-        callGetSurveysPage();
+        loadSurveys();
     }, [paginationOptions, searchFilter]);
 
     const handleSearchBarClick = (surveyNameFilter: string) => {

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import { Link } from 'react-router-dom';
 import { MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Survey } from 'models/survey';
-import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
+import { createDefaultPageInfo, HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
 import { Link as MuiLink } from '@mui/material';
 import TextField from '@mui/material/TextField';
@@ -29,9 +29,7 @@ const SurveyListing = () => {
         nested_sort_key: 'survey.name',
         sort_order: 'asc',
     });
-    const [pageInfo, setPageInfo] = useState<PageInfo>({
-        total: 0,
-    });
+    const [pageInfo, setPageInfo] = useState<PageInfo>(createDefaultPageInfo());
 
     const [tableLoading, setTableLoading] = useState(true);
 

--- a/met-web/src/services/commentService/index.tsx
+++ b/met-web/src/services/commentService/index.tsx
@@ -3,14 +3,41 @@ import { Comment } from 'models/comment';
 import Endpoints from 'apiManager/endpoints';
 
 import { replaceUrl } from 'helper';
+import { Page } from 'services/type';
 
 interface FetchCommentParams {
     survey_id: number;
 }
 export const fetchComments = async ({ survey_id }: FetchCommentParams): Promise<Comment[]> => {
-    const url = replaceUrl(Endpoints.Comment.GET_ALL, 'survey_id', String(survey_id));
+    const url = replaceUrl(Endpoints.Comment.GET_LIST, 'survey_id', String(survey_id));
     const responseData = await http.GetRequest<Comment[]>(url);
     return responseData.data.result ?? [];
+};
+
+interface GetCommentsParams {
+    survey_id: number;
+    page?: number;
+    size?: number;
+    sort_key?: string;
+    sort_order?: 'asc' | 'desc';
+    search_text?: string;
+}
+export const getCommentsPage = async ({
+    survey_id,
+    page,
+    size,
+    sort_key,
+    sort_order,
+    search_text,
+}: GetCommentsParams): Promise<Page<Comment>> => {
+    const url = replaceUrl(Endpoints.Comment.GET_LIST, 'survey_id', String(survey_id));
+    const responseData = await http.GetRequest<Page<Comment>>(url, { page, size, sort_key, sort_order, search_text });
+    return (
+        responseData.data.result ?? {
+            items: [],
+            total: 0,
+        }
+    );
 };
 
 export const getComment = async (commentId: number): Promise<Comment> => {

--- a/met-web/src/services/engagementService/index.ts
+++ b/met-web/src/services/engagementService/index.ts
@@ -5,12 +5,30 @@ import { Engagement } from 'models/engagement';
 import { PostEngagementRequest, PutEngagementRequest } from './types';
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
+import { Page } from 'services/type';
 
 export const fetchAll = async (dispatch: Dispatch<AnyAction>): Promise<Engagement[]> => {
-    const responseData = await http.GetRequest<Engagement[]>(Endpoints.Engagement.GET_ALL);
+    const responseData = await http.GetRequest<Engagement[]>(Endpoints.Engagement.GET_LIST);
     const engagements = responseData.data.result ?? [];
     dispatch(setEngagements(engagements));
     return engagements;
+};
+
+interface GetEngagementsParams {
+    page?: number;
+    size?: number;
+    sort_key?: string;
+    sort_order?: 'asc' | 'desc';
+    search_text?: string;
+}
+export const getEngagements = async (params: GetEngagementsParams = {}): Promise<Page<Engagement>> => {
+    const responseData = await http.GetRequest<Page<Engagement>>(Endpoints.Engagement.GET_LIST, params);
+    return (
+        responseData.data.result ?? {
+            items: [],
+            total: 0,
+        }
+    );
 };
 
 export const getEngagement = async (engagementId: number): Promise<Engagement> => {

--- a/met-web/src/services/surveyService/form/index.ts
+++ b/met-web/src/services/surveyService/form/index.ts
@@ -2,13 +2,31 @@ import http from 'apiManager/httpRequestHandler';
 import { Survey } from 'models/survey';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
+import { Page } from 'services/type';
 
 interface FetchSurveyParams {
     unlinked?: boolean;
 }
 export const fetchSurveys = async (params: FetchSurveyParams = {}): Promise<Survey[]> => {
-    const responseData = await http.GetRequest<Survey[]>(Endpoints.Survey.GET_ALL, params);
+    const responseData = await http.GetRequest<Survey[]>(Endpoints.Survey.GET_LIST, params);
     return responseData.data.result ?? [];
+};
+
+interface GetSurveysParams {
+    page?: number;
+    size?: number;
+    sort_key?: string;
+    sort_order?: 'asc' | 'desc';
+    search_text?: string;
+}
+export const getSurveysPage = async (params: GetSurveysParams = {}): Promise<Page<Survey>> => {
+    const responseData = await http.GetRequest<Page<Survey>>(Endpoints.Survey.GET_LIST, params);
+    return (
+        responseData.data.result ?? {
+            items: [],
+            total: 0,
+        }
+    );
 };
 
 export const getSurvey = async (surveyId: number): Promise<Survey> => {

--- a/met-web/src/services/type.ts
+++ b/met-web/src/services/type.ts
@@ -1,0 +1,4 @@
+export interface Page<T> {
+    items: T[];
+    total: number;
+}


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/561

*Description of changes:*

- Configure MetTable to have server side pagination
- update listings pages: Engagements, surveys and comments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
