### PR TITLE
Add unit tests for survey listing

### DIFF
--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -192,12 +192,13 @@ const SurveyListing = () => {
                             variant="outlined"
                             label="Search by name"
                             fullWidth
+                            name="searchText"
                             value={searchText}
                             onChange={(e) => setSearchText(e.target.value)}
                             size="small"
                         />
                         <PrimaryButton
-                            data-testid="SurveyListing/search-button"
+                            data-testid="survey/listing/search-button"
                             onClick={() => handleSearchBarClick(searchText)}
                         >
                             <SearchIcon />

--- a/met-web/src/components/survey/submit/SurveySubmitWrapped.tsx
+++ b/met-web/src/components/survey/submit/SurveySubmitWrapped.tsx
@@ -30,17 +30,17 @@ const SurveySubmitWrapped = () => {
                 </Grid>
                 <Grid item xs={12}>
                     <MetPaper elevation={2}>
-                        <ConditionalComponent condition={isTokenValid && savedSurvey.engagement}>
+                        <ConditionalComponent condition={isTokenValid && Boolean(savedSurvey.engagement)}>
                             <SurveyForm
                                 handleClose={() => {
-                                    navigate(`/engagements/${savedSurvey.engagement.id}/view`);
+                                    navigate(`/engagements/${savedSurvey.engagement?.id}/view`);
                                 }}
                             />
                         </ConditionalComponent>
                         <InvalidTokenModal
-                            open={!isTokenValid && savedSurvey.engagement}
+                            open={!isTokenValid && Boolean(savedSurvey.engagement)}
                             handleClose={() => {
-                                navigate(`/engagements/${savedSurvey.engagement.id}/view`);
+                                navigate(`/engagements/${savedSurvey.engagement?.id}/view`);
                             }}
                         />
                     </MetPaper>

--- a/met-web/tests/unit/components/surveyListing.test.tsx
+++ b/met-web/tests/unit/components/surveyListing.test.tsx
@@ -33,7 +33,7 @@ const mockSurveyOne = {
     ...createDefaultSurvey(),
     id: 1,
     name: 'Survey One',
-    engagement_id: '1',
+    engagement_id: 1,
     engagement: mockEngagementOne,
     created_date: '2022-09-14 00:00:00',
 };
@@ -57,7 +57,7 @@ const mockSurveyTwo = {
     ...createDefaultSurvey(),
     id: 2,
     name: 'Survey Two',
-    engagement_id: '2',
+    engagement_id: 2,
     engagement: mockEngagementTwo,
     created_date: '2022-09-15 00:00:00',
     comments_meta_data: {

--- a/met-web/tests/unit/components/surveyListing.test.tsx
+++ b/met-web/tests/unit/components/surveyListing.test.tsx
@@ -1,20 +1,145 @@
-import { render, waitFor, screen } from '@testing-library/react';
-import React from 'react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import React, { ReactNode } from 'react';
 import '@testing-library/jest-dom';
 import SurveyListing from '../../../src/components/survey/listing';
-import ProviderShell from './ProviderShell';
 import { setupEnv } from './setEnvVars';
+import * as reactRedux from 'react-redux';
+import * as surveyService from 'services/surveyService/form';
+import * as notificationSlice from 'services/notificationService/notificationSlice';
+import { createDefaultSurvey } from 'models/survey';
+import { createDefaultEngagement } from 'models/engagement';
+import { EngagementStatus } from 'constants/engagementStatus';
+import assert from 'assert';
 
-test('render SurveyListing', async () => {
-    setupEnv();
-    render(
-        <ProviderShell>
-            <SurveyListing />
-        </ProviderShell>,
-    );
+const mockEngagementOne = {
+    ...createDefaultEngagement(),
+    id: 1,
+    name: 'Engagement One',
+    created_date: '2022-09-14 00:00:00',
+    rich_content:
+        '{"blocks":[{"key":"29p4m","text":"Test content","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
+    content: 'Test content',
+    rich_description:
+        '{"blocks":[{"key":"bqupg","text":"Test description","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
+    description: 'Test description',
+    start_date: '2022-09-01',
+    end_date: '2022-09-30',
+    engagement_status: {
+        id: EngagementStatus.Draft,
+        status_name: 'Draft',
+    },
+};
+const mockSurveyOne = {
+    ...createDefaultSurvey(),
+    id: 1,
+    name: 'Survey One',
+    engagement_id: '1',
+    engagement: mockEngagementOne,
+    created_date: '2022-09-14 00:00:00',
+};
 
-    await waitFor(() => screen.getByTestId('SurveyListing/search-button'));
-    expect(screen.getByTestId('SurveyListing/search-button'));
+const mockEngagementTwo = {
+    ...mockEngagementOne,
+    id: 2,
+    name: 'Engagement Two',
+    engagement_status: {
+        id: EngagementStatus.Published,
+        status_name: 'Published',
+    },
+    created_date: '2022-09-15 00:00:00',
+    published_date: '2022-09-19 00:00:00',
+    submissions_meta_data: {
+        total: 1,
+    },
+};
 
-    expect(screen.getByTestId('SurveyListing/search-button')).not.toBeDisabled();
+const mockSurveyTwo = {
+    ...createDefaultSurvey(),
+    id: 2,
+    name: 'Survey Two',
+    engagement_id: '2',
+    engagement: mockEngagementTwo,
+    created_date: '2022-09-15 00:00:00',
+    comments_meta_data: {
+        pending: 1,
+        total: 12,
+    },
+};
+
+jest.mock('@mui/material', () => ({
+    ...jest.requireActual('@mui/material'),
+    Link: ({ children }: { children: ReactNode }) => {
+        return <a>{children}</a>;
+    },
+}));
+
+jest.mock('components/common', () => ({
+    ...jest.requireActual('components/common'),
+    PrimaryButton: ({ children, ...rest }: { children: ReactNode; [prop: string]: unknown }) => {
+        return <button {...rest}>{children}</button>;
+    },
+}));
+
+describe('Survey form page tests', () => {
+    jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
+    jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());
+    const getSurveysPageMock = jest.spyOn(surveyService, 'getSurveysPage');
+
+    beforeEach(() => {
+        setupEnv();
+    });
+
+    test('Survey table is rendered and surveys are fetched', async () => {
+        getSurveysPageMock.mockReturnValue(
+            Promise.resolve({
+                items: [mockSurveyOne, mockSurveyTwo],
+                total: 2,
+            }),
+        );
+        render(<SurveyListing />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Survey One')).toBeInTheDocument();
+            expect(screen.getByText('2022-09-14')).toBeInTheDocument();
+            expect(screen.getByText('Draft')).toBeInTheDocument();
+
+            expect(screen.getByText('Survey Two')).toBeInTheDocument();
+            expect(screen.getByText('2022-09-15')).toBeInTheDocument();
+            expect(screen.getByText('Published')).toBeInTheDocument();
+            expect(screen.getByText('2022-09-19')).toBeInTheDocument();
+            expect(screen.getByText('View Report')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Create Survey', { exact: false })).toBeInTheDocument();
+    });
+
+    test('Search filter works and fetchs surveys with the search text as a param', async () => {
+        getSurveysPageMock.mockReturnValue(
+            Promise.resolve({
+                items: [mockSurveyOne],
+                total: 1,
+            }),
+        );
+        const { container } = render(<SurveyListing />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Survey One')).toBeInTheDocument();
+        });
+
+        const searchField = container.querySelector('input[name="searchText"]');
+        assert(searchField, 'Unable to find search field that matches the given query');
+
+        fireEvent.change(searchField, { target: { value: 'Survey One' } });
+        fireEvent.click(screen.getByTestId('survey/listing/search-button'));
+
+        await waitFor(() => {
+            expect(getSurveysPageMock).lastCalledWith({
+                page: 1,
+                size: 10,
+                sort_key: 'survey.name',
+                sort_order: 'asc',
+                search_text: 'Survey One',
+            });
+        });
+    });
 });


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/646

*Description of changes:*

- Add unit test to check table rendering and rows fetching
- Add unit test to check search filter working and calling proper service method


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
