### PR TITLE
Re-write ETL jobs to dagster

### DIFF
--- a/met-etl/src/etl_project/services/jobs/met_data_ingestion.py
+++ b/met-etl/src/etl_project/services/jobs/met_data_ingestion.py
@@ -29,17 +29,20 @@ def met_data_ingestion():
 
 
     # etl for engagement
-    engagement_last_run_cycle_time, engagement_new_runcycleid_created = get_engagement_last_run_cycle_time()
-    updated_engagement, engagement_new_runcycleid_passed_to_load = extract_engagement(engagement_last_run_cycle_time,
-                                                                          engagement_new_runcycleid_created)
-    engagement_new_runcycleid_passed_to_end = load_engagement(updated_engagement,
-                                                      engagement_new_runcycleid_passed_to_load)
+    engagement_last_run_cycle_time, engagement_new_runcycleid_created = get_engagement_last_run_cycle_time(
+                                                                                    flag_to_run_step_after_user)
+    new_engagements, updated_engagement, engagement_new_runcycleid_passed_to_load = extract_engagement(
+                                                                                    engagement_last_run_cycle_time,
+                                                                                    engagement_new_runcycleid_created)
+    engagement_new_runcycleid_passed_to_end = load_engagement(new_engagements, updated_engagement,
+                                                                                    engagement_new_runcycleid_passed_to_load)
 
-    flag_to_run_step_after_engagament = engagement_end_run_cycle(engagement_new_runcycleid_passed_to_end)
+    flag_to_run_step_after_engagement = engagement_end_run_cycle(engagement_new_runcycleid_passed_to_end)
 
 
     # etl run for survey
-    survey_last_run_cycle_time, survey_new_runcycleid_created = get_survey_last_run_cycle_time()
+    survey_last_run_cycle_time, survey_new_runcycleid_created = get_survey_last_run_cycle_time(
+                                                                                    flag_to_run_step_after_engagement)
 
     new_survey, updated_survey, survey_new_runcycleid_passed_to_load = extract_survey(survey_last_run_cycle_time,
                                                                                       survey_new_runcycleid_created)
@@ -64,14 +67,3 @@ def met_data_ingestion():
                                                                          submission_new_runcycleid_passed_to_load_reponse)
 
     flag_to_run_step_after_submission = submission_end_run_cycle(submission_new_runcycleid_passed_to_end)
-
-    # etl run for comments
-    comments_last_run_cycle_time, comments_new_runcycleid_created = get_comments_last_run_cycle_time(
-        flag_to_run_step_after_submission)
-
-    new_comments, comments_new_runcycleid_passed_to_load = extract_comments(comments_last_run_cycle_time,
-                                                                            comments_new_runcycleid_created)
-
-    comments_new_runcycleid_passed_to_end = load_comments(new_comments, comments_new_runcycleid_passed_to_load)
-
-    flag_to_run_step_after_comments = comments_end_run_cycle(comments_new_runcycleid_passed_to_end)

--- a/met-etl/src/etl_project/services/ops/comments_etl_service.py
+++ b/met-etl/src/etl_project/services/ops/comments_etl_service.py
@@ -108,7 +108,7 @@ def comments_end_run_cycle(context, comments_new_run_cycle_id):
     met_etl_db_session.query(EtlRunCycleModel).filter(
         EtlRunCycleModel.id == comments_new_run_cycle_id, EtlRunCycleModel.packagename == 'userfeedback',
         EtlRunCycleModel.success == False).update(
-        {'success': True, 'description': 'ended the load for table user_feedback'})
+        {'success': True, 'enddatetime': datetime.utcnow(), 'description': 'ended the load for table user_feedback'})
 
     context.log.info("run cycle ended for comments table")
 

--- a/met-etl/src/etl_project/services/ops/engagement_etl_service.py
+++ b/met-etl/src/etl_project/services/ops/engagement_etl_service.py
@@ -1,5 +1,5 @@
 from dagster import Out, Output, op
-from met_api.models import EngagementStatus
+from met_api.constants.engagement_status import Status as EngagementStatus
 from met_api.models.engagement import Engagement as MetEngagementModel
 from met_cron.models.engagement import Engagement as EtlEngagementModel
 from sqlalchemy import func
@@ -10,7 +10,7 @@ from met_cron.models.etlruncycle import EtlRunCycle as EtlRunCycleModel
 # get the last run cycle id for user detail etl
 @op(required_resource_keys={"met_db_session", "met_etl_db_session"},
     out={"engagement_last_run_cycle_datetime": Out(), "engagement_new_run_cycle_id": Out()})
