### PR TITLE
Fix CodeCov duplicated branch naming

### DIFF
--- a/.github/workflows/met-api-ci.yml
+++ b/.github/workflows/met-api-ci.yml
@@ -103,8 +103,8 @@ jobs:
       # Set codecov branch name with prefix if pull request
       - name: Sets Codecov branch name
         run: |
-          echo "CODECOV_BRANCH=PR_$github.head_ref" >> $GITHUB_ENV
-        if: startsWith(github.event_name, 'pull_request')
+          echo "CODECOV_BRANCH=PR_${{github.head_ref}}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
         
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/met-api-ci.yml
+++ b/.github/workflows/met-api-ci.yml
@@ -19,7 +19,7 @@ jobs:
   setup-job:
     runs-on: ubuntu-20.04
 
-    if: github.repository == 'bcgov/met-public'
+    #if: github.repository == 'bcgov/met-public'
 
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
       KEYCLOAK_TEST_BASE_URL: "http://localhost:8081"
       KEYCLOAK_TEST_REALMNAME: "demo"
       USE_TEST_KEYCLOAK_DOCKER: "YES"
-
+      
     runs-on: ubuntu-20.04
 
     services:
@@ -99,6 +99,13 @@ jobs:
         id: test
         run: |
           make test
+
+      # Set codecov branch name with prefix if pull request
+      - name: Sets Codecov branch name
+        run: |
+          echo "CODECOV_BRANCH=PR_$github.head_ref" >> $GITHUB_ENV
+        if: startsWith(github.event_name, 'pull_request')
+        
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -107,6 +114,7 @@ jobs:
           name: codecov-met-api
           fail_ci_if_error: true   
           verbose: true 
+          override_branch: ${{env.CODECOV_BRANCH}}
 
   build-check:
     needs: setup-job

--- a/.github/workflows/met-api-ci.yml
+++ b/.github/workflows/met-api-ci.yml
@@ -19,7 +19,7 @@ jobs:
   setup-job:
     runs-on: ubuntu-20.04
 
-    #if: github.repository == 'bcgov/met-public'
+    if: github.repository == 'bcgov/met-public'
 
     steps:
       - uses: actions/checkout@v2
@@ -109,7 +109,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./met-api/coverage.xml
           flags: metapi
           name: codecov-met-api
           fail_ci_if_error: true   

--- a/.github/workflows/met-web-ci.yml
+++ b/.github/workflows/met-web-ci.yml
@@ -53,17 +53,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Install dependencies
         run: |
           npm install --legacy-peer-deps
+
       - name: Test with jest
         id: test
         run: |
           npm test -- --coverage
+
+      # Set codecov branch name with prefix if pull request
+      - name: Sets Codecov branch name
+        run: |
+          echo "CODECOV_BRANCH=PR_${{github.head_ref}}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -71,6 +81,7 @@ jobs:
           name: codecov-met-web
           fail_ci_if_error: true    
           verbose: true
+          override_branch: ${{env.CODECOV_BRANCH}}
 
   build-check:
     needs: setup-job


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/625

*Description of changes:*
When creating a PR from a fork repo, if the branch name is the same as the protected branch ('main') the coverage gets directly updated in Codecov. As a workaround this change will override the branch name with a prefix (PR_) if the CI is originating from a PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
