### PR TITLE
Implement design tweaks to engagement phase component for desktop

### DIFF
--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -174,6 +174,7 @@ export const MetSmallText = ({ bold, children, sx, ...rest }: HeaderProps) => {
                 ...sx,
                 fontSize: '13px',
                 fontFamily: MET_Header_Font_Family,
+                fontWeight: bold ? 'bold' : MET_Header_Font_Weight,
             }}
             variant="subtitle1"
             {...rest}

--- a/met-web/src/components/engagement/form/EngagementWidgets/Phases/PhasesForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Phases/PhasesForm.tsx
@@ -34,6 +34,10 @@ const PhasesForm = () => {
             label: 'Early Engagement',
         },
         {
+            id: EngagementPhases.ReadinessDecision,
+            label: 'Readiness Decision',
+        },
+        {
             id: EngagementPhases.ProcessPlanning,
             label: 'Process Planning',
         },
@@ -42,8 +46,16 @@ const PhasesForm = () => {
             label: 'Application Development & Review',
         },
         {
-            id: EngagementPhases.EffectsAssessmentRecomendation,
-            label: 'Effects Assessment & Recommendation',
+            id: EngagementPhases.Recommendation,
+            label: 'Recommendation',
+        },
+        {
+            id: EngagementPhases.Decision,
+            label: 'Decision',
+        },
+        {
+            id: EngagementPhases.PostCertificate,
+            label: 'Post-certificate',
         },
     ];
 

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/EngagementPhase.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/EngagementPhase.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Grid } from '@mui/material';
 import { MetHeader4, MetParagraph } from 'components/common';
 import { ReadMoreBox } from './ReadMoreBox';
-import { ProcessStageProps } from 'models/engagementPhases';
+import { EngagementPhases, PAST_PHASE, ProcessStageProps } from 'models/engagementPhases';
 import { PhaseBox } from './PhaseBox';