-def get_engagement_last_run_cycle_time(context):
+def get_engagement_last_run_cycle_time(context, flag_to_run_step_after_user):
     met_etl_db_session = context.resources.met_etl_db_session
     default_datetime = datetime(1900, 1, 1, 0, 0, 0, 0)
 
@@ -39,17 +39,31 @@ def get_engagement_last_run_cycle_time(context):
 
 # extract the surveys that have been created or updated after the last run
 @op(required_resource_keys={"met_db_session", "met_etl_db_session"},
-    out={"updated_engagements": Out(), "eng_new_runcycleid": Out()})
+    out={"new_engagements": Out(), "updated_engagements": Out(), "eng_new_runcycleid": Out()})
 def extract_engagement(context, eng_last_run_cycle_time, eng_new_runcycleid):
     session = context.resources.met_db_session
+    default_datetime = datetime(1900, 1, 1, 0, 0, 0, 0)
+    new_engagements = []
     updated_engagements = []
 
     for last_run_cycle_time in eng_last_run_cycle_time:
         context.log.info("started extracting new data from engagement table")
-        updated_engagements = session.query(MetEngagementModel).filter(
-            MetEngagementModel.updated_date > last_run_cycle_time,
+        new_engagements = session.query(MetEngagementModel).filter(
+			MetEngagementModel.created_date > last_run_cycle_time,
             MetEngagementModel.status_id != EngagementStatus.Draft.value).all()
+        
+        context.log.info(last_run_cycle_time)	
+        context.log.info(len(new_engagements))
 
+        if last_run_cycle_time > default_datetime:
+            updated_engagements = session.query(MetEngagementModel).filter(
+				MetEngagementModel.updated_date > last_run_cycle_time,
+				MetEngagementModel.status_id != EngagementStatus.Draft.value).all()
+
+        context.log.info(len(updated_engagements))
+
+    yield Output(new_engagements, "new_engagements")
+	
     yield Output(updated_engagements, "updated_engagements")
 
     yield Output(eng_new_runcycleid, "eng_new_runcycleid")
@@ -63,19 +77,22 @@ def extract_engagement(context, eng_last_run_cycle_time, eng_new_runcycleid):
 
 # load the surveys created or updated after last run to the analytics database
 @op(required_resource_keys={"met_db_session", "met_etl_db_session"}, out={"engagement_new_runcycleid": Out()})
-def load_engagement(context, updated_engagements, engagement_new_runcycleid):
+def load_engagement(context, new_engagements, updated_engagements, engagement_new_runcycleid):
     session = context.resources.met_etl_db_session
-    if len(updated_engagements) > 0:
+    all_engagements = new_engagements + updated_engagements
+    if len(all_engagements) > 0:
 
         context.log.info("loading new inputs")
-        for engagement in updated_engagements:
+        for engagement in all_engagements:
+            session.query(EtlEngagementModel).filter(EtlEngagementModel.source_engagement_id == engagement.id).update(
+                {'is_active': False})
             engagement_model = EtlEngagementModel(name=engagement.name,
                                                   source_engagement_id=engagement.id,
                                                   start_date=engagement.start_date,
                                                   end_date=engagement.end_date,
                                                   is_active=True,
                                                   published_date=engagement.published_date,
-                                                  runcycle_id=1,
+                                                  runcycle_id=engagement_new_runcycleid,
                                                   created_date=engagement.created_date,
                                                   updated_date=engagement.updated_date
                                                   )
@@ -91,13 +108,13 @@ def load_engagement(context, updated_engagements, engagement_new_runcycleid):
 
 # update the status for survey etl in run cycle table as successful
 @op(required_resource_keys={"met_db_session", "met_etl_db_session"}, out={"flag_to_run_step_after_engagement": Out()})
-def engagement_end_run_cycle(context, survey_new_runcycleid):
+def engagement_end_run_cycle(context, engagement_new_runcycleid):
     met_etl_db_session = context.resources.met_etl_db_session
 
     met_etl_db_session.query(EtlRunCycleModel).filter(
-        EtlRunCycleModel.id == survey_new_runcycleid, EtlRunCycleModel.packagename == 'engagement',
-        EtlRunCycleModel.success is False).update(
-        {'success': True, 'description': 'ended the load for tables Engagement'})
+        EtlRunCycleModel.id == engagement_new_runcycleid, EtlRunCycleModel.packagename == 'engagement',
+        EtlRunCycleModel.success == False).update(
+        {'success': True, 'enddatetime': datetime.utcnow(), 'description': 'ended the load for tables Engagement'})
 
     context.log.info("run cycle ended for Engagement table")
 

