### PR TITLE
fixing a bug for closed engagement

### DIFF
--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -13,7 +13,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import Stack from '@mui/material/Stack';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import MetTable from 'components/common/Table';
-import { SubmissionStatus } from 'constants/engagementStatus';
+import { EngagementStatus, SubmissionStatus } from 'constants/engagementStatus';
 
 const EngagementListing = () => {
     const [searchFilter, setSearchFilter] = useState({
@@ -104,8 +104,15 @@ const EngagementListing = () => {
             label: 'Status',
             allowSort: true,
             getValue: (row: Engagement) => {
-                if (row.engagement_status.status_name === 'Published') {
-                    return row.engagement_status.status_name + '/' + SubmissionStatus[row.submission_status];
+                if (
+                    row.engagement_status.status_name === EngagementStatus[EngagementStatus.Published].toString() ||
+                    row.engagement_status.status_name === EngagementStatus[EngagementStatus.Closed].toString()
+                ) {
+                    return (
+                        EngagementStatus[EngagementStatus.Published].toString() +
+                        '/' +
+                        SubmissionStatus[row.submission_status]
+                    );
                 }
                 return row.engagement_status.status_name;
             },

--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -104,15 +104,12 @@ const EngagementListing = () => {
             label: 'Status',
             allowSort: true,
             getValue: (row: Engagement) => {
-                if (
-                    row.engagement_status.status_name === EngagementStatus[EngagementStatus.Published].toString() ||
-                    row.engagement_status.status_name === EngagementStatus[EngagementStatus.Closed].toString()
-                ) {
-                    return (
-                        EngagementStatus[EngagementStatus.Published].toString() +
-                        '/' +
-                        SubmissionStatus[row.submission_status]
-                    );
+                const acceptable_status = [
+                    EngagementStatus[EngagementStatus.Published],
+                    EngagementStatus[EngagementStatus.Closed],
+                ];
+                if (acceptable_status.includes(row.engagement_status.status_name)) {
+                    return `${EngagementStatus[EngagementStatus.Published]}/${SubmissionStatus[row.submission_status]}`;
                 }
                 return row.engagement_status.status_name;
             },

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -13,8 +13,7 @@ import Stack from '@mui/material/Stack';
 import { getSurveysPage } from 'services/surveyService/form';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { EngagementStatus } from 'constants/engagementStatus';
-import { SubmissionStatus } from 'constants/engagementStatus';
+import { EngagementStatus, SubmissionStatus } from 'constants/engagementStatus';
 
 const SurveyListing = () => {
     const [searchFilter, setSearchFilter] = useState({
@@ -149,9 +148,14 @@ const SurveyListing = () => {
             label: 'Status',
             allowSort: true,
             getValue: (row: Survey) => {
-                if (row.engagement?.engagement_status.status_name === 'Published') {
+                if (
+                    row.engagement?.engagement_status.status_name ===
+                        EngagementStatus[EngagementStatus.Published].toString() ||
+                    row.engagement?.engagement_status.status_name ===
+                        EngagementStatus[EngagementStatus.Closed].toString()
+                ) {
                     return (
-                        row.engagement.engagement_status.status_name +
+                        EngagementStatus[EngagementStatus.Published].toString() +
                         '/' +
                         SubmissionStatus[row.engagement.submission_status]
                     );

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -148,12 +148,11 @@ const SurveyListing = () => {
             label: 'Status',
             allowSort: true,
             getValue: (row: Survey) => {
-                if (
-                    row.engagement?.engagement_status.status_name ===
-                        EngagementStatus[EngagementStatus.Published].toString() ||
-                    row.engagement?.engagement_status.status_name ===
-                        EngagementStatus[EngagementStatus.Closed].toString()
-                ) {
+                const acceptable_status = [
+                    EngagementStatus[EngagementStatus.Published],
+                    EngagementStatus[EngagementStatus.Closed],
+                ];
+                if (row.engagement && acceptable_status.includes(row.engagement.engagement_status.status_name)) {
                     return (
                         EngagementStatus[EngagementStatus.Published].toString() +
                         '/' +

--- a/met-web/src/constants/engagementStatus.ts
+++ b/met-web/src/constants/engagementStatus.ts
@@ -1,6 +1,7 @@
 export enum EngagementStatus {
     Draft = 1,
     Published = 2,
+    Closed = 3,
 }
 
 export enum SubmissionStatus {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/413

*Description of changes:*
Changes made to handle closed engagements. Status for closed engagements/surveys should show as Published/Closed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
