### PR TITLE
Remove rich description & content as mandatory fields for Engagement Form

### DIFF
--- a/met-api/src/met_api/schemas/engagement.py
+++ b/met-api/src/met_api/schemas/engagement.py
@@ -24,18 +24,8 @@ class EngagementSchema(Schema):
 
     id = fields.Int(data_key='id')
     name = fields.Str(data_key='name', required=True, validate=validate.Length(min=1, error='Name cannot be blank'))
-    description = fields.Str(
-        data_key='description',
-        required=True,
-        validate=validate.Length(
-            min=1,
-            error='Description cannot be blank'))
-    rich_description = fields.Str(
-        data_key='rich_description',
-        required=True,
-        validate=validate.Length(
-            min=1,
-            error='Rich description cannot be blank'))
+    description = fields.Str(data_key='description')
+    rich_description = fields.Str(data_key='rich_description')
     start_date = fields.Date(data_key='start_date', required=True)
     end_date = fields.Date(data_key='end_date', required=True)
     status_id = fields.Int(data_key='status_id')
@@ -45,18 +35,8 @@ class EngagementSchema(Schema):
     updated_date = fields.Str(data_key='updated_date')
     published_date = fields.Str(data_key='published_date')
     scheduled_date = fields.Str(data_key='scheduled_date')
-    content = fields.Str(
-        data_key='content',
-        required=True,
-        validate=validate.Length(
-            min=1,
-            error='Content cannot be blank'))
-    rich_content = fields.Str(
-        data_key='rich_content',
-        required=True,
-        validate=validate.Length(
-            min=1,
-            error='Rich Content cannot be blank'))
+    content = fields.Str(data_key='content')
+    rich_content = fields.Str(data_key='rich_content')
     banner_filename = fields.Str(data_key='banner_filename')
     engagement_status = fields.Nested(EngagementStatusSchema)
     surveys = fields.List(fields.Nested(EngagementSurveySchema))

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -98,8 +98,7 @@ class EngagementService:
     @staticmethod
     def validate_fields(data):
         """Validate all fields."""
-        empty_fields = [not data[field] for field in ['name', 'description', 'rich_description',
-                                                      'start_date', 'end_date']]
+        empty_fields = [not data[field] for field in ['name', 'start_date', 'end_date']]
 
         if data['start_date'] > data['end_date']:
             raise ValueError('Start date cannot be after End date')

--- a/met-web/src/components/common/Modals/Schedule/index.tsx
+++ b/met-web/src/components/common/Modals/Schedule/index.tsx
@@ -23,11 +23,16 @@ const ScheduleModal = ({ reschedule, open, updateModal }: ScheduleModalProps) =>
     const [scheduledDate, setScheduledDate] = useState<Dayjs | null>(dayjs(Date.now()));
     const { savedEngagement, scheduleEngagement } = useContext(ActionContext);
     const dispatch = useAppDispatch();
