### PR TITLE
Change default sorting in engagement and survey to by date

### DIFF
--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -32938,8 +32938,7 @@
         "react-if": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/react-if/-/react-if-4.1.4.tgz",
-            "integrity": "sha512-bjufPfCdPBiBy9EO/BeoxaqGc/xCwTu0coKtHfjpJw+v85DLMbpG43IUPISh+m3DzENx1rOYLpqbp2KaDmEYlg==",
-            "requires": {}
+            "integrity": "sha512-bjufPfCdPBiBy9EO/BeoxaqGc/xCwTu0coKtHfjpJw+v85DLMbpG43IUPISh+m3DzENx1rOYLpqbp2KaDmEYlg=="
         },
         "react-is": {
             "version": "18.2.0",

--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -24,9 +24,9 @@ const EngagementListing = () => {
     const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Engagement>>({
         page: 1,
         size: 10,
-        sort_key: 'name',
-        nested_sort_key: null,
-        sort_order: 'asc',
+        sort_key: 'created_date',
+        nested_sort_key: 'engagement.created_date',
+        sort_order: 'desc',
     });
 
     const [pageInfo, setPageInfo] = useState<PageInfo>(createDefaultPageInfo());

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -25,9 +25,9 @@ const SurveyListing = () => {
     const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<Survey>>({
         page: 1,
         size: 10,
-        sort_key: 'name',
-        nested_sort_key: 'survey.name',
-        sort_order: 'asc',
+        sort_key: 'created_date',
+        nested_sort_key: 'survey.created_date',
+        sort_order: 'desc',
     });
     const [pageInfo, setPageInfo] = useState<PageInfo>(createDefaultPageInfo());
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/664

*Description of changes:*

- Change default sorting for engagements listing to by created date descending
- Change default sorting for surveys listing to by created date descending

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
