### PR TITLE
Fix document reordering

### DIFF
--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -29,6 +29,7 @@ class WidgetDocumentService:
     @staticmethod
     def _attach_file_nodes(docs, root):
         files = list(filter(lambda doc: doc.type == DocumentType.FILE.value, docs))
+        files.sort(key=lambda doc: doc.id)
         for file in files:
             props = WidgetDocumentService._fetch_props(file)
             parent_node = root
@@ -38,7 +39,9 @@ class WidgetDocumentService:
 
     @staticmethod
     def _attach_folder_nodes(docs, root):
+
         folders = list(filter(lambda doc: doc.type == DocumentType.FOLDER.value, docs))
+        folders.sort(key=lambda doc: doc.id)
         for folder in folders:
             props = WidgetDocumentService._fetch_props(folder)
             AnyNode(**props, parent=root)

--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -29,6 +29,7 @@ class WidgetDocumentService:
     @staticmethod
     def _attach_file_nodes(docs, root):
         files = list(filter(lambda doc: doc.type == DocumentType.FILE.value, docs))
+        files.sort(key=lambda doc: doc.id)
         for file in files:
             props = WidgetDocumentService._fetch_props(file)
             parent_node = root

--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -29,6 +29,7 @@ class WidgetDocumentService:
     @staticmethod
     def _attach_file_nodes(docs, root):
         files = list(filter(lambda doc: doc.type == DocumentType.FILE.value, docs))
+        files.sort(key=lambda doc: doc.id)
         for file in files:
             props = WidgetDocumentService._fetch_props(file)
             parent_node = root
@@ -40,6 +41,7 @@ class WidgetDocumentService:
     def _attach_folder_nodes(docs, root):
 
         folders = list(filter(lambda doc: doc.type == DocumentType.FOLDER.value, docs))
+        folders.sort(key=lambda doc: doc.id)
         for folder in folders:
             props = WidgetDocumentService._fetch_props(folder)
             AnyNode(**props, parent=root)

--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -29,7 +29,6 @@ class WidgetDocumentService:
     @staticmethod
     def _attach_file_nodes(docs, root):
         files = list(filter(lambda doc: doc.type == DocumentType.FILE.value, docs))
-        files.sort(key=lambda doc: doc.id)
         for file in files:
             props = WidgetDocumentService._fetch_props(file)
             parent_node = root
@@ -41,7 +40,6 @@ class WidgetDocumentService:
     def _attach_folder_nodes(docs, root):
 
         folders = list(filter(lambda doc: doc.type == DocumentType.FOLDER.value, docs))
-        folders.sort(key=lambda doc: doc.id)
         for folder in folders:
             props = WidgetDocumentService._fetch_props(folder)
             AnyNode(**props, parent=root)

--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -29,7 +29,6 @@ class WidgetDocumentService:
     @staticmethod
     def _attach_file_nodes(docs, root):
         files = list(filter(lambda doc: doc.type == DocumentType.FILE.value, docs))
-        files.sort(key=lambda doc: doc.id)
         for file in files:
             props = WidgetDocumentService._fetch_props(file)
             parent_node = root
@@ -39,9 +38,7 @@ class WidgetDocumentService:
 
     @staticmethod
     def _attach_folder_nodes(docs, root):
-
         folders = list(filter(lambda doc: doc.type == DocumentType.FOLDER.value, docs))
-        folders.sort(key=lambda doc: doc.id)
         for folder in folders:
             props = WidgetDocumentService._fetch_props(folder)
             AnyNode(**props, parent=root)

--- a/met-api/src/met_api/services/widget_documents_service.py
+++ b/met-api/src/met_api/services/widget_documents_service.py
@@ -40,6 +40,7 @@ class WidgetDocumentService:
     def _attach_folder_nodes(docs, root):
 
         folders = list(filter(lambda doc: doc.type == DocumentType.FOLDER.value, docs))
+        folders.sort(key=lambda doc: doc.id)
         for folder in folders:
             props = WidgetDocumentService._fetch_props(folder)
             AnyNode(**props, parent=root)

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -56,9 +56,10 @@ def test_get_all_by_widget_id(session):
     session.commit()
     expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
     assert len(expected_docs) == 2
-    
+
     
 def test_documents_by_widget_id(session):
