### PR TITLE
Add service and api unit tests for widget documents

### DIFF
--- a/met-api/src/met_api/resources/widget_documents.py
+++ b/met-api/src/met_api/resources/widget_documents.py
@@ -37,7 +37,7 @@ class WidgetDocuments(Resource):
     def get(widget_id):
         """Fetch a list of widgets by engagement_id."""
         try:
-            documents = WidgetDocumentService().get_document_by_widget_id(widget_id)
+            documents = WidgetDocumentService().get_documents_by_widget_id(widget_id)
             return ActionResult.success(result=documents)
         except (KeyError, ValueError) as err:
             return ActionResult.error(str(err))

--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -13,7 +13,7 @@ class WidgetDocumentService:
     """Widget Documents management service."""
 
     @staticmethod
-    def get_document_by_widget_id(widget_id):
+    def get_documents_by_widget_id(widget_id):
         """Get documents by widget id."""
         docs = WidgetDocumentsModel.get_all_by_widget_id(widget_id)
         if not docs:

--- a/met-api/tests/unit/api/test_widget_document.py
+++ b/met-api/tests/unit/api/test_widget_document.py
@@ -40,7 +40,7 @@ def test_create_documents(client, jwt, session, document_info):  # pylint:disabl
     }
 
     rv = client.post(
-        f'/api/widgets/{str(widget.id)}/documents',
+        f'/api/widgets/{widget.id}/documents',
         data=json.dumps(data),
         headers=headers,
         content_type='application/json'
@@ -63,7 +63,7 @@ def test_get_document(client, jwt, session, document_info):  # pylint:disable=un
     })
 
     rv = client.get(
-        f'/api/widgets/{str(widget.id)}/documents',
+        f'/api/widgets/{widget.id}/documents',
         headers=headers,
         content_type='application/json'
     )

--- a/met-api/tests/unit/api/test_widget_document.py
+++ b/met-api/tests/unit/api/test_widget_document.py
@@ -38,8 +38,13 @@ def test_create_documents(client, jwt, session, document_info):  # pylint:disabl
         **TestWidgetDocumentInfo.document1,
         'widget_id': widget.id,
     }
-    rv = client.post('/api/widgets/' + str(widget.id) + '/documents', data=json.dumps(data),
-                     headers=headers, content_type='application/json')
+
+    rv = client.post(
+        f'/api/widgets/{str(widget.id)}/documents',
+        data=json.dumps(data),
+        headers=headers,
+        content_type='application/json'
+    )
     assert rv.status_code == 200
 
 
@@ -58,10 +63,10 @@ def test_get_document(client, jwt, session, document_info):  # pylint:disable=un
     })
 
     rv = client.get(
-        '/api/widgets/' + str(widget.id) + '/documents',
+        f'/api/widgets/{str(widget.id)}/documents',
         headers=headers,
         content_type='application/json'
     )
 
-    assert rv.json.get('result').get('children')[0].get('id') == document.id
     assert rv.status_code == 200
+    assert rv.json.get('result').get('children')[0].get('id') == document.id

