### PR TITLE
Remove extra character from copy url

### DIFF
--- a/met-web/src/components/engagement/form/EngagementSettings.tsx
+++ b/met-web/src/components/engagement/form/EngagementSettings.tsx
@@ -14,7 +14,7 @@ const EngagementSettings = () => {
     const newEngagement = !savedEngagement.id || isNaN(Number(savedEngagement.id));
     const engagementUrl = newEngagement
         ? 'Link will appear when the engagement is saved'
-        : `${window.location.origin}/engagements/${savedEngagement.id}/view}`;
+        : `${window.location.origin}/engagements/${savedEngagement.id}/view`;
 
     const [copyTooltip, setCopyTooltip] = useState(false);
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/707

*Description of changes:*

- Remove extra character  '}' from copy url


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
