### PR TITLE
survey block statuses tab updates

### DIFF
--- a/met-web/src/components/engagement/form/ActionContext.tsx
+++ b/met-web/src/components/engagement/form/ActionContext.tsx
@@ -92,7 +92,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
             const result = await postEngagement({
                 ...engagement,
                 banner_filename: uploadedBannerImageFileName,
-                status_block: statusBlockContent,
+                status_block: Object.keys(statusBlockContent[0]).length > 0 ? statusBlockContent : undefined,
             });
 
             dispatch(openNotification({ severity: 'success', text: 'Engagement Created Successfully' }));
@@ -129,7 +129,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
             const engagementEditsToPatch = updatedDiff(state, {
                 ...engagement,
                 banner_filename: uploadedBannerImageFileName,
-                status_block: statusBlockContent,
+                status_block: Object.keys(statusBlockContent[0]).length > 0 ? statusBlockContent : undefined,
             }) as PatchEngagementRequest;
 
             const updatedEngagement = await patchEngagement({
@@ -151,7 +151,11 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
     const [statusBlockContent, setstatusBlockContent] = useState([{}]);
     const handleStatusBlockChange = React.useCallback(
         (newArray: { survey_status: string; block_text: string }[]) => {
-            setstatusBlockContent(newArray);
+            // exclude content having empty block text
+            const filterContentList = newArray.filter(function (el) {
+                return el.block_text !== '';
+            });
+            setstatusBlockContent(filterContentList);
         },
         [statusBlockContent],
     );

--- a/met-web/src/components/engagement/form/AddSurveyBlock.tsx
+++ b/met-web/src/components/engagement/form/AddSurveyBlock.tsx
@@ -9,8 +9,13 @@ import { EngagementStatus } from 'constants/engagementStatus';
 import { unlinkSurvey } from 'services/surveyService';
 import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
 import AddSurveyBlockTabs from './AddSurveyBlockTabs';
+import { EngagementStatusBlock } from '../../../models/engagementStatusBlock';
 
-export const AddSurveyBlock = () => {
+export const AddSurveyBlock = ({
+    handleStatusBlockChange = (statusBlock: EngagementStatusBlock[]) => {
+        /* empty default method  */
+    },
+}) => {
     const { savedEngagement, fetchEngagement } = useContext(ActionContext);
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
@@ -97,7 +102,7 @@ export const AddSurveyBlock = () => {
                     sx={{ padding: '1em' }}
                 >
                     <Grid item xs={12}>
-                        <AddSurveyBlockTabs />
+                        <AddSurveyBlockTabs handleChange={handleStatusBlockChange} />
                     </Grid>
                     <Grid item xs={12} container direction="row" justifyContent="flex-end">
                         <SecondaryButton onClick={handleAddSurvey} disabled={savedEngagement.surveys.length > 0}>

--- a/met-web/src/components/engagement/form/AddSurveyBlockTabs.tsx
+++ b/met-web/src/components/engagement/form/AddSurveyBlockTabs.tsx
@@ -1,13 +1,46 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import TabContext from '@mui/lab/TabContext';
 import RichTextEditor from './RichTextEditor';
 import { MetTab, MetTabList, MetTabPanel } from './StyledTabComponents';
 import { upcomingText, openText, closedText } from 'constants/submissionStatusText';
 import { SubmissionStatus } from 'constants/engagementStatus';
+import { EngagementStatusBlock } from '../../../models/engagementStatusBlock';
 
-const AddSurveyBlockTabs = () => {
+const AddSurveyBlockTabs = ({
+    handleChange = (statusBlock: EngagementStatusBlock[]) => {
+        /* empty default method  */
+    },
+}) => {
+    // set initial value to upcoming
     const [value, setValue] = React.useState(SubmissionStatus[SubmissionStatus.Upcoming]);
+
+    // array to pass updated content to engagement context
+    const surveyBlockContent = [
+        { survey_status: SubmissionStatus[SubmissionStatus.Upcoming], block_text: '' },
+        { survey_status: SubmissionStatus[SubmissionStatus.Open], block_text: '' },
+        { survey_status: SubmissionStatus[SubmissionStatus.Closed], block_text: '' },
+    ];
+    const [contentList, setcontentList] = useState(surveyBlockContent);
+
+    // capture changes in richdescription
+    const handleRichDescriptionChange = (newState: string) => {
+        const updatedSurveyBlockContent = contentList.map((item) => {
+            if (item.survey_status === value && newState) {
+                item.block_text = newState;
+            }
+            return item;
+        });
+        setcontentList(updatedSurveyBlockContent);
+    };
+
+    // exclude content having empty block text
+    useEffect(() => {
+        const filterContentList = contentList.filter(function (el) {
+            return el.block_text != '';
+        });
+        handleChange(filterContentList);
+    }, [contentList]);
 
     return (
         <Box sx={{ width: '100%', typography: 'body1' }}>
@@ -25,13 +58,19 @@ const AddSurveyBlockTabs = () => {
                     </MetTabList>
                 </Box>
                 <MetTabPanel value={SubmissionStatus[SubmissionStatus.Upcoming]}>
-                    <RichTextEditor initialHTMLText={upcomingText} />
+                    <RichTextEditor
+                        handleEditorStateChange={handleRichDescriptionChange}
+                        initialHTMLText={upcomingText}
+                    />
                 </MetTabPanel>
                 <MetTabPanel value={SubmissionStatus[SubmissionStatus.Open]}>
-                    <RichTextEditor initialHTMLText={openText} />
+                    <RichTextEditor handleEditorStateChange={handleRichDescriptionChange} initialHTMLText={openText} />
                 </MetTabPanel>
                 <MetTabPanel value={SubmissionStatus[SubmissionStatus.Closed]}>
-                    <RichTextEditor initialHTMLText={closedText} />
+                    <RichTextEditor
+                        handleEditorStateChange={handleRichDescriptionChange}
+                        initialHTMLText={closedText}
+                    />
                 </MetTabPanel>
             </TabContext>
         </Box>

--- a/met-web/src/components/engagement/form/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementForm.tsx
@@ -15,6 +15,7 @@ const EngagementForm = () => {
         savedEngagement,
         engagementId,
         handleAddBannerImage,
+        handleStatusBlockChange,
     } = useContext(ActionContext);
 
     const navigate = useNavigate();
@@ -286,7 +287,7 @@ const EngagementForm = () => {
                 </Grid>
 
                 <Grid item xs={12}>
-                    <AddSurveyBlock />
+                    <AddSurveyBlock handleStatusBlockChange={handleStatusBlockChange} />
                 </Grid>
 
                 <Grid item xs={12}>

--- a/met-web/src/components/engagement/form/types.ts
+++ b/met-web/src/components/engagement/form/types.ts
@@ -1,4 +1,5 @@
 import { Engagement } from '../../../models/engagement';
+import { EngagementStatusBlock } from '../../../models/engagementStatusBlock';
 
 export interface EngagementContext {
     handleCreateEngagementRequest: (_engagement: EngagementForm) => Promise<Engagement>;
@@ -8,6 +9,7 @@ export interface EngagementContext {
     engagementId: string | undefined;
     loadingSavedEngagement: boolean;
     handleAddBannerImage: (_files: File[]) => void;
+    handleStatusBlockChange: (_statusBlock: EngagementStatusBlock[]) => void;
     fetchEngagement: () => void;
 }
 

--- a/met-web/src/models/engagement.ts
+++ b/met-web/src/models/engagement.ts
@@ -1,4 +1,5 @@
 import { Survey, SurveySubmissionData } from './survey';
+import { EngagementStatusBlock } from './engagementStatusBlock';
 import { Status } from './status';
 import { SubmissionStatus } from 'constants/engagementStatus';
 export interface Engagement {
@@ -22,6 +23,7 @@ export interface Engagement {
     engagement_status: Status;
     submission_status: SubmissionStatus;
     submissions_meta_data: SurveySubmissionData;
+    status_block: EngagementStatusBlock[];
 }
 
 export const createDefaultEngagement = (): Engagement => {
@@ -48,5 +50,6 @@ export const createDefaultEngagement = (): Engagement => {
         submissions_meta_data: {
             total: 0,
         },
+        status_block: [],
     };
 };

--- a/met-web/src/models/engagementStatusBlock.ts
+++ b/met-web/src/models/engagementStatusBlock.ts
@@ -1,0 +1,11 @@
+export interface EngagementStatusBlock {
+    survey_status: string;
+    block_text: string;
+}
+
+export const createDefaultStatusBlock = (): EngagementStatusBlock => {
+    return {
+        survey_status: '',
+        block_text: '',
+    };
+};

--- a/met-web/src/services/engagementService/types.ts
+++ b/met-web/src/services/engagementService/types.ts
@@ -13,6 +13,7 @@ export interface PostEngagementRequest {
     content: string;
     rich_content: string;
     banner_filename?: string;
+    status_block?: unknown[];
 }
 
 export interface PutEngagementRequest {
@@ -25,6 +26,7 @@ export interface PutEngagementRequest {
     content: string;
     rich_content: string;
     banner_filename?: string;
+    status_block?: unknown[];
 }
 
 export interface PatchEngagementRequest {
@@ -37,4 +39,5 @@ export interface PatchEngagementRequest {
     content?: string;
     rich_content?: string;
     banner_filename?: string;
+    status_block?: unknown[];
 }

--- a/met-web/tests/unit/components/engagement/EngagementForm.test.tsx
+++ b/met-web/tests/unit/components/engagement/EngagementForm.test.tsx
@@ -96,6 +96,10 @@ describe('Engagement form page tests', () => {
         const toDateInput = container.querySelector('input[name="end_date"]');
         expect(toDateInput).not.toBeNull();
         expect(toDateInput).toHaveAttribute('value', '');
+		
+        expect(screen.getByText('Upcoming')).toBeInTheDocument();
+		expect(screen.getByText('Open')).toBeInTheDocument();
+		expect(screen.getByText('Closed')).toBeInTheDocument();
 
         expect(container.querySelector('input[type="file"][accept="image/*"]')).not.toBeNull();
     });

--- a/met-web/tests/unit/components/engagement/EngagementForm.test.tsx
+++ b/met-web/tests/unit/components/engagement/EngagementForm.test.tsx
@@ -96,10 +96,10 @@ describe('Engagement form page tests', () => {
         const toDateInput = container.querySelector('input[name="end_date"]');
         expect(toDateInput).not.toBeNull();
         expect(toDateInput).toHaveAttribute('value', '');
-		
+
         expect(screen.getByText('Upcoming')).toBeInTheDocument();
-		expect(screen.getByText('Open')).toBeInTheDocument();
-		expect(screen.getByText('Closed')).toBeInTheDocument();
+        expect(screen.getByText('Open')).toBeInTheDocument();
+        expect(screen.getByText('Closed')).toBeInTheDocument();
 
         expect(container.querySelector('input[type="file"][accept="image/*"]')).not.toBeNull();
     });


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/397

*Description of changes:*
Changes made to 
- insert status blocks data to engagement status block table in case the default values are updated during engagement creation
- update status blocks data for an engagement for any changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
