### PR TITLE
Fix sort_key always defaulting to default value

### DIFF
--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -86,7 +86,7 @@ class Comments(Resource):
             pagination_options = PaginationOptions(
                 page=args.get('page', 1, int),
                 size=args.get('size', 10, int),
-                sort_key=args.get('sort_key', 'name', int),
+                sort_key=args.get('sort_key', 'name', str),
                 sort_order=args.get('sort_order', 'asc', str),
             )
             comment_records = CommentService()\

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -72,7 +72,7 @@ class Engagements(Resource):
             pagination_options = PaginationOptions(
                 page=args.get('page', 1, int),
                 size=args.get('size', 10, int),
-                sort_key=args.get('sort_key', 'name', int),
+                sort_key=args.get('sort_key', 'name', str),
                 sort_order=args.get('sort_order', 'asc', str),
             )
 

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -96,7 +96,7 @@ class Surveys(Resource):
             pagination_options = PaginationOptions(
                 page=args.get('page', 1, int),
                 size=args.get('size', 10, int),
-                sort_key=args.get('sort_key', 'survey.name', int),
+                sort_key=args.get('sort_key', 'survey.name', str),
                 sort_order=args.get('sort_order', 'asc', str),
             )
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/595

*Description of changes:*

- args.get('sort_key', 'name', str) change third argument from int to str to fix sort_key always defaulting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