--- a/met-etl/src/etl_project/services/ops/submission_etl_service.py
+++ b/met-etl/src/etl_project/services/ops/submission_etl_service.py
@@ -353,7 +353,7 @@ def submission_end_run_cycle(context, submission_new_runcycleid):
 
     met_etl_db_session.query(EtlRunCycleModel).filter(
         EtlRunCycleModel.id == submission_new_runcycleid, EtlRunCycleModel.packagename == 'submission',
-        EtlRunCycleModel.success == False).update({'success': True,
+        EtlRunCycleModel.success == False).update({'success': True, 'enddatetime': datetime.utcnow(),
                                                    'description': 'ended the load for tables user response detail and responses'})
 
     context.log.info("run cycle ended for submission table")

--- a/met-etl/src/etl_project/services/ops/survey_etl_service.py
+++ b/met-etl/src/etl_project/services/ops/survey_etl_service.py
@@ -16,7 +16,7 @@ from met_cron.utils import FormIoComponentType
 # get the last run cycle id for survey etl
 @op(required_resource_keys={"met_db_session", "met_etl_db_session"},
     out={"survey_last_run_cycle_time": Out(), "survey_new_runcycleid": Out()})
-def get_survey_last_run_cycle_time(context):
+def get_survey_last_run_cycle_time(context, flag_to_run_step_after_engagement):
     met_etl_db_session = context.resources.met_etl_db_session
     default_datetime = datetime(1900, 1, 1, 0, 0, 0, 0)
 
@@ -221,7 +221,7 @@ def survey_end_run_cycle(context, survey_new_runcycleid):
     met_etl_db_session.query(EtlRunCycleModel).filter(
         EtlRunCycleModel.id == survey_new_runcycleid, EtlRunCycleModel.packagename == 'survey',
         EtlRunCycleModel.success == False).update(
-        {'success': True, 'description': 'ended the load for tables survey and requests'})
+        {'success': True, 'enddatetime': datetime.utcnow(), 'description': 'ended the load for tables survey and requests'})
 
     context.log.info("run cycle ended for survey table")
 

--- a/met-etl/src/etl_project/services/ops/user_etl_service.py
+++ b/met-etl/src/etl_project/services/ops/user_etl_service.py
@@ -11,7 +11,7 @@ from met_cron.models.etlruncycle import EtlRunCycle as EtlRunCycleModel
 # get the last run cycle id for user detail etl
 @op(required_resource_keys={"met_db_session", "met_etl_db_session"},
     out={"user_details_last_run_cycle_datetime": Out(), "user_details_new_run_cycle_id": Out()})
-def get_user_details_last_run_cycle_time(context):
+def get_user_last_run_cycle_time(context):
     met_etl_db_session = context.resources.met_etl_db_session
     default_datetime = datetime(1900, 1, 1, 0, 0, 0, 0)
 
@@ -98,18 +98,18 @@ def load_user(context, new_users, updated_users, user_details_new_run_cycle_id):
 
 
 # update the status for user detail etl in run cycle table as successful
-@op(required_resource_keys={"met_db_session", "met_etl_db_session"}, out={"flag_to_run_step_after_user_details": Out()})
-def user_details_end_run_cycle(context, user_details_new_run_cycle_id):
+@op(required_resource_keys={"met_db_session", "met_etl_db_session"}, out={"flag_to_run_step_after_user": Out()})
+def user_end_run_cycle(context, user_details_new_run_cycle_id):
     met_etl_db_session = context.resources.met_etl_db_session
 
     met_etl_db_session.query(EtlRunCycleModel).filter(
         EtlRunCycleModel.id == user_details_new_run_cycle_id, EtlRunCycleModel.packagename == 'userdetails',
         EtlRunCycleModel.success == False).update(
-        {'success': True, 'description': 'ended the load for table user_details'})
+        {'success': True, 'enddatetime': datetime.utcnow(), 'description': 'ended the load for table user_details'})
 
     context.log.info("run cycle ended for user_details table")
 
-    yield Output("userdetails", "flag_to_run_step_after_user_details")
+    yield Output("userdetails", "flag_to_run_step_after_user")
 
     met_etl_db_session.commit()
 

--- a/met-etl/src/etl_project/services/schedules/met_data_ingestion_schedule.py
+++ b/met-etl/src/etl_project/services/schedules/met_data_ingestion_schedule.py
@@ -3,7 +3,7 @@ from jobs.met_data_ingestion import met_data_ingestion
 
 
 @schedule(
-    cron_schedule="* 1 * * *",
+    cron_schedule="*/30 * * * *",
     job=met_data_ingestion,
     execution_timezone="US/Central",
 )


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/745

*Description of changes:*
- Added logic to update the run cycle end time
- Updated the job run schedule to be every 30 mins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
