### PR TITLE
Make survey clone options text fields consistent

### DIFF
--- a/met-web/src/components/survey/create/CloneOptions.tsx
+++ b/met-web/src/components/survey/create/CloneOptions.tsx
@@ -166,6 +166,7 @@ const CloneOptions = () => {
                             fullWidth
                         />
                     )}
+                    size="small"
                     getOptionLabel={(engagement: Engagement) => engagement.name}
                     onChange={(_e: React.SyntheticEvent<Element, Event>, engagement: Engagement | null) => {
                         setSelectedEngagement(engagement);
@@ -174,7 +175,8 @@ const CloneOptions = () => {
                     disabled={loadingEngagements}
                 />
             </Grid>
-            <Grid item xs={12}>
+            <Grid item xs={6}></Grid>
+            <Grid item xs={6}>
                 <MetLabel sx={{ marginBottom: '2px' }}>Select Survey</MetLabel>
                 <Autocomplete
                     id="survey-selector"
@@ -189,6 +191,7 @@ const CloneOptions = () => {
                             fullWidth
                         />
                     )}
+                    size="small"
                     getOptionLabel={(survey: Survey) => survey.name}
                     value={selectedSurvey}
                     onChange={(_e: React.SyntheticEvent<Element, Event>, survey: Survey | null) =>
@@ -197,6 +200,7 @@ const CloneOptions = () => {
                     disabled={loadingSurveys}
                 />
             </Grid>
+            <Grid item xs={6}></Grid>
             <Grid item xs={6}>
                 <Stack direction="column" spacing={2}>
                     <MetLabel>Enter Survey Name</MetLabel>


### PR DESCRIPTION
*Issue #946 :*
https://github.com/bcgov/met-public/issues/946
-Consistent width & height between input fields for survey clone options

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/103138766/208135741-038ee5e1-6da1-4a1b-b424-844f49179512.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
