### PR TITLE
Make paginated resources optionally return everything

### DIFF
--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -52,14 +52,14 @@ class Comment(db.Model):
             else desc(text(pagination_options.sort_key))
 
         query = query.order_by(sort)
-        
+
         no_pagination_options = not pagination_options.page or not pagination_options.size
         if no_pagination_options:
             items = query.all()
             return items, len(items)
-        
+
         page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
-        
+
         return page.items, page.total
 
     @classmethod
@@ -79,14 +79,14 @@ class Comment(db.Model):
                 ))\
 
         query = query.order_by(Comment.id.desc())
-        
+
         no_pagination_options = not pagination_options.page or not pagination_options.size
         if no_pagination_options:
             items = query.all()
             return items, len(items)
-        
+
         page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
-                
+
         return page.items, page.total
 
     @staticmethod

--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -51,7 +51,16 @@ class Comment(db.Model):
         sort = asc(text(pagination_options.sort_key)) if pagination_options.sort_order == 'asc'\
             else desc(text(pagination_options.sort_key))
 
-        return query.order_by(sort).paginate(page=pagination_options.page, per_page=pagination_options.size)
+        query = query.order_by(sort)
+        
+        no_pagination_options = not pagination_options.page or not pagination_options.size
+        if no_pagination_options:
+            items = query.all()
+            return items, len(items)
+        
+        page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
+        
+        return page.items, page.total
 
     @classmethod
     def get_accepted_comments_by_survey_id_where_engagement_closed_paginated(
@@ -69,8 +78,16 @@ class Comment(db.Model):
                     CommentStatus.id == Status.Approved.value
                 ))\
 
-        return query.order_by(Comment.id.desc()).paginate(
-            page=pagination_options.page, per_page=pagination_options.size)
+        query = query.order_by(Comment.id.desc())
+        
+        no_pagination_options = not pagination_options.page or not pagination_options.size
+        if no_pagination_options:
+            items = query.all()
+            return items, len(items)
+        
+        page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
+                
+        return page.items, page.total
 
     @staticmethod
     def __create_new_comment_entity(comment):

--- a/met-api/src/met_api/models/engagement.py
+++ b/met-api/src/met_api/models/engagement.py
@@ -68,7 +68,15 @@ class Engagement(db.Model):
         sort = asc(text(pagination_options.sort_key)) if pagination_options.sort_order == 'asc'\
             else desc(text(pagination_options.sort_key))
 
-        return query.order_by(sort).paginate(page=pagination_options.page, per_page=pagination_options.size)
+        query = query.order_by(sort)
+        
+        no_pagination_options = not pagination_options.page or not pagination_options.size
+        if no_pagination_options:
+            items = query.all()
+            return items, len(items)
+
+        page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
+        return page.items, page.total
 
     @classmethod
     def get_engagements_by_status(cls, status_id):

--- a/met-api/src/met_api/models/engagement.py
+++ b/met-api/src/met_api/models/engagement.py
@@ -69,7 +69,7 @@ class Engagement(db.Model):
             else desc(text(pagination_options.sort_key))
 
         query = query.order_by(sort)
-        
+
         no_pagination_options = not pagination_options.page or not pagination_options.size
         if no_pagination_options:
             items = query.all()

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -59,7 +59,7 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         query = db.session.query(Survey).join(Engagement, isouter=True).join(EngagementStatus, isouter=True)
 
         if unlinked:
-            query = query.filter(Survey.engagement_id == None)
+            query = query.filter(Survey.engagement_id is None)
 
         if search_text:
             query = query.filter(Survey.name.ilike('%' + search_text + '%'))
@@ -68,14 +68,14 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
             else desc(text(pagination_options.sort_key))
 
         query = query.order_by(sort)
-        
+
         no_pagination_options = not pagination_options.page or not pagination_options.size
         if no_pagination_options:
             items = query.all()
             return items, len(items)
-        
+
         page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
-        
+
         return page.items, page.total
 
     @classmethod

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -59,7 +59,7 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         query = db.session.query(Survey).join(Engagement, isouter=True).join(EngagementStatus, isouter=True)
 
         if unlinked:
-            query = query.filter(Survey.engagement_id is None)
+            query = query.filter(Survey.engagement_id == None)
 
         if search_text:
             query = query.filter(Survey.name.ilike('%' + search_text + '%'))
@@ -67,7 +67,16 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         sort = asc(text(pagination_options.sort_key)) if pagination_options.sort_order == 'asc'\
             else desc(text(pagination_options.sort_key))
 
-        return query.order_by(sort).paginate(page=pagination_options.page, per_page=pagination_options.size)
+        query = query.order_by(sort)
+        
+        no_pagination_options = not pagination_options.page or not pagination_options.size
+        if no_pagination_options:
+            items = query.all()
+            return items, len(items)
+        
+        page = query.paginate(page=pagination_options.page, per_page=pagination_options.size)
+        
+        return page.items, page.total
 
     @classmethod
     def create_survey(cls, survey: SurveySchema) -> DefaultMethodResult:

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -59,7 +59,7 @@ class Survey(db.Model):  # pylint: disable=too-few-public-methods
         query = db.session.query(Survey).join(Engagement, isouter=True).join(EngagementStatus, isouter=True)
 
         if unlinked:
