### PR TITLE
Change the order of Status column and values for open and closed engagement

### DIFF
--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -98,23 +98,6 @@ const EngagementListing = () => {
             getValue: (row: Engagement) => formatDate(row.created_date),
         },
         {
-            key: 'status_id',
-            numeric: true,
-            disablePadding: false,
-            label: 'Status',
-            allowSort: true,
-            getValue: (row: Engagement) => {
-                const acceptable_status = [
-                    EngagementStatus[EngagementStatus.Published],
-                    EngagementStatus[EngagementStatus.Closed],
-                ];
-                if (acceptable_status.includes(row.engagement_status.status_name)) {
-                    return `${EngagementStatus[EngagementStatus.Published]}/${SubmissionStatus[row.submission_status]}`;
-                }
-                return row.engagement_status.status_name;
-            },
-        },
-        {
             key: 'published_date',
             numeric: true,
             disablePadding: false,
@@ -125,6 +108,31 @@ const EngagementListing = () => {
                     return '';
                 }
                 return formatDate(row.published_date);
+            },
+        },
+        {
+            key: 'status_id',
+            numeric: true,
+            disablePadding: false,
+            label: 'Status',
+            allowSort: true,
+            getValue: (row: Engagement) => {
+                const acceptable_status = [
+                    SubmissionStatus[SubmissionStatus.Open],
+                    SubmissionStatus[SubmissionStatus.Closed],
+                ];
+                if (row.engagement_status.status_name === EngagementStatus[EngagementStatus.Published]) {
+                    if (acceptable_status.includes(SubmissionStatus[row.submission_status])) {
+                        return SubmissionStatus[row.submission_status];
+                    } else {
+                        return (
+                            EngagementStatus[EngagementStatus.Published] +
+                            ' - ' +
+                            SubmissionStatus[row.submission_status]
+                        );
+                    }
+                }
+                return row.engagement_status.status_name;
             },
         },
         {

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -103,6 +103,37 @@ const SurveyListing = () => {
         },
         {
             key: 'engagement',
+            nestedSortKey: 'engagement.status_id',
+            numeric: true,
+            disablePadding: false,
+            label: 'Status',
+            allowSort: true,
+            getValue: (row: Survey) => {
+                const acceptable_status = [
+                    SubmissionStatus[SubmissionStatus.Open],
+                    SubmissionStatus[SubmissionStatus.Closed],
+                ];
+                if (
+                    row.engagement &&
+                    row.engagement.engagement_status.status_name === EngagementStatus[EngagementStatus.Published]
+                ) {
+                    if (acceptable_status.includes(SubmissionStatus[row.engagement.submission_status])) {
+                        return SubmissionStatus[row.engagement.submission_status];
+                    } else {
+                        return (
+                            EngagementStatus[EngagementStatus.Published].toString() +
+                            ' - ' +
+                            SubmissionStatus[row.engagement.submission_status]
+                        );
+                    }
+                }
+                return (
+                    row.engagement?.engagement_status.status_name || EngagementStatus[EngagementStatus.Draft].toString()
+                );
+            },
+        },
+        {
+            key: 'engagement',
             nestedSortKey: 'engagement.name',
             numeric: true,
             disablePadding: false,
@@ -137,30 +168,6 @@ const SurveyListing = () => {
                         {`${total}`}
                         {pending ? ` (${pending} New)` : ''}
                     </MuiLink>
-                );
-            },
-        },
-        {
-            key: 'engagement',
-            nestedSortKey: 'engagement.status_id',
-            numeric: true,
-            disablePadding: false,
-            label: 'Status',
-            allowSort: true,
-            getValue: (row: Survey) => {
-                const acceptable_status = [
-                    EngagementStatus[EngagementStatus.Published],
-                    EngagementStatus[EngagementStatus.Closed],
-                ];
-                if (row.engagement && acceptable_status.includes(row.engagement.engagement_status.status_name)) {
-                    return (
-                        EngagementStatus[EngagementStatus.Published].toString() +
-                        '/' +
-                        SubmissionStatus[row.engagement.submission_status]
-                    );
-                }
-                return (
-                    row.engagement?.engagement_status.status_name || EngagementStatus[EngagementStatus.Draft].toString()
                 );
             },
         },

--- a/met-web/tests/unit/components/EngagementListing.test.tsx
+++ b/met-web/tests/unit/components/EngagementListing.test.tsx
@@ -45,7 +45,7 @@ const mockEngagementTwo = {
     name: 'Engagement Two',
     engagement_status: {
         id: EngagementStatus.Published,
-        status_name: 'Published/Open',
+        status_name: 'Open',
     },
     created_date: '2022-09-15 00:00:00',
     published_date: '2022-09-19 00:00:00',
@@ -94,7 +94,7 @@ describe('Engagement form page tests', () => {
 
             expect(screen.getByText('Engagement Two')).toBeInTheDocument();
             expect(screen.getByText('2022-09-15')).toBeInTheDocument();
-            expect(screen.getByText('Published/Open')).toBeInTheDocument();
+            expect(screen.getByText('Open')).toBeInTheDocument();
             expect(screen.getByText('2022-09-19')).toBeInTheDocument();
             expect(screen.getByText('View Survey')).toBeInTheDocument();
             expect(screen.getByText('View Report')).toBeInTheDocument();

--- a/met-web/tests/unit/components/surveyListing.test.tsx
+++ b/met-web/tests/unit/components/surveyListing.test.tsx
@@ -44,7 +44,7 @@ const mockEngagementTwo = {
     name: 'Engagement Two',
     engagement_status: {
         id: EngagementStatus.Published,
-        status_name: 'Published/Open',
+        status_name: 'Open',
     },
     created_date: '2022-09-15 00:00:00',
     published_date: '2022-09-19 00:00:00',
@@ -105,7 +105,7 @@ describe('Survey form page tests', () => {
 
             expect(screen.getByText('Survey Two')).toBeInTheDocument();
             expect(screen.getByText('2022-09-15')).toBeInTheDocument();
-            expect(screen.getByText('Published/Open')).toBeInTheDocument();
+            expect(screen.getByText('Open')).toBeInTheDocument();
             expect(screen.getByText('2022-09-19')).toBeInTheDocument();
             expect(screen.getByText('View Report')).toBeInTheDocument();
         });


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/413

*Description of changes:*
Changes made to: 
- Show the Status column after the "Date Published" column on both the Survey and Engagement pages
- The values in Status column is changed to be as below: 
   - Draft
   - Published - Upcoming
   - Open
   - Closed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