--- a/met-api/tests/unit/api/test_widget_document.py
+++ b/met-api/tests/unit/api/test_widget_document.py
@@ -1,0 +1,63 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the Widget API end-point.
+
+Test-Suite to ensure that the Widget endpoint is working as expected.
+"""
+import json
+
+import pytest
+
+from tests.utilities.factory_scenarios import TestJwtClaims, TestWidgetDocumentInfo, TestWidgetInfo, TestWidgetItemInfo
+from tests.utilities.factory_utils import (
+    factory_auth_header, factory_document_model, factory_engagement_model, factory_widget_model)
+
+
+@pytest.mark.parametrize('document_info', [TestWidgetItemInfo.widget_item1])
+def test_create_documents(client, jwt, session, document_info):  # pylint:disable=unused-argument
+    """Assert that widget items can be POSTed."""
+    engagement = factory_engagement_model()
+    TestWidgetInfo.widget1['engagement_id'] = engagement.id
+    widget = factory_widget_model(TestWidgetInfo.widget1)
+
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)
+
+    data = {
+        **TestWidgetDocumentInfo.document1,
+        'widget_id': widget.id,
+    }
+    rv = client.post('/api/widgets/' + str(widget.id) + '/documents', data=json.dumps(data),
+                     headers=headers, content_type='application/json')
+    assert rv.status_code == 200
+    
+@pytest.mark.parametrize('document_info', [TestWidgetItemInfo.widget_item1])
+def test_get_document(client, jwt, session, document_info):  # pylint:disable=unused-argument
+    """Assert that widget items can be POSTed."""
+    engagement = factory_engagement_model()
+    TestWidgetInfo.widget1['engagement_id'] = engagement.id
+    widget = factory_widget_model(TestWidgetInfo.widget1)
+
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)    
+
+    document = factory_document_model({
+        **TestWidgetDocumentInfo.document1,
+        'widget_id': widget.id,
+    })
+    
+    rv = client.get('/api/widgets/' + str(widget.id) + '/documents',
+                     headers=headers, content_type='application/json')
+    
+    assert rv.json.get('result').get('children')[0].get('id') == document.id
+    assert rv.status_code == 200

--- a/met-api/tests/unit/api/test_widget_document.py
+++ b/met-api/tests/unit/api/test_widget_document.py
@@ -41,7 +41,8 @@ def test_create_documents(client, jwt, session, document_info):  # pylint:disabl
     rv = client.post('/api/widgets/' + str(widget.id) + '/documents', data=json.dumps(data),
                      headers=headers, content_type='application/json')
     assert rv.status_code == 200
-    
+
+
 @pytest.mark.parametrize('document_info', [TestWidgetItemInfo.widget_item1])
 def test_get_document(client, jwt, session, document_info):  # pylint:disable=unused-argument
     """Assert that widget items can be POSTed."""
@@ -49,15 +50,18 @@ def test_get_document(client, jwt, session, document_info):  # pylint:disable=un
     TestWidgetInfo.widget1['engagement_id'] = engagement.id
     widget = factory_widget_model(TestWidgetInfo.widget1)
 
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)    
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)
 
     document = factory_document_model({
         **TestWidgetDocumentInfo.document1,
         'widget_id': widget.id,
     })
-    
-    rv = client.get('/api/widgets/' + str(widget.id) + '/documents',
-                     headers=headers, content_type='application/json')
-    
+
+    rv = client.get(
+        '/api/widgets/' + str(widget.id) + '/documents',
+        headers=headers,
+        content_type='application/json'
+    )
+
     assert rv.json.get('result').get('children')[0].get('id') == document.id
     assert rv.status_code == 200

--- a/met-api/tests/unit/services/test_widget_documents.py
+++ b/met-api/tests/unit/services/test_widget_documents.py
@@ -1,0 +1,61 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Widget service.
+
+Test suite to ensure that the Widget service routines are working as expected.
+"""
+
+from faker import Faker
+
+from met_api.services.widget_documents_service import WidgetDocumentService
+from tests.utilities.factory_scenarios import TestWidgetDocumentInfo, TestWidgetInfo
+from tests.utilities.factory_utils import factory_document_model, factory_engagement_model, factory_widget_model
+
+
+fake = Faker()
+date_format = '%Y-%m-%d'
+
+
+def test_get_document_by_widget_id(session):  # pylint:disable=unused-argument
+    """Assert that documents can be fetched."""
+    engagement = factory_engagement_model()
+    TestWidgetInfo.widget1['engagement_id'] = engagement.id
+    widget = factory_widget_model(TestWidgetInfo.widget1)
+
+    factory_document_model({
+        **TestWidgetDocumentInfo.document1,
+        'widget_id': widget.id,
+    })
+
+    factory_document_model({
+        **TestWidgetDocumentInfo.document2,
+        'widget_id': widget.id,
+    })
+
+    documents_root = WidgetDocumentService.get_document_by_widget_id(widget.id)
+
+    documents = documents_root.get('children')
+
+    assert len(documents) == 2
+
+
+def test_create_document(session):  # pylint:disable=unused-argument
+    """Assert that documents can be fetched."""
+    engagement = factory_engagement_model()
+    TestWidgetInfo.widget1['engagement_id'] = engagement.id
+    widget = factory_widget_model(TestWidgetInfo.widget1)
+
+    document = WidgetDocumentService.create_document(widget.id, TestWidgetDocumentInfo.document1)
+
+    assert document != None

--- a/met-api/tests/unit/services/test_widget_documents.py
+++ b/met-api/tests/unit/services/test_widget_documents.py
@@ -43,7 +43,7 @@ def test_get_document_by_widget_id(session):  # pylint:disable=unused-argument
         'widget_id': widget.id,
     })
 
-    documents_root = WidgetDocumentService.get_document_by_widget_id(widget.id)
+    documents_root = WidgetDocumentService.get_documents_by_widget_id(widget.id)
 
     documents = documents_root.get('children')
 
