### PR TITLE
Fix unsafe-eval with Evaluator.noeval = true

### DIFF
--- a/met-web/package.json
+++ b/met-web/package.json
@@ -48,7 +48,7 @@
     },
     "scripts": {
         "start": "react-app-rewired start",
-        "build": "set \"INLINE_RUNTIME_CHUNK=false\" && react-app-rewired build",
+        "build": "react-app-rewired build",
         "test": "jest",
         "eject": "react-scripts eject",
         "lint": "eslint '*/**/*.{ts,tsx}'",

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -15,8 +15,10 @@ import { FormBuilderData } from 'components/Form/types';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
+import Formio from 'formiojs';
 
 const SurveyFormBuilder = () => {
+    Formio.Utils.Evaluator.noeval = true;
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
     const { surveyId } = useParams<SurveyParams>();


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/731

*Description of changes:*
Enable noeval in formio to avoid unsafe-eval CSP issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
