### PR TITLE
Fix comment type NONE

### DIFF
--- a/met-api/migrations/versions/224b70277ac4_alter_commenttype.py
+++ b/met-api/migrations/versions/224b70277ac4_alter_commenttype.py
@@ -1,0 +1,25 @@
+"""alter commenttype
+
+Revision ID: 224b70277ac4
+Revises: 5110026db916
+Create Date: 2022-10-05 11:00:13.349968
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '224b70277ac4'
+down_revision = '5110026db916'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('ALTER TYPE public.commenttype ADD VALUE IF NOT EXISTS \'NONE\' AFTER \'Else\';')
+
+
+def downgrade():
+    # alter type will not be reverted since it does not impact the structure.
+    pass

--- a/met-api/src/met_api/constants/feedback.py
+++ b/met-api/src/met_api/constants/feedback.py
@@ -28,6 +28,7 @@ class RatingType(IntEnum):
 class CommentType(IntEnum):
     """Comment types enum."""
 
+    NONE = 0
     Issue = 1
     Idea = 2
     Else = 3


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/337

*Description of changes:*
Fixes submit feedback when comment type is not selected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