@@ -57,5 +57,10 @@ def test_create_document(session):  # pylint:disable=unused-argument
     widget = factory_widget_model(TestWidgetInfo.widget1)
 
     document = WidgetDocumentService.create_document(widget.id, TestWidgetDocumentInfo.document1)
+    documents_root = WidgetDocumentService.get_documents_by_widget_id(widget.id)
+    documents = documents_root.get('children')
+    document_fetched = documents[0]
 
     assert document is not None
+    assert document.id == document_fetched.get('id')
+    assert document.title == document_fetched.get('title')

--- a/met-api/tests/unit/services/test_widget_documents.py
+++ b/met-api/tests/unit/services/test_widget_documents.py
@@ -58,4 +58,4 @@ def test_create_document(session):  # pylint:disable=unused-argument
 
     document = WidgetDocumentService.create_document(widget.id, TestWidgetDocumentInfo.document1)
 
-    assert document != None
+    assert document is not None

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -216,3 +216,25 @@ class TestCommentInfo(dict, Enum):
         'component_id': 'simpletextarea',
         'submission_date': datetime.now().strftime('%Y-%m-%d'),
     }
+
+
+class TestWidgetDocumentInfo(dict, Enum):
+    """Test scenarios of contact."""
+
+    document1 = {
+        'title': fake.word(),
+        'type': 'folder',
+        'parent_document_id': None,
+        'url': None,
+        'sort_index': 1,
+        'widget_id': 1,
+    }
+
+    document2 = {
+        'title': fake.file_name(extension='pdf'),
+        'type': 'file',
+        'parent_document_id': None,
+        'url': fake.image_url(),
+        'sort_index': 1,
+        'widget_id': 1,
+    }

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -216,6 +216,5 @@ def factory_document_model(document_info: dict = TestWidgetDocumentInfo.document
         sort_index=document_info.get('sort_index'),
         widget_id=document_info.get('widget_id'),
     )
-    db.session.add(document)
-    db.session.commit()
+    document.save()
     return document

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -30,9 +30,10 @@ from met_api.models.survey import Survey as SurveyModel
 from met_api.models.user import User as UserModel
 from met_api.models.widget import Widget as WidgetModal
 from met_api.models.widget_item import WidgetItem as WidgetItemModal
+from met_api.models.widget_documents import WidgetDocuments as WidgetDocumentModel
 from tests.utilities.factory_scenarios import (
     TestCommentInfo, TestEngagementInfo, TestFeedbackInfo, TestSubmissionInfo, TestSurveyInfo, TestUserInfo,
-    TestWidgetInfo, TestWidgetItemInfo)
+    TestWidgetInfo, TestWidgetItemInfo, TestWidgetDocumentInfo)
 
 
 CONFIG = get_named_config('testing')
@@ -203,3 +204,18 @@ def factory_comment_model(survey_id, submission_id, comment_info: dict = TestCom
     db.session.add(comment)
     db.session.commit()
     return comment
+
+
+def factory_document_model(document_info: dict = TestWidgetDocumentInfo.document1):
+    """Produce a comment model."""
+    document = WidgetDocumentModel(
+        title=document_info.get('title'),
+        type=document_info.get('type'),
+        parent_document_id=document_info.get('parent_document_id'),
+        url=document_info.get('url'),
+        sort_index=document_info.get('sort_index'),
+        widget_id=document_info.get('widget_id'),
+    )
+    db.session.add(document)
+    db.session.commit()
+    return document

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -29,11 +29,11 @@ from met_api.models.submission import Submission as SubmissionModel
 from met_api.models.survey import Survey as SurveyModel
 from met_api.models.user import User as UserModel
 from met_api.models.widget import Widget as WidgetModal
-from met_api.models.widget_item import WidgetItem as WidgetItemModal
 from met_api.models.widget_documents import WidgetDocuments as WidgetDocumentModel
+from met_api.models.widget_item import WidgetItem as WidgetItemModal
 from tests.utilities.factory_scenarios import (
     TestCommentInfo, TestEngagementInfo, TestFeedbackInfo, TestSubmissionInfo, TestSurveyInfo, TestUserInfo,
-    TestWidgetInfo, TestWidgetItemInfo, TestWidgetDocumentInfo)
+    TestWidgetDocumentInfo, TestWidgetInfo, TestWidgetItemInfo)
 
 
 CONFIG = get_named_config('testing')


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/162
https://github.com/bcgov/met-public/issues/163

*Description of changes:*

- Add widget document api unit tests for GET and POST
- Add widget document service unit tests for GET and POST


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