-            query = query.filter(Survey.engagement_id is None)
+            query = query.filter(Survey.engagement_id.is_(None))
 
         if search_text:
             query = query.filter(Survey.name.ilike('%' + search_text + '%'))

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -84,8 +84,8 @@ class Comments(Resource):
             args = request.args
 
             pagination_options = PaginationOptions(
-                page=args.get('page', 1, int),
-                size=args.get('size', 10, int),
+                page=args.get('page', None, int),
+                size=args.get('size', None, int),
                 sort_key=args.get('sort_key', 'name', int),
                 sort_order=args.get('sort_order', 'asc', str),
             )

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -70,8 +70,8 @@ class Engagements(Resource):
             user_id = TokenInfo.get_id()
 
             pagination_options = PaginationOptions(
-                page=args.get('page', 1, int),
-                size=args.get('size', 10, int),
+                page=args.get('page', None, int),
+                size=args.get('size', None, int),
                 sort_key=args.get('sort_key', 'name', int),
                 sort_order=args.get('sort_order', 'asc', str),
             )

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -94,9 +94,9 @@ class Surveys(Resource):
             args = request.args
 
             pagination_options = PaginationOptions(
-                page=args.get('page', 1, int),
-                size=args.get('size', 10, int),
-                sort_key=args.get('sort_key', 'survey.name', int),
+                page=args.get('page', None, int),
+                size=args.get('size', None, int),
+                sort_key=args.get('sort_key', 'survey.name', str),
                 sort_order=args.get('sort_order', 'asc', str),
             )
 

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -27,18 +27,18 @@ class CommentService:
         """Get comments paginated."""
         if not user_id:
             comment_schema = CommentSchema(many=True, only=('text', 'submission_date', 'survey'))
-            comments_page = Comment.get_accepted_comments_by_survey_id_where_engagement_closed_paginated(
+            items, total = Comment.get_accepted_comments_by_survey_id_where_engagement_closed_paginated(
                 survey_id, pagination_options)
         else:
             comment_schema = CommentSchema(many=True)
-            comments_page = Comment.get_comments_by_survey_id_paginated(
+            items, total = Comment.get_comments_by_survey_id_paginated(
                 survey_id,
                 pagination_options,
                 search_text,
             )
         return {
-            'items': comment_schema.dump(comments_page.items),
-            'total': comments_page.total
+            'items': comment_schema.dump(items),
+            'total': total
         }
 
     @classmethod

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -48,17 +48,17 @@ class EngagementService:
     @staticmethod
     def get_engagements_paginated(user_id, pagination_options: PaginationOptions, search_text=''):
         """Get engagements paginated."""
-        engagements_page = EngagementModel.get_engagements_paginated(
+        items, total = EngagementModel.get_engagements_paginated(
             pagination_options,
             search_text,
             statuses=None if user_id else [Status.Published.value],
         )
         engagements_schema = EngagementSchema(many=True)
-        engagements = engagements_schema.dump(engagements_page.items)
+        engagements = engagements_schema.dump(items)
 
         return {
             'items': engagements,
-            'total': engagements_page.total
+            'total': total
         }
 
     @staticmethod

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -39,7 +39,7 @@ class SurveyService:
     @staticmethod
     def get_surveys_paginated(pagination_options: PaginationOptions, search_text='', unlinked=False):
         """Get engagements paginated."""
-        surveys_page = SurveyModel.get_surveys_paginated(
+        items, total = SurveyModel.get_surveys_paginated(
             pagination_options,
             search_text,
             unlinked,
@@ -47,8 +47,8 @@ class SurveyService:
         surveys_schema = SurveySchema(many=True)
 
         return {
-            'items': surveys_schema.dump(surveys_page.items),
-            'total': surveys_page.total
+            'items': surveys_schema.dump(items),
+            'total': total
         }
 
     @classmethod

--- a/met-web/src/services/surveyService/form/index.ts
+++ b/met-web/src/services/surveyService/form/index.ts
@@ -8,8 +8,8 @@ interface FetchSurveyParams {
     unlinked?: boolean;
 }
 export const fetchSurveys = async (params: FetchSurveyParams = {}): Promise<Survey[]> => {
-    const responseData = await http.GetRequest<Survey[]>(Endpoints.Survey.GET_LIST, params);
-    return responseData.data.result ?? [];
+    const responseData = await http.GetRequest<Page<Survey>>(Endpoints.Survey.GET_LIST, { ...params });
+    return responseData.data.result?.items ?? [];
 };
 
 interface GetSurveysParams {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/615

*Description of changes:*

- If page and size are not passed to pagination resources all records will be returned
- Fix Select component triggering error when adding existing survey to engagement


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