+    """Assert that widget documents are sorted in ascending order."""
     widget = _create_widget()
     document1 = WidgetDocumentsModel(
         **TestWidgetDocumentInfo.document1
@@ -78,7 +79,6 @@ def test_documents_by_widget_id(session):
     session.commit()
     expected_docs = WidgetDocumentService.get_documents_by_widget_id(widget.id)
     assert(all(expected_docs[i].id <= expected_docs[i + 1].id for i in range(len(expected_docs) - 1)))
-
 
 
 def test_edit_widget_document(session):

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -48,6 +48,23 @@ def test_get_all_by_widget_id(session):
     document2 = WidgetDocumentsModel(
         **TestWidgetDocumentInfo.document2
     )
+    document1.widget_id = widget.id
+    document2.widget_id = widget.id
+    session.add(document1)
+    session.add(document2)
+    session.commit()
+    expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
+    assert len(expected_docs) == 2
+    
+    
+def test_documents_by_widget_id(session):
+    widget = _create_widget()
+    document1 = WidgetDocumentsModel(
+        **TestWidgetDocumentInfo.document1
+    )
+    document2 = WidgetDocumentsModel(
+        **TestWidgetDocumentInfo.document2
+    )
     document3 = WidgetDocumentsModel(
         **TestWidgetDocumentInfo.document3
     )
@@ -58,10 +75,9 @@ def test_get_all_by_widget_id(session):
     session.add(document2)
     session.add(document3)
     session.commit()
-
-    expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
+    expected_docs = WidgetDocumentsModel.get_documents_by_widget_id(widget.id)
     assert(all(expected_docs[i].id <= expected_docs[i + 1].id for i in range(len(expected_docs) - 1)))
-    assert len(expected_docs) == 2
+
 
 
 def test_edit_widget_document(session):

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -48,10 +48,15 @@ def test_get_all_by_widget_id(session):
     document2 = WidgetDocumentsModel(
         **TestWidgetDocumentInfo.document2
     )
+    document3 = WidgetDocumentsModel(
+        **TestWidgetDocumentInfo.document3
+    )
     document1.widget_id = widget.id
     document2.widget_id = widget.id
+    document3.widget_id = widget.id
     session.add(document1)
     session.add(document2)
+    session.add(document3)
     session.commit()
 
     expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -55,6 +55,7 @@ def test_get_all_by_widget_id(session):
     session.commit()
 
     expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
+    all(expected_docs[i].id <= expected_docs[i+1].id for i in range(len(expected_docs) - 1))
     assert len(expected_docs) == 2
 
 

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -55,7 +55,7 @@ def test_get_all_by_widget_id(session):
     session.commit()
 
     expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
-    all(expected_docs[i].id <= expected_docs[i+1].id for i in range(len(expected_docs) - 1))
+    all(expected_docs[i].id <= expected_docs[i + 1].id for i in range(len(expected_docs) - 1))
     assert len(expected_docs) == 2
 
 

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -57,7 +57,7 @@ def test_get_all_by_widget_id(session):
     expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
     assert len(expected_docs) == 2
 
-    
+
 def test_documents_by_widget_id(session):
     """Assert that widget documents are sorted in ascending order."""
     widget = _create_widget()

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -55,7 +55,7 @@ def test_get_all_by_widget_id(session):
     session.commit()
 
     expected_docs = WidgetDocumentsModel.get_all_by_widget_id(widget.id)
-    all(expected_docs[i].id <= expected_docs[i + 1].id for i in range(len(expected_docs) - 1))
+    assert(all(expected_docs[i].id <= expected_docs[i + 1].id for i in range(len(expected_docs) - 1)))
     assert len(expected_docs) == 2
 
 

--- a/met-api/tests/unit/models/test_widget_documents.py
+++ b/met-api/tests/unit/models/test_widget_documents.py
@@ -19,6 +19,7 @@ Test suite to ensure that the Engagement model routines are working as expected.
 from faker import Faker
 
 from met_api.models import WidgetDocuments as WidgetDocumentsModel
+from met_api.services.widget_documents_service import WidgetDocumentService
 from tests.utilities.factory_scenarios import TestWidgetDocumentInfo, TestWidgetInfo
 from tests.utilities.factory_utils import factory_engagement_model, factory_widget_model
 
@@ -75,7 +76,7 @@ def test_documents_by_widget_id(session):
     session.add(document2)
     session.add(document3)
     session.commit()
-    expected_docs = WidgetDocumentsModel.get_documents_by_widget_id(widget.id)
+    expected_docs = WidgetDocumentService.get_documents_by_widget_id(widget.id)
     assert(all(expected_docs[i].id <= expected_docs[i + 1].id for i in range(len(expected_docs) - 1)))
 
 

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -274,5 +274,3 @@ class TestWidgetDocumentInfo(dict, Enum):
         'url': fake.image_url(),
         'sort_index': 1,
     }
-    
-    

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -265,7 +265,7 @@ class TestWidgetDocumentInfo(dict, Enum):
         'url': fake.image_url(),
         'sort_index': 1,
     }
-    
+
     document3 = {
         'id': '3',
         'title': fake.file_name(extension='pdf'),

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -249,6 +249,7 @@ class TestWidgetDocumentInfo(dict, Enum):
     """Test scenarios of contact."""
 
     document1 = {
+        'id': '4',
         'title': fake.word(),
         'type': 'folder',
         'parent_document_id': None,
@@ -257,9 +258,21 @@ class TestWidgetDocumentInfo(dict, Enum):
     }
 
     document2 = {
+        'id': '2',
         'title': fake.file_name(extension='pdf'),
         'type': 'file',
         'parent_document_id': None,
         'url': fake.image_url(),
         'sort_index': 1,
     }
+    
+    document3 = {
+        'id': '3',
+        'title': fake.file_name(extension='pdf'),
+        'type': 'file',
+        'parent_document_id': None,
+        'url': fake.image_url(),
+        'sort_index': 1,
+    }
+    
+    


### PR DESCRIPTION
*Issue #1001 :*
https://github.com/bcgov/met-public/issues/1001

Expectation:
-When document folders or files are edited do not reorder the data files randomly.

Current version: 
-When documents are reordered they randomly shuffle order.

This pr:
-Sort folders by ascending id order to  make document order consistent in the widget tab 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
