### PR TITLE
Add unit testing for document widgets

### DIFF
--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/DocumentFolder.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/DocumentFolder.tsx
@@ -36,22 +36,20 @@ const DocumentFolder = ({ documentItem }: { documentItem: DocumentItem }) => {
                 <Grid item xs={12} container justifyContent={'flex-end'} spacing={2}>
                     {documentItem.children?.map((item) => {
                         return (
-                            <>
-                                <Grid item xs={12}>
-                                    <Stack direction="row" spacing={1} alignItems="flex-start">
-                                        <IconButton
-                                            sx={{ padding: 0, margin: 0, height: '2em' }}
-                                            style={{ color: 'inherit' }}
-                                            color="info"
-                                            aria-label="drag-indicator"
-                                            disabled={true}
-                                        >
-                                            <SubdirectoryArrowRightIcon />
-                                        </IconButton>
-                                        <DocumentSwitch documentItem={item} />
-                                    </Stack>
-                                </Grid>
-                            </>
+                            <Grid key={`child-document-${item.id}`} item xs={12}>
+                                <Stack direction="row" spacing={1} alignItems="flex-start">
+                                    <IconButton
+                                        sx={{ padding: 0, margin: 0, height: '2em' }}
+                                        style={{ color: 'inherit' }}
+                                        color="info"
+                                        aria-label="drag-indicator"
+                                        disabled={true}
+                                    >
+                                        <SubdirectoryArrowRightIcon />
+                                    </IconButton>
+                                    <DocumentSwitch documentItem={item} />
+                                </Stack>
+                            </Grid>
                         );
                     })}
                 </Grid>

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/DocumentsBlock.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/DocumentsBlock.tsx
@@ -9,7 +9,7 @@ const DocumentsBlock = () => {
     return (
         <Grid item xs={12} container alignItems="flex-start" justifyContent={'flex-start'} spacing={2}>
             {documents.map((document) => {
-                return <DocumentSwitch documentItem={document} />;
+                return <DocumentSwitch key={`document-${document.id}`} documentItem={document} />;
             })}
         </Grid>
     );

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/FileDrawer.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/FileDrawer.tsx
@@ -128,8 +128,8 @@ const FileDrawer = () => {
                             <Grid item xs={12}>
                                 <MetLabel sx={{ marginBottom: '2px' }}>Folder</MetLabel>
                                 <ControlledSelect
-                                    name="folderId"
                                     id="document-folder"
+                                    name="folderId"
                                     data-testid="document-form/folderId"
                                     variant="outlined"
                                     label=" "
@@ -139,11 +139,15 @@ const FileDrawer = () => {
                                     fullWidth
                                     size="small"
                                 >
-                                    <MenuItem value={0} sx={{ height: '2em' }}></MenuItem>
+                                    <MenuItem key={`folder-option-0`} value={0} sx={{ height: '2em' }}></MenuItem>
                                     {documents
                                         .filter((document) => document.type === DOCUMENT_TYPE.FOLDER)
                                         .map((document) => {
-                                            return <MenuItem value={document.id}>{document.title}</MenuItem>;
+                                            return (
+                                                <MenuItem key={`folder-option-${document.id}`} value={document.id}>
+                                                    {document.title}
+                                                </MenuItem>
+                                            );
                                         })}
                                 </ControlledSelect>
                             </Grid>

--- a/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
@@ -10,11 +10,9 @@ import * as widgetService from 'services/widgetService';
 import * as documentService from 'services/widgetService/DocumentService.tsx';
 import * as notificationSlice from 'services/notificationService/notificationSlice';
 import * as notificationModalSlice from 'services/notificationModalService/notificationModalSlice';
-import { createDefaultSurvey, Survey } from 'models/survey';
 import { createDefaultEngagement, Engagement } from 'models/engagement';
 import { EngagementStatus } from 'constants/engagementStatus';
-import { Widget, WidgetItem, WidgetType } from 'models/widget';
-import { Contact } from 'models/contact';
+import { Widget, WidgetType } from 'models/widget';
 import { Box } from '@mui/material';
 import { DocumentItem } from 'models/document';
 
@@ -73,20 +71,12 @@ describe('Document widget in engagement page tests', () => {
     jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
-    const openNotificationMock = jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());
-    const openNotificationModalMock = jest
-        .spyOn(notificationModalSlice, 'openNotificationModal')
-        .mockImplementation(jest.fn());
+    jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());
+    jest.spyOn(engagementService, 'getEngagement').mockReturnValue(Promise.resolve(engagement));
+    jest.spyOn(documentService, 'fetchDocuments').mockReturnValue(Promise.resolve([mockFolder]));
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
-    const getEngagementMock = jest
-        .spyOn(engagementService, 'getEngagement')
-        .mockReturnValue(Promise.resolve(engagement));
     const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([documentWidget]));
     const postWidgetMock = jest.spyOn(widgetService, 'postWidget').mockReturnValue(Promise.resolve(documentWidget));
-
-    const getDocumentsMock = jest
-        .spyOn(documentService, 'fetchDocuments')
-        .mockReturnValue(Promise.resolve([mockFolder]));
 
     beforeEach(() => {
         setupEnv();

--- a/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
@@ -152,7 +152,7 @@ describe('Document widget in engagement page tests', () => {
         });
     });
 
-    test('Creat folder appears', async () => {
+    test('Creat file appears', async () => {
         useParamsMock.mockReturnValue({ engagementId: '1' });
         getWidgetsMock.mockReturnValueOnce(Promise.resolve([]));
         postWidgetMock.mockReturnValue(Promise.resolve(documentWidget));

--- a/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
@@ -9,7 +9,6 @@ import * as engagementService from 'services/engagementService';
 import * as widgetService from 'services/widgetService';
 import * as documentService from 'services/widgetService/DocumentService.tsx';
 import * as notificationSlice from 'services/notificationService/notificationSlice';
-import * as notificationModalSlice from 'services/notificationModalService/notificationModalSlice';
 import { createDefaultEngagement, Engagement } from 'models/engagement';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { Widget, WidgetType } from 'models/widget';

--- a/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/EngagementFormDocumentWidget.test.tsx
@@ -1,0 +1,202 @@
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import EngagementForm from '../../../src/components/engagement/form';
+import { setupEnv } from './setEnvVars';
+import * as reactRedux from 'react-redux';
+import * as reactRouter from 'react-router';
+import * as engagementService from 'services/engagementService';
+import * as widgetService from 'services/widgetService';
+import * as documentService from 'services/widgetService/DocumentService.tsx';
+import * as notificationSlice from 'services/notificationService/notificationSlice';
+import * as notificationModalSlice from 'services/notificationModalService/notificationModalSlice';
+import { createDefaultSurvey, Survey } from 'models/survey';
+import { createDefaultEngagement, Engagement } from 'models/engagement';
+import { EngagementStatus } from 'constants/engagementStatus';
+import { Widget, WidgetItem, WidgetType } from 'models/widget';
+import { Contact } from 'models/contact';
+import { Box } from '@mui/material';
+import { DocumentItem } from 'models/document';
+
+const engagement: Engagement = {
+    ...createDefaultEngagement(),
+    id: 1,
+    name: 'Test Engagement',
+    created_date: '2022-09-14 20:16:29.846877',
+    rich_content:
+        '{"blocks":[{"key":"29p4m","text":"Test content","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
+    content: 'Test content',
+    rich_description:
+        '{"blocks":[{"key":"bqupg","text":"Test description","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
+    description: 'Test description',
+    start_date: '2022-09-01',
+    end_date: '2022-09-30',
+    engagement_status: {
+        id: EngagementStatus.Draft,
+        status_name: 'Draft',
+    },
+};
+
+const mockFile: DocumentItem = {
+    id: 1,
+    title: 'Test file',
+    type: 'file',
+    url: 'https://random-s3-url/new-bucket-048a62a2/test.jpg',
+};
+
+const mockFolder: DocumentItem = {
+    id: 2,
+    title: 'Test folder',
+    type: 'folder',
+    children: [mockFile],
+};
+
+const documentWidget: Widget = {
+    id: 1,
+    widget_type_id: WidgetType.Document,
+    engagement_id: 1,
+    items: [],
+};
+
+jest.mock('react-dnd', () => ({
+    ...jest.requireActual('react-dnd'),
+    useDrag: jest.fn(),
+    useDrop: jest.fn(),
+}));
+
+jest.mock('components/common/Dragndrop', () => ({
+    ...jest.requireActual('components/common/Dragndrop'),
+    DragItem: ({ children }: { children: React.ReactNode }) => <Box>{children}</Box>,
+}));
+
+describe('Document widget in engagement page tests', () => {
+    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
+    jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
+    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
+    const openNotificationMock = jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());
+    const openNotificationModalMock = jest
+        .spyOn(notificationModalSlice, 'openNotificationModal')
+        .mockImplementation(jest.fn());
+    const useParamsMock = jest.spyOn(reactRouter, 'useParams');
+    const getEngagementMock = jest
+        .spyOn(engagementService, 'getEngagement')
+        .mockReturnValue(Promise.resolve(engagement));
+    const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([documentWidget]));
+    const postWidgetMock = jest.spyOn(widgetService, 'postWidget').mockReturnValue(Promise.resolve(documentWidget));
+
+    const getDocumentsMock = jest
+        .spyOn(documentService, 'fetchDocuments')
+        .mockReturnValue(Promise.resolve([mockFolder]));
+
+    beforeEach(() => {
+        setupEnv();
+    });
+
+    test('Document widget is created when option is clicked', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        getWidgetsMock.mockReturnValueOnce(Promise.resolve([]));
+        postWidgetMock.mockReturnValue(Promise.resolve(documentWidget));
+        getWidgetsMock.mockReturnValueOnce(Promise.resolve([documentWidget]));
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        const addWidgetButton = screen.getByText('Add Widget');
+        fireEvent.click(addWidgetButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Select Widget')).toBeVisible();
+        });
+
+        const documentOption = screen.getByTestId(`widget-drawer-option/${WidgetType.Document}`);
+        fireEvent.click(documentOption);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test file')).toBeVisible();
+            expect(screen.getByText('Test folder')).toBeVisible();
+        });
+        expect(postWidgetMock).toHaveBeenNthCalledWith(1, engagement.id, {
+            widget_type_id: WidgetType.Document,
+            engagement_id: engagement.id,
+        });
+        expect(getWidgetsMock).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('Create Folder')).toBeVisible();
+        expect(screen.getByText('Add Document')).toBeVisible();
+    });
+
+    test('Creat folder appears', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        getWidgetsMock.mockReturnValueOnce(Promise.resolve([]));
+        postWidgetMock.mockReturnValue(Promise.resolve(documentWidget));
+        getWidgetsMock.mockReturnValueOnce(Promise.resolve([documentWidget]));
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        const addWidgetButton = screen.getByText('Add Widget');
+        fireEvent.click(addWidgetButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Select Widget')).toBeVisible();
+        });
+
+        const documentOption = screen.getByTestId(`widget-drawer-option/${WidgetType.Document}`);
+        fireEvent.click(documentOption);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test file')).toBeVisible();
+            expect(screen.getByText('Test folder')).toBeVisible();
+        });
+
+        const createFolderButton = screen.getByText('Create Folder');
+        fireEvent.click(createFolderButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Folder name')).toBeVisible();
+            expect(screen.getByText('Add Folder')).toBeVisible();
+        });
+    });
+
+    test('Creat folder appears', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        getWidgetsMock.mockReturnValueOnce(Promise.resolve([]));
+        postWidgetMock.mockReturnValue(Promise.resolve(documentWidget));
+        getWidgetsMock.mockReturnValueOnce(Promise.resolve([documentWidget]));
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        const addWidgetButton = screen.getByText('Add Widget');
+        fireEvent.click(addWidgetButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Select Widget')).toBeVisible();
+        });
+
+        const documentOption = screen.getByTestId(`widget-drawer-option/${WidgetType.Document}`);
+        fireEvent.click(documentOption);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test file')).toBeVisible();
+            expect(screen.getByText('Test folder')).toBeVisible();
+        });
+
+        const addDocumentButton = screen.getByText('Add Document');
+        fireEvent.click(addDocumentButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Link')).toBeVisible();
+            expect(screen.getByText('Name')).toBeVisible();
+            expect(screen.getByText('Folder')).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/163
*Description of changes:*

- Add unit test to test document widget can be created
- test Folder form appearing
- test file form appearing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
