### PR TITLE
Add current phase Icon and background color for mobile process widget

### DIFF
--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhaseBox.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhaseBox.tsx
@@ -49,7 +49,7 @@ export const PhaseBox = ({
                 <If condition={isCurrentPhase}>
                     <Then>
                         <Stack direction="row" height="3em" alignItems={'center'}>
-                            <Box marginLeft={'1em'} color="#D8292F">
+                            <Box marginLeft={{ xs: '0', lg: '1em' }} color="#D8292F">
                                 <LocationOnIcon fontSize="large" />
                             </Box>
                             <MetSmallText sx={{ fontStyle: 'italic', overflow: 'visible' }}>Current Phase</MetSmallText>

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/EngagementPhaseMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/EngagementPhaseMobile.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { Grid } from '@mui/material';
-import { MetParagraph } from 'components/common';
+import { MetHeader4, MetParagraph } from 'components/common';
 import { EngagementPhases, PAST_PHASE, ProcessStageProps } from 'models/engagementPhases';
 import { PhaseBoxMobile } from './PhaseBoxMobile';
 import { ReadMoreBox } from '../ReadMoreBox';
@@ -31,7 +31,7 @@ export const EngagementPhaseMobile = ({
                     sx={{ p: 0, margin: 0 }}
                 >
                     <Grid
-                        sx={{ color: isCurrent ? 'black' : 'white' }}
+                        sx={[!isCurrent && { color: 'white' }]}
                         container
                         direction="row"
                         justifyContent="flex-start"
@@ -39,7 +39,7 @@ export const EngagementPhaseMobile = ({
                         spacing={1}
                     >
                         <Grid item xs={12}>
-                            <MetParagraph sx={{ fontWeight: 'bold', fontSize: '1.3rem' }}>{title}</MetParagraph>
+                            <MetHeader4 bold>{title}</MetHeader4>
                         </Grid>
                         {learnMoreText}
                     </Grid>

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/EngagementPhaseMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/EngagementPhaseMobile.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Grid } from '@mui/material';
 import { MetParagraph } from 'components/common';
+import { EngagementPhases, PAST_PHASE, ProcessStageProps } from 'models/engagementPhases';
 import { PhaseBoxMobile } from './PhaseBoxMobile';
 import { ReadMoreBox } from '../ReadMoreBox';
-import { ProcessStageProps } from 'models/engagementPhases';
+import { ActionContext } from 'components/engagement/view/ActionContext';
+import { Widget, WidgetType } from 'models/widget';
 
 export const EngagementPhaseMobile = ({
     backgroundColor,
@@ -12,15 +14,24 @@ export const EngagementPhaseMobile = ({
     learnMoreText,
     popOverText,
     accordionBackground,
+    phaseId,
 }: ProcessStageProps) => {
+    const { widgets } = useContext(ActionContext);
+    const phasesWidget = widgets.find((widget: Widget) => widget.widget_type_id === WidgetType.Phases);
+    const currentPhase = phasesWidget?.items[0]?.widget_data_id || EngagementPhases.Standalone;
+    const isCurrent = phaseId >= currentPhase;
+
     return (
         <PhaseBoxMobile
             title={title}
-            backgroundColor={backgroundColor}
+            backgroundColor={isCurrent ? backgroundColor : PAST_PHASE.backgroundColor}
             learnMoreBox={
-                <ReadMoreBox backgroundColor={accordionBackground} sx={{ p: 0, margin: 0 }}>
+                <ReadMoreBox
+                    backgroundColor={isCurrent ? accordionBackground : PAST_PHASE.backgroundColor}
+                    sx={{ p: 0, margin: 0 }}
+                >
                     <Grid
-                        sx={{ color: 'black' }}
+                        sx={{ color: isCurrent ? 'black' : 'white' }}
                         container
                         direction="row"
                         justifyContent="flex-start"
@@ -28,16 +39,17 @@ export const EngagementPhaseMobile = ({
                         spacing={1}
                     >
                         <Grid item xs={12}>
-                            <MetParagraph sx={{ fontWeight: 'bold', fontSize: '1.3rem', color: 'black' }}>
-                                {title}
-                            </MetParagraph>
+                            <MetParagraph sx={{ fontWeight: 'bold', fontSize: '1.3rem' }}>{title}</MetParagraph>
                         </Grid>
                         {learnMoreText}
                     </Grid>
                 </ReadMoreBox>
             }
-            accordionBackground={accordionBackground}
+            accordionBackground={isCurrent ? accordionBackground : PAST_PHASE.backgroundColor}
             iconBox={popOverText ? <MetParagraph>{popOverText}</MetParagraph> : false}
+            isCurrentPhase={phaseId === currentPhase}
+            isCurrent={isCurrent}
+            currentPhase={currentPhase}
         />
     );
 };

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
@@ -91,9 +91,7 @@ export const PhaseBoxMobile = ({
                                             aria-controls="panel1a-content"
                                             id="panel1a-header"
                                         >
-                                            <Typography sx={{ color: isCurrent ? 'black' : 'white' }}>
-                                                Learn More
-                                            </Typography>
+                                            <Typography sx={[!isCurrent && { color: 'white' }]}>Learn More</Typography>
                                         </AccordionSummary>
                                         <AccordionDetails>{learnMoreBox}</AccordionDetails>
                                     </Accordion>

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
@@ -1,14 +1,15 @@
-import React, { ReactNode, useRef, useState } from 'react';
-import { Box, Grid, Popover } from '@mui/material';
+import React, { ReactNode, useRef } from 'react';
+import { Box, Grid, Stack } from '@mui/material';
 import { MetHeader4, MetPaper } from 'components/common';
-import { When } from 'react-if';
 import { IconBox } from '../IconBox';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-
+import { If, Then, When } from 'react-if';
+import LocationOn from '@mui/icons-material/LocationOn';
+import { EngagementPhases } from 'models/engagementPhases';
 interface PhaseBoxProps {
     title: string;
     backgroundColor?: string;
@@ -17,6 +18,9 @@ interface PhaseBoxProps {
     children?: ReactNode;
     readMoreBackground?: string;
     accordionBackground?: string;
+    isCurrentPhase: boolean;
+    currentPhase: number;
+    isCurrent: boolean;
 }
 export const PhaseBoxMobile = ({
     title,
@@ -25,8 +29,10 @@ export const PhaseBoxMobile = ({
     readMoreBackground,
     iconBox,
     accordionBackground,
+    isCurrentPhase = false,
+    currentPhase,
+    isCurrent,
 }: PhaseBoxProps) => {
-    const [readMoreOpen, setReadMoreOpen] = useState(false);
     const PhaseBoxRef = useRef<HTMLButtonElement | null>(null);
 
     return (
@@ -53,9 +59,20 @@ export const PhaseBoxMobile = ({
                         >
                             <Grid container direction="column" justifyContent="space-between" height="100%" spacing={2}>
                                 <Grid item>
-                                    <MetHeader4 bold sx={{ color: 'white' }}>
-                                        {title}
-                                    </MetHeader4>
+                                    <Stack direction="row">
+                                        <MetHeader4 bold sx={{ color: 'white' }}>
+                                            {title}
+                                        </MetHeader4>
+                                        <When condition={currentPhase !== EngagementPhases.Standalone}>
+                                            <If condition={isCurrentPhase}>
+                                                <Then>
+                                                    <Box marginLeft={'1em'} color="#D8292F">
+                                                        <LocationOn fontSize="large" />
+                                                    </Box>
+                                                </Then>
+                                            </If>
+                                        </When>
+                                    </Stack>
                                 </Grid>
                                 <Grid item container xs={12}>
                                     <Grid item xs={8}></Grid>
@@ -68,11 +85,15 @@ export const PhaseBoxMobile = ({
                                 <Grid item container direction="row" xs={12} justifyContent="flex-start">
                                     <Accordion sx={{ background: accordionBackground }}>
                                         <AccordionSummary
-                                            expandIcon={<ExpandMoreIcon htmlColor="#000000" />}
+                                            expandIcon={
+                                                <ExpandMoreIcon htmlColor={isCurrent ? '#000000' : '#FFFFFF'} />
+                                            }
                                             aria-controls="panel1a-content"
                                             id="panel1a-header"
                                         >
-                                            <Typography sx={{ color: 'black' }}>Learn More</Typography>
+                                            <Typography sx={{ color: isCurrent ? 'black' : 'white' }}>
+                                                Learn More
+                                            </Typography>
                                         </AccordionSummary>
                                         <AccordionDetails>{learnMoreBox}</AccordionDetails>
                                     </Accordion>

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/PhasesWidgetMobile/PhaseBoxMobile.tsx
@@ -82,25 +82,6 @@ export const PhaseBoxMobile = ({
                     </Grid>
                 </Grid>
             </MetPaper>
-            <When condition={Boolean(readMoreBox)}>
-                <Popover
-                    id={readMoreOpen ? `${title}-readmore-popover` : undefined}
-                    open={readMoreOpen}
-                    onClose={() => setReadMoreOpen(false)}
-                    anchorOrigin={{
-                        vertical: 'top',
-                        horizontal: 'right',
-                    }}
-                    elevation={0}
-                    PaperProps={{
-                        sx: {
-                            borderRadius: 0,
-                        },
-                    }}
-                >
-                    {readMoreBox}
-                </Popover>
-            </When>
         </>
     );
 };

--- a/met-web/src/components/engagement/view/widgets/PhasesWidget/index.tsx
+++ b/met-web/src/components/engagement/view/widgets/PhasesWidget/index.tsx
@@ -5,6 +5,7 @@ import { WidgetType } from 'models/widget';
 import { ActionContext } from '../../ActionContext';
 import { EngagementPhase } from './EngagementPhase';
 import { ENGAGEMENT_PHASES } from 'models/engagementPhases';
+import { ForumIcon } from './ForumIcon';
 
 interface PhaseContextProps {
     anchorEl: HTMLButtonElement | null;
@@ -47,6 +48,7 @@ export const PhasesWidget = () => {
                         <MetBody>
                             Click on the sections below to expand them and learn more about each EA process phase. You
                             can also learn more about each engagement period by clicking the engagement icon.
+                            {<ForumIcon />}
                         </MetBody>
                     </Grid>
                     <Grid item xs={12} sx={{ maxWidth: '99%' }}>


### PR DESCRIPTION
*Issue #992 :*
https://github.com/bcgov/met-public/issues/#992

-Add Icon for current phase

-Add background color for phases that are not in the current phase

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
