### PR TITLE
fix for firefox date error

### DIFF
--- a/met-web/package.json
+++ b/met-web/package.json
@@ -35,7 +35,6 @@
         "jsonwebtoken": "^8.5.1",
         "keycloak-js": "^10.0.2",
         "met-formio": "^1.0.9-rc.2",
-        "moment": "^2.29.4",
         "mui-sx": "^1.0.0",
         "node-sass": "^7.0.3",
         "react": "^18.0.0",

--- a/met-web/src/components/common/dateHelper.tsx
+++ b/met-web/src/components/common/dateHelper.tsx
@@ -1,24 +1,24 @@
-import { format, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
-import moment from 'moment';
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import tz from 'dayjs/plugin/timezone';
+dayjs.extend(utc);
+dayjs.extend(tz);
 
-const formatToPSTTimeZone = (date: Date, fmt: string, tz: string) =>
-    format(utcToZonedTime(date, tz), fmt, { timeZone: tz });
+const formatToPSTTimeZone = (date: string, fmt: string, tz: string) => dayjs.utc(date).tz(tz).format(fmt);
 
-const formatToUTCTimeZone = (date: Date, fmt: string, tz: string) =>
-    moment(date.setHours(date.getHours() + zonedTimeToUtc(date, tz).getTimezoneOffset() / 60)).format(fmt);
+const formatToUTCTimeZone = (date: string, fmt: string) => dayjs(date).utc().format(fmt);
 
-export const formatDate = (date: string, formatString = 'yyyy-MM-dd') => {
+export const formatDate = (date: string, formatString = 'YYYY-MM-DD') => {
     if (date) {
-        return formatToPSTTimeZone(new Date(date + ' UTC'), formatString, 'PST');
+        return formatToPSTTimeZone(date, formatString, 'America/Vancouver');
     } else {
         return '';
     }
 };
 
-export const formatToUTC = (date: Dayjs | string, formatString = 'yyyy-MM-DD HH:mm:ss') => {
+export const formatToUTC = (date: Dayjs | string, formatString = 'YYYY-MM-DD HH:mm:ss') => {
     if (date) {
-        return formatToUTCTimeZone(new Date(date.toString()), formatString, 'PST');
+        return formatToUTCTimeZone(date.toString(), formatString);
     } else {
         return '';
     }

--- a/met-web/src/components/engagement/banner/BannerWithImage.tsx
+++ b/met-web/src/components/engagement/banner/BannerWithImage.tsx
@@ -6,14 +6,14 @@ import { BannerProps } from '../view/types';
 import { EngagementStatusChip } from '../status';
 import { Editor } from 'react-draft-wysiwyg';
 import { getEditorState } from 'utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 const BannerWithImage = ({ savedEngagement, children }: BannerProps) => {
     const { name, end_date, banner_url, start_date, submission_status, rich_description } = savedEngagement;
     const [imageError, setImageError] = useState(false);
-    const dateFormat = 'MMM DD, yyyy';
+    const dateFormat = 'MMM DD, YYYY';
 
-    const EngagementDate = `Engagement dates: ${moment(start_date).format(dateFormat)} to ${moment(end_date).format(
+    const EngagementDate = `Engagement dates: ${dayjs(start_date).format(dateFormat)} to ${dayjs(end_date).format(
         dateFormat,
     )}`;
 

--- a/met-web/src/components/engagement/banner/BannerWithoutImage.tsx
+++ b/met-web/src/components/engagement/banner/BannerWithoutImage.tsx
@@ -6,14 +6,14 @@ import { EngagementStatusChip } from '../status';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { Editor } from 'react-draft-wysiwyg';
 import { getEditorState } from 'utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 const BannerWithoutImage = ({ savedEngagement }: BannerProps) => {
     const { rich_description, name, start_date, end_date, submission_status } = savedEngagement;
     const isDraft = savedEngagement.status_id === EngagementStatus.Draft;
-    const dateFormat = 'MMM DD, yyyy';
+    const dateFormat = 'MMM DD, YYYY';
 
-    const EngagementDate = `Engagement dates: ${moment(start_date).format(dateFormat)} to ${moment(end_date).format(
+    const EngagementDate = `Engagement dates: ${dayjs(start_date).format(dateFormat)} to ${dayjs(end_date).format(
         dateFormat,
     )}`;
 

--- a/met-web/src/components/engagement/view/PreviewBanner.tsx
+++ b/met-web/src/components/engagement/view/PreviewBanner.tsx
@@ -22,7 +22,7 @@ export const PreviewBanner = () => {
     const engagementId = savedEngagement.id || '';
     const imageExists = !!savedEngagement.banner_url;
     const isScheduled = savedEngagement.status_id === EngagementStatus.Scheduled;
-    const scheduledDate = formatDate(savedEngagement.scheduled_date, 'MMM dd yyyy');
+    const scheduledDate = formatDate(savedEngagement.scheduled_date, 'MMM DD YYYY');
     const scheduledTime = formatDate(savedEngagement.scheduled_date, 'HH:mm');
     const engagementBannerText = isScheduled
         ? 'Engagement scheduled - ' + scheduledDate + ' at ' + scheduledTime + ' PST'


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/940

*Description of changes:*
- Fixed the issues with date formatting so that the app works on Firefox browser as well. Functions used to convert date to/from utc like utcToZonedTime and zonedTimeToUtc where causing issues on Firefox browser. Removed the dependency on these and instead used dayjs for date formatting.
- Changes made to remove the dependency on moment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
