### PR TITLE
change published with the status of the engagement

### DIFF
--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -13,6 +13,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import Stack from '@mui/material/Stack';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import MetTable from 'components/common/Table';
+import { SubmissionStatus } from 'constants/engagementStatus';
 
 const EngagementListing = () => {
     const [searchFilter, setSearchFilter] = useState({
@@ -102,7 +103,16 @@ const EngagementListing = () => {
             disablePadding: false,
             label: 'Status',
             allowSort: true,
-            getValue: (row: Engagement) => row.engagement_status.status_name,
+            getValue: (row: Engagement) => {
+                if (row.engagement_status.status_name === 'Published') {
+                    return (
+                        row.engagement_status.status_name +
+                        '/' +
+                        Object.keys(SubmissionStatus)[Object.values(SubmissionStatus).indexOf(row.submission_status)]
+                    );
+                }
+                return row.engagement_status.status_name;
+            },
         },
         {
             key: 'published_date',

--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -105,11 +105,7 @@ const EngagementListing = () => {
             allowSort: true,
             getValue: (row: Engagement) => {
                 if (row.engagement_status.status_name === 'Published') {
-                    return (
-                        row.engagement_status.status_name +
-                        '/' +
-                        Object.keys(SubmissionStatus)[Object.values(SubmissionStatus).indexOf(row.submission_status)]
-                    );
+                    return row.engagement_status.status_name + '/' + SubmissionStatus[row.submission_status];
                 }
                 return row.engagement_status.status_name;
             },

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -14,6 +14,7 @@ import { getSurveysPage } from 'services/surveyService/form';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { EngagementStatus } from 'constants/engagementStatus';
+import { SubmissionStatus } from 'constants/engagementStatus';
 
 const SurveyListing = () => {
     const [searchFilter, setSearchFilter] = useState({
@@ -147,8 +148,18 @@ const SurveyListing = () => {
             disablePadding: false,
             label: 'Status',
             allowSort: true,
-            getValue: (row: Survey) =>
-                row.engagement?.engagement_status.status_name || EngagementStatus[EngagementStatus.Draft].toString(),
+            getValue: (row: Survey) => {
+                if (row.engagement?.engagement_status.status_name === 'Published') {
+                    return (
+                        row.engagement.engagement_status.status_name +
+                        '/' +
+                        SubmissionStatus[row.engagement.submission_status]
+                    );
+                }
+                return (
+                    row.engagement?.engagement_status.status_name || EngagementStatus[EngagementStatus.Draft].toString()
+                );
+            },
         },
         {
             key: 'id',

--- a/met-web/src/components/survey/submit/EngagementLink.tsx
+++ b/met-web/src/components/survey/submit/EngagementLink.tsx
@@ -14,7 +14,7 @@ export const EngagementLink = () => {
         return null;
     }
     return (
-        <MuiLink component={Link} to={`/engagement/view/${savedEngagement.id}`}>
+        <MuiLink component={Link} to={`/engagements/${savedEngagement.id}/view`}>
             {`<< Return to ${savedEngagement.name} Engagement`}
         </MuiLink>
     );

--- a/met-web/tests/unit/components/EngagementListing.test.tsx
+++ b/met-web/tests/unit/components/EngagementListing.test.tsx
@@ -45,7 +45,7 @@ const mockEngagementTwo = {
     name: 'Engagement Two',
     engagement_status: {
         id: EngagementStatus.Published,
-        status_name: 'Published',
+        status_name: 'Published/Open',
     },
     created_date: '2022-09-15 00:00:00',
     published_date: '2022-09-19 00:00:00',
@@ -94,7 +94,7 @@ describe('Engagement form page tests', () => {
 
             expect(screen.getByText('Engagement Two')).toBeInTheDocument();
             expect(screen.getByText('2022-09-15')).toBeInTheDocument();
-            expect(screen.getByText('Published')).toBeInTheDocument();
+            expect(screen.getByText('Published/Open')).toBeInTheDocument();
             expect(screen.getByText('2022-09-19')).toBeInTheDocument();
             expect(screen.getByText('View Survey')).toBeInTheDocument();
             expect(screen.getByText('View Report')).toBeInTheDocument();

--- a/met-web/tests/unit/components/surveyListing.test.tsx
+++ b/met-web/tests/unit/components/surveyListing.test.tsx
@@ -44,7 +44,7 @@ const mockEngagementTwo = {
     name: 'Engagement Two',
     engagement_status: {
         id: EngagementStatus.Published,
-        status_name: 'Published',
+        status_name: 'Published/Open',
     },
     created_date: '2022-09-15 00:00:00',
     published_date: '2022-09-19 00:00:00',
@@ -105,7 +105,7 @@ describe('Survey form page tests', () => {
 
             expect(screen.getByText('Survey Two')).toBeInTheDocument();
             expect(screen.getByText('2022-09-15')).toBeInTheDocument();
-            expect(screen.getByText('Published')).toBeInTheDocument();
+            expect(screen.getByText('Published/Open')).toBeInTheDocument();
             expect(screen.getByText('2022-09-19')).toBeInTheDocument();
             expect(screen.getByText('View Report')).toBeInTheDocument();
         });


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/413

*Description of changes:*
Changes made on the engagement page to replace the status of Published with the status of the engagement:
Published/Upcoming
Published/Open
Published/Closed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