-    const isValid =
-        savedEngagement.surveys.length === 0 &&
-        savedEngagement.content &&
-        savedEngagement.description &&
-        savedEngagement.banner_url;
+
+    const isEngagementReady = () => {
+        return (
+            savedEngagement.surveys.length === 0 &&
+            savedEngagement.content &&
+            savedEngagement.description &&
+            savedEngagement.banner_url
+        );
+    };
+
     const handleChange = (newDate: Dayjs | null) => {
         if (newDate != null) {
             setScheduledDate(newDate);
@@ -49,7 +54,7 @@ const ScheduleModal = ({ reschedule, open, updateModal }: ScheduleModalProps) =>
     };
 
     const handleSchedule = async () => {
-        if (!isValid) {
+        if (!isEngagementReady()) {
             dispatch(
                 openNotification({
                     severity: 'error',

--- a/met-web/src/components/common/Modals/Schedule/index.tsx
+++ b/met-web/src/components/common/Modals/Schedule/index.tsx
@@ -23,7 +23,11 @@ const ScheduleModal = ({ reschedule, open, updateModal }: ScheduleModalProps) =>
     const [scheduledDate, setScheduledDate] = useState<Dayjs | null>(dayjs(Date.now()));
     const { savedEngagement, scheduleEngagement } = useContext(ActionContext);
     const dispatch = useAppDispatch();
-
+    const isValid =
+        savedEngagement.surveys.length === 0 &&
+        savedEngagement.content &&
+        savedEngagement.description &&
+        savedEngagement.banner_url;
     const handleChange = (newDate: Dayjs | null) => {
         if (newDate != null) {
             setScheduledDate(newDate);
@@ -45,11 +49,11 @@ const ScheduleModal = ({ reschedule, open, updateModal }: ScheduleModalProps) =>
     };
 
     const handleSchedule = async () => {
-        if (savedEngagement.surveys.length === 0) {
+        if (!isValid) {
             dispatch(
                 openNotification({
                     severity: 'error',
-                    text: 'Please add a survey to the engagement before scheduling it',
+                    text: 'Please complete engagement before scheduling it',
                 }),
             );
             return;

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -108,8 +108,8 @@ const EngagementForm = () => {
             name: !(name && name.length < 50),
             start_date: !start_date,
             end_date: !end_date,
-            description: !description,
-            content: !content,
+            description: false,
+            content: false,
         };
         setEngagementFormError(errors);
 

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -42,13 +42,11 @@ const EngagementForm = () => {
         setRichDescription(savedEngagement?.rich_description || '');
         setRichContent(savedEngagement?.rich_content || '');
     }, [savedEngagement]);
-    const { name, start_date, end_date, description, content } = engagementFormData;
+    const { name, start_date, end_date } = engagementFormData;
     const [engagementFormError, setEngagementFormError] = useState({
         name: false,
         start_date: false,
         end_date: false,
-        description: false,
-        content: false,
     });
 
     const getErrorMessage = () => {
@@ -79,7 +77,6 @@ const EngagementForm = () => {
 
         setEngagementFormError({
             ...engagementFormError,
-            description: false,
         });
     };
 
@@ -108,8 +105,6 @@ const EngagementForm = () => {
             name: !(name && name.length < 50),
             start_date: !start_date,
             end_date: !end_date,
-            description: false,
-            content: false,
         };
         setEngagementFormError(errors);
 

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -188,7 +188,7 @@ const EngagementForm = () => {
                     />
                 </Grid>
                 <Grid item xs={12} lg={8} md={6}>
-                    <MetLabel sx={{ marginBottom: '2px' }}>Engagement Name</MetLabel>
+                    <MetLabel sx={{ marginBottom: '2px' }}>Engagement Name {isNewEngagement ? '*' : ''}</MetLabel>
                     <TextField
                         id="engagement-name"
                         data-testid="engagement-form/name"
@@ -217,7 +217,7 @@ const EngagementForm = () => {
                     columnSpacing={2}
                 >
                     <Grid item xs={12}>
-                        <MetLabel>Engagement Date</MetLabel>
+                        <MetLabel>Engagement Date {isNewEngagement ? '*' : ''}</MetLabel>
                     </Grid>
 
                     <Grid item md={6} xs={12}>

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -174,7 +174,7 @@ const EngagementForm = () => {
                     />
                 </Grid>
                 <Grid item xs={12} lg={8} md={6}>
-                    <MetLabel sx={{ marginBottom: '2px' }}>Engagement Name *</MetLabel>
+                    <MetLabel sx={{ marginBottom: '2px' }}>Engagement Name </MetLabel>
                     <TextField
                         id="engagement-name"
                         data-testid="engagement-form/name"
@@ -203,7 +203,7 @@ const EngagementForm = () => {
                     columnSpacing={2}
                 >
                     <Grid item xs={12}>
-                        <MetLabel>Engagement Date *</MetLabel>
+                        <MetLabel>Engagement Date </MetLabel>
                     </Grid>
 
                     <Grid item md={6} xs={12}>

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -88,7 +88,6 @@ const EngagementForm = () => {
 
         setEngagementFormError({
             ...engagementFormError,
-            content: false,
         });
     };
 
@@ -266,8 +265,6 @@ const EngagementForm = () => {
                         setRawText={handleDescriptionChange}
                         handleEditorStateChange={handleRichDescriptionChange}
                         initialRawEditorState={savedEngagement.rich_description || ''}
-                        error={engagementFormError.description}
-                        helperText="Description cannot be empty"
                     />
                 </Grid>
 
@@ -290,8 +287,6 @@ const EngagementForm = () => {
                                     setRawText={handleContentChange}
                                     handleEditorStateChange={handleRichContentChange}
                                     initialRawEditorState={savedEngagement.rich_content || ''}
-                                    error={engagementFormError.content}
-                                    helperText="Content cannot be empty"
                                 />
                             </Grid>
                         </Grid>

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -74,20 +74,12 @@ const EngagementForm = () => {
             ...engagementFormData,
             description: rawText,
         });
-
-        setEngagementFormError({
-            ...engagementFormError,
-        });
     };
 
     const handleContentChange = (rawText: string) => {
         setEngagementFormData({
             ...engagementFormData,
             content: rawText,
-        });
-
-        setEngagementFormError({
-            ...engagementFormError,
         });
     };
 
@@ -182,7 +174,7 @@ const EngagementForm = () => {
                     />
                 </Grid>
                 <Grid item xs={12} lg={8} md={6}>
-                    <MetLabel sx={{ marginBottom: '2px' }}>Engagement Name {isNewEngagement ? '*' : ''}</MetLabel>
+                    <MetLabel sx={{ marginBottom: '2px' }}>Engagement Name *</MetLabel>
                     <TextField
                         id="engagement-name"
                         data-testid="engagement-form/name"
@@ -211,7 +203,7 @@ const EngagementForm = () => {
                     columnSpacing={2}
                 >
                     <Grid item xs={12}>
-                        <MetLabel>Engagement Date {isNewEngagement ? '*' : ''}</MetLabel>
+                        <MetLabel>Engagement Date *</MetLabel>
                     </Grid>
 
                     <Grid item md={6} xs={12}>

--- a/met-web/src/components/engagement/view/PreviewBanner.tsx
+++ b/met-web/src/components/engagement/view/PreviewBanner.tsx
@@ -6,10 +6,10 @@ import { EngagementStatus } from 'constants/engagementStatus';
 import { MetHeader1, PrimaryButton, SecondaryButton, MetBody } from 'components/common';
 import { useAppSelector } from 'hooks';
 import ImageIcon from '@mui/icons-material/Image';
-import PollIcon from '@mui/icons-material/Poll';
 import UnpublishedIcon from '@mui/icons-material/Unpublished';
 import IconButton from '@mui/material/IconButton';
 import ScheduleModal from 'components/common/Modals/Schedule';
+import ArticleIcon from '@mui/icons-material/Article';
 import { formatDate } from 'components/common/dateHelper';
 import { When } from 'react-if';
 
@@ -84,11 +84,45 @@ export const PreviewBanner = () => {
                                             onClick={() => navigate(`/surveys/create?engagementId=${engagementId}`)}
                                             aria-label="no survey"
                                         >
-                                            <PollIcon />
+                                            <ArticleIcon />
                                         </IconButton>
                                     </Grid>
                                     <Grid item xs={10} sm={10}>
                                         <MetBody>This engagement is missing a survey.</MetBody>
+                                    </Grid>
+                                </Grid>
+                            </When>
+                            <When condition={!savedEngagement.description}>
+                                <Grid container direction="row" alignItems="center" item xs={12} lg={8}>
+                                    <Grid item sm={0.5} xs={2}>
+                                        <IconButton
+                                            sx={{ padding: 0, margin: 0 }}
+                                            color="inherit"
+                                            onClick={() => navigate(`/engagements/${engagementId}/form`)}
+                                            aria-label="no description"
+                                        >
+                                            <ArticleIcon />
+                                        </IconButton>
+                                    </Grid>
+                                    <Grid item xs={10} sm={10}>
+                                        <MetBody>This engagement is missing a description.</MetBody>
+                                    </Grid>
+                                </Grid>
+                            </When>
+                            <When condition={!savedEngagement.content}>
+                                <Grid container direction="row" alignItems="center" item xs={12} lg={8}>
+                                    <Grid item sm={0.5} xs={2}>
+                                        <IconButton
+                                            sx={{ padding: 0, margin: 0 }}
+                                            color="inherit"
+                                            onClick={() => navigate(`/engagements/${engagementId}/form`)}
+                                            aria-label="no content"
+                                        >
+                                            <ArticleIcon />
+                                        </IconButton>
+                                    </Grid>
+                                    <Grid item xs={10} sm={10}>
+                                        <MetBody>This engagement is missing content.</MetBody>
                                     </Grid>
                                 </Grid>
                             </When>


### PR DESCRIPTION
*Issue #402 :*
https://github.com/bcgov/met-public/issues/402

- Remove description and content as mandatory fields for engagement creation
-Add indicator in preview page that content and description is missing
-Prevent scheduling if engagement has no description or content
-Update back end by removing description and content as required fields for db


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