+import { ActionContext } from '../../ActionContext';
+import { WidgetType } from 'models/widget';
 
 export const EngagementPhase = ({
     backgroundColor,
@@ -11,13 +13,30 @@ export const EngagementPhase = ({
     title,
     learnMoreText,
     popOverText,
+    phaseId,
 }: ProcessStageProps) => {
+    const { widgets } = useContext(ActionContext);
+    const phasesWidget = widgets.find((widget) => widget.widget_type_id === WidgetType.Phases);
+    const currentPhase = phasesWidget?.items[0]?.widget_data_id || EngagementPhases.Standalone;
+    const isCurrent = phaseId >= currentPhase;
+
     return (
         <PhaseBox
             title={title}
-            backgroundColor={backgroundColor}
-            readMoreBox={
-                <ReadMoreBox backgroundColor={learnMoreBackgroundColor} sx={{ border: '3px solid #54858D', margin: 0 }}>
+            backgroundColor={isCurrent ? backgroundColor : PAST_PHASE.backgroundColor}
+            sx={{ borderRight: isCurrent ? 'none' : `1px solid ${PAST_PHASE.borderColor}` }}
+            learnMoreBox={
+                <ReadMoreBox
+                    backgroundColor={isCurrent ? learnMoreBackgroundColor : PAST_PHASE.backgroundColor}
+                    sx={[
+                        { margin: 0 },
+                        isCurrent && { border: `3px solid ${backgroundColor}` },
+                        !isCurrent && {
+                            color: 'white',
+                            border: `3px solid ${PAST_PHASE.borderColor}`,
+                        },
+                    ]}
+                >
                     <Grid container direction="row" justifyContent="flex-start" alignItems="flex-start" spacing={2}>
                         <Grid item xs={12}>
                             <MetHeader4 bold>{title}</MetHeader4>

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/EngagementPhase.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/EngagementPhase.tsx
@@ -46,6 +46,8 @@ export const EngagementPhase = ({
                 </ReadMoreBox>
             }
             iconBox={popOverText ? <MetParagraph>{popOverText}</MetParagraph> : false}
+            isCurrentPhase={phaseId === currentPhase}
+            currentPhase={currentPhase}
         />
     );
 };

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/ForumIcon.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/ForumIcon.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { SvgIcon } from '@mui/material';
+
+export const ForumIcon = ({ ...props }: { [prop: string]: unknown }) => {
+    return (
+        <SvgIcon width="72.696" height="69.501" viewBox="0 0 72.696 69.501" {...props}>
+            <g fill="#458686" stroke="#fff" stroke-width="2">
+                <rect width="65" height="35" rx="10" stroke="none" />
+                <rect x="1" y="1" width="63" height="33" rx="9" fill="none" />
+            </g>
+            <g transform="translate(72.696 69.501) rotate(180)">
+                <g transform="translate(0 0)">
+                    <g fill="#9be2df" stroke="#fff" stroke-width="1">
+                        <rect width="65" height="35" rx="10" stroke="none" />
+                        <rect x="0.5" y="0.5" width="64" height="34" rx="9.5" fill="none" />
+                    </g>
+                    <path
+                        d="M18.449,0s-7.276,32.853-7.82,20.193S0,.278,0,.278"
+                        transform="translate(37.175 33.042)"
+                        fill="#9be2df"
+                    />
+                </g>
+            </g>
+            <path
+                d="M-22838.951-17532s-8.5,36.906-9.141,22.686-12.42-22.373-12.42-22.373"
+                transform="translate(22893.012 17560.459)"
+                fill="#458686"
+            />
+        </SvgIcon>
+    );
+};

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/IconBox.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/IconBox.tsx
@@ -13,7 +13,7 @@ export const IconBox = ({ children }: { children: ReactNode }) => {
         <>
             <IconButton
                 ref={iconRef}
-                sx={{ marginTop: '-0.8em', marginLeft: '1em', color: '#458686' }}
+                sx={{ marginTop: '-0.5em', marginLeft: '1em', color: '#458686' }}
                 onClick={() => setOpen(!open)}
             >
                 <ForumIcon fontSize="large" />

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/IconBox.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/IconBox.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useRef, useState } from 'react';
 import { Box, ClickAwayListener, IconButton, Paper } from '@mui/material';
-import ForumIcon from '@mui/icons-material/Forum';
 import { Arrow, PopperArrow } from 'components/common/MetPopper';
 import CloseIcon from '@mui/icons-material/Close';
+import { ForumIcon } from './ForumIcon';
 
 export const IconBox = ({ children }: { children: ReactNode }) => {
     const iconRef = useRef<HTMLButtonElement | null>(null);

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhaseBox.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhaseBox.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useContext, useRef, useState } from 'react';
-import { Box, Grid, Link, Popover } from '@mui/material';
+import { Box, Grid, Link, Popover, SxProps, Theme } from '@mui/material';
 import { MetHeader4, MetPaper, MetSmallText } from 'components/common';
 import { PhaseContext } from '.';
 import { When } from 'react-if';
@@ -8,11 +8,20 @@ import { IconBox } from './IconBox';
 interface PhaseBoxProps {
     title: string;
     backgroundColor?: string;
-    readMoreBox?: ReactNode;
+    learnMoreBox?: ReactNode;
     iconBox?: ReactNode;
     children?: ReactNode;
+    border?: string;
+    sx?: SxProps<Theme>;
 }
-export const PhaseBox = ({ title, backgroundColor = 'white', readMoreBox, iconBox }: PhaseBoxProps) => {
+export const PhaseBox = ({
+    title,
+    backgroundColor = 'white',
+    learnMoreBox,
+    iconBox,
+    border = 'none',
+    sx = {},
+}: PhaseBoxProps) => {
     const [readMoreOpen, setReadMoreOpen] = useState(false);
     const { anchorEl, setAnchorEl } = useContext(PhaseContext);
 
@@ -25,15 +34,18 @@ export const PhaseBox = ({ title, backgroundColor = 'white', readMoreBox, iconBo
     return (
         <>
             <MetPaper
-                sx={{
-                    borderRadius: 0,
-                    border: 'none',
-                    backgroundColor: backgroundColor,
-                    height: '10em',
-                    marginBottom: '2em',
-                    maxWidth: { xl: '16%', xs: 'auto' },
-                    minWidth: { xl: '10%', xs: 'auto' },
-                }}
+                sx={[
+                    {
+                        borderRadius: 0,
+                        border: border,
+                        backgroundColor: backgroundColor,
+                        height: '10em',
+                        marginBottom: '2em',
+                        maxWidth: { xl: '16%', xs: 'auto' },
+                        minWidth: { xl: '10%', xs: 'auto' },
+                    },
+                    { ...sx },
+                ]}
             >
                 <Grid container direction="row" spacing={0}>
                     <Grid item xs={12}>
@@ -52,13 +64,15 @@ export const PhaseBox = ({ title, backgroundColor = 'white', readMoreBox, iconBo
                                 </Grid>
                                 <Grid item container direction="row" justifyContent="flex-end">
                                     <Grid item>
-                                        <MetSmallText
-                                            component={Link}
-                                            sx={{ color: 'white', cursor: 'pointer' }}
+                                        <Link
+                                            component={MetSmallText}
+                                            sx={{ cursor: 'pointer', color: 'white', ':hover': { fontWeight: 'bold' } }}
                                             onClick={handleReadMoreClick}
+                                            color="inherit"
+                                            underline="always"
                                         >
-                                            Read more
-                                        </MetSmallText>
+                                            Learn more
+                                        </Link>
                                     </Grid>
                                 </Grid>
                             </Grid>
@@ -72,7 +86,7 @@ export const PhaseBox = ({ title, backgroundColor = 'white', readMoreBox, iconBo
                 </Grid>
             </MetPaper>
 
-            <When condition={Boolean(readMoreBox)}>
+            <When condition={Boolean(learnMoreBox)}>
                 <Popover
                     id={readMoreOpen ? `${title}-readmore-popover` : undefined}
                     open={readMoreOpen}
@@ -89,7 +103,7 @@ export const PhaseBox = ({ title, backgroundColor = 'white', readMoreBox, iconBo
                         },
                     }}
                 >
-                    {readMoreBox}
+                    {learnMoreBox}
                 </Popover>
             </When>
         </>

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhaseBox.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhaseBox.tsx
@@ -1,9 +1,11 @@
 import React, { ReactNode, useContext, useRef, useState } from 'react';
-import { Box, Grid, Link, Popover, SxProps, Theme } from '@mui/material';
+import { Box, Grid, Link, Popover, Stack, SxProps, Theme } from '@mui/material';
 import { MetHeader4, MetPaper, MetSmallText } from 'components/common';
 import { PhaseContext } from '.';
-import { When } from 'react-if';
+import { Else, If, Then, When } from 'react-if';
 import { IconBox } from './IconBox';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import { EngagementPhases } from 'models/engagementPhases';
 
 interface PhaseBoxProps {
     title: string;
@@ -13,14 +15,18 @@ interface PhaseBoxProps {
     children?: ReactNode;
     border?: string;
     sx?: SxProps<Theme>;
+    isCurrentPhase: boolean;
+    currentPhase: number;
 }
 export const PhaseBox = ({
     title,
     backgroundColor = 'white',
     learnMoreBox,
     iconBox,
+    currentPhase,
     border = 'none',
     sx = {},
+    isCurrentPhase = false,
 }: PhaseBoxProps) => {
     const [readMoreOpen, setReadMoreOpen] = useState(false);
     const { anchorEl, setAnchorEl } = useContext(PhaseContext);
@@ -32,7 +38,28 @@ export const PhaseBox = ({
         setReadMoreOpen(true);
     };
     return (
-        <>
+        <Stack
+            direction="column"
+            sx={{
+                maxWidth: { xl: '20%', md: 'auto' },
+                minWidth: { xl: '10%', md: 'auto' },
+            }}
+        >
+            <When condition={currentPhase !== EngagementPhases.Standalone}>
+                <If condition={isCurrentPhase}>
+                    <Then>
+                        <Stack direction="row" height="3em" alignItems={'center'}>
+                            <Box marginLeft={'1em'} color="#D8292F">
+                                <LocationOnIcon fontSize="large" />
+                            </Box>
+                            <MetSmallText sx={{ fontStyle: 'italic', overflow: 'visible' }}>Current Phase</MetSmallText>
+                        </Stack>
+                    </Then>
+                    <Else>
+                        <span style={{ marginBottom: '3em' }} />
+                    </Else>
+                </If>
+            </When>
             <MetPaper
                 sx={[
                     {
@@ -40,9 +67,6 @@ export const PhaseBox = ({
                         border: border,
                         backgroundColor: backgroundColor,
                         height: '10em',
-                        marginBottom: '2em',
-                        maxWidth: { xl: '16%', xs: 'auto' },
-                        minWidth: { xl: '10%', xs: 'auto' },
                     },
                     { ...sx },
                 ]}
@@ -78,13 +102,13 @@ export const PhaseBox = ({
                             </Grid>
                         </Box>
                     </Grid>
-                    <Grid item xs={12}>
-                        <When condition={Boolean(iconBox)}>
-                            <IconBox>{iconBox}</IconBox>
-                        </When>
-                    </Grid>
                 </Grid>
             </MetPaper>
+            <When condition={Boolean(iconBox)}>
+                <Box>
+                    <IconBox>{iconBox}</IconBox>
+                </Box>
+            </When>
 
             <When condition={Boolean(learnMoreBox)}>
                 <Popover
@@ -106,6 +130,6 @@ export const PhaseBox = ({
                     {learnMoreBox}
                 </Popover>
             </When>
-        </>
+        </Stack>
     );
 };

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/EngagementPhaseMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/EngagementPhaseMobile.tsx
@@ -17,7 +17,7 @@ export const EngagementPhaseMobile = ({
         <PhaseBoxMobile
             title={title}
             backgroundColor={backgroundColor}
-            readMoreBox={
+            learnMoreBox={
                 <ReadMoreBox backgroundColor={accordionBackground} sx={{ p: 0, margin: 0 }}>
                     <Grid
                         sx={{ color: 'black' }}

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
@@ -12,7 +12,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 interface PhaseBoxProps {
     title: string;
     backgroundColor?: string;
-    readMoreBox?: ReactNode;
+    learnMoreBox?: ReactNode;
     iconBox?: ReactNode;
     children?: ReactNode;
     readMoreBackground?: string;
@@ -21,7 +21,7 @@ interface PhaseBoxProps {
 export const PhaseBoxMobile = ({
     title,
     backgroundColor = 'white',
-    readMoreBox,
+    learnMoreBox,
     readMoreBackground,
     iconBox,
     accordionBackground,
@@ -74,7 +74,7 @@ export const PhaseBoxMobile = ({
                                         >
                                             <Typography sx={{ color: 'black' }}>Learn More</Typography>
                                         </AccordionSummary>
-                                        <AccordionDetails>{readMoreBox}</AccordionDetails>
+                                        <AccordionDetails>{learnMoreBox}</AccordionDetails>
                                     </Accordion>
                                 </Grid>
                             </Grid>
@@ -82,7 +82,7 @@ export const PhaseBoxMobile = ({
                     </Grid>
                 </Grid>
             </MetPaper>
-            <When condition={Boolean(readMoreBox)}>
+            <When condition={Boolean(learnMoreBox)}>
                 <Popover
                     id={readMoreOpen ? `${title}-readmore-popover` : undefined}
                     open={readMoreOpen}
@@ -98,7 +98,7 @@ export const PhaseBoxMobile = ({
                         },
                     }}
                 >
-                    {readMoreBox}
+                    {learnMoreBox}
                 </Popover>
             </When>
         </>

--- a/met-web/src/models/engagementPhases.tsx
+++ b/met-web/src/models/engagementPhases.tsx
@@ -1,16 +1,20 @@
+import React, { ReactNode } from 'react';
 import { Grid } from '@mui/material';
 import { MetParagraph } from 'components/common';
-import React, { ReactNode } from 'react';
 
 export enum EngagementPhases {
     Standalone = 0,
     EarlyEngagement = 1,
-    ProcessPlanning = 2,
-    ApplicationDevelopmentReview = 3,
-    EffectsAssessmentRecomendation = 4,
+    ReadinessDecision = 2,
+    ProcessPlanning = 3,
+    ApplicationDevelopmentReview = 4,
+    Recommendation = 5,
+    Decision = 6,
+    PostCertificate = 7,
 }
 
 export interface ProcessStageProps {
+    phaseId: number;
     backgroundColor: string;
     learnMoreBackgroundColor: string;
     title: string;
@@ -19,12 +23,18 @@ export interface ProcessStageProps {
     accordionBackground?: string;
 }
 
+export const PAST_PHASE = {
+    backgroundColor: '#7B8283',
+    borderColor: '#565656',
+};
+
 export const ENGAGEMENT_PHASES = {
     EarlyEngagement: {
+        phaseId: EngagementPhases.EarlyEngagement,
         title: 'Early Engagement',
         backgroundColor: '#54858D',
         accordionBackground: '#A8D5DD',
-        learnMoreBackgroundColor: '#D1D9DD',
+        learnMoreBackgroundColor: '#A8D5DD',
         learnMoreText: (
             <Grid item xs={12}>
                 <MetParagraph>
@@ -37,9 +47,10 @@ export const ENGAGEMENT_PHASES = {
             'Tell us about your interests, issues and concerns about the initial proposal for the project. How would the project as proposed personally affect you, your family, or your community? Tell us how you want to provide feedback and be involved in the rest of the assessment process.',
     },
     ReadinessDecision: {
+        phaseId: EngagementPhases.ReadinessDecision,
         title: 'Readiness Decision',
         backgroundColor: '#DA6D65',
-        learnMoreBackgroundColor: '#FCE5E4',
+        learnMoreBackgroundColor: '#EFBDB9',
         accordionBackground: '#EFBDB9',
         learnMoreText: (
             <Grid item xs={12}>
@@ -53,10 +64,11 @@ export const ENGAGEMENT_PHASES = {
             'Decision point: EAO can recommend project proceed to assessment, be exempted or terminated from the process.',
     },
     ProcessPlanning: {
+        phaseId: EngagementPhases.ProcessPlanning,
         title: 'Process Planning',
         backgroundColor: '#043673',
         accordionBackground: '#89A4C4',
-        learnMoreBackgroundColor: '#C8CAD6',
+        learnMoreBackgroundColor: '#89A4C4',
         learnMoreText: (
             <Grid item xs={12}>
                 <MetParagraph>
@@ -70,10 +82,11 @@ export const ENGAGEMENT_PHASES = {
             'Tell us what you think of the draft process order and assessment plan. Have we captured everything that should be assessed and the information required? Are the timelines and assessment methods appropriate? What do you think of how we plan to collect feedback from the public?',
     },
     AppDevReview: {
+        phaseId: EngagementPhases.ApplicationDevelopmentReview,
         title: 'Application Development & Review',
         backgroundColor: '#4D95D0',
         accordionBackground: '#9AC0E0',
-        learnMoreBackgroundColor: '#D7EBF8',
+        learnMoreBackgroundColor: '#9AC0E0',
         learnMoreText: (
             <>
                 <Grid item xs={12}>
@@ -98,11 +111,12 @@ export const ENGAGEMENT_PHASES = {
         popOverText:
             'Tell us what you think about the proponent’s application. Are there effects that haven’t been fully considered? Now that you have the proponent’s full assessment, is there anything new or is still raising concerns for you ? Do you think something has been assessed inaccurately?',
     },
-    EffectAssessmentReview: {
-        title: 'Effect Assessment & Review',
+    Recommendation: {
+        phaseId: EngagementPhases.Recommendation,
+        title: 'Recommendation',
         backgroundColor: '#E7A913',
         accordionBackground: '#EDC970',
-        learnMoreBackgroundColor: '#FAEACC',
+        learnMoreBackgroundColor: '#EDC970',
         learnMoreText: (
             <>
                 <Grid item xs={12}>
@@ -125,10 +139,11 @@ export const ENGAGEMENT_PHASES = {
             ' Tell us what you think about the package of draft decision materials that will be provided to Ministers, who will decide whether or not to issue an environmental assessment certificate. Is anything missing? Has something been assessed incorrectly? What should the ministers consider that isn’t already included?',
     },
     Decision: {
+        phaseId: EngagementPhases.Decision,
         title: 'Decision',
         backgroundColor: '#6A54A3',
         accordionBackground: '#AAA2BF',
-        learnMoreBackgroundColor: '#D6D1E7',
+        learnMoreBackgroundColor: '#AAA2BF',
         learnMoreText: (
             <Grid item xs={12}>
                 <MetParagraph sx={{ fontStyle: 'italic' }}>
@@ -139,10 +154,11 @@ export const ENGAGEMENT_PHASES = {
         ),
     },
     PostCertificate: {
+        phaseId: EngagementPhases.PostCertificate,
         title: 'Post-Certificate',
         backgroundColor: '#A6BB2E',
         accordionBackground: '#D5DE9E',
-        learnMoreBackgroundColor: '#EDF2D4',
+        learnMoreBackgroundColor: '#D5DE9E',
         learnMoreText: (
             <>
                 <Grid item xs={12}>


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/979
*Description of changes:*

- Grey out past phases
- Add custom forum icon
- Add current phase indicator
- Update background color for learn more boxes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
