### PR TITLE
fix to save the state for survey status block

### DIFF
--- a/met-web/src/components/engagement/form/AddSurveyBlockTabs.tsx
+++ b/met-web/src/components/engagement/form/AddSurveyBlockTabs.tsx
@@ -49,11 +49,11 @@ const AddSurveyBlockTabs = ({
         },
         {
             survey_status: SubmissionStatus[SubmissionStatus.Open],
-            block_text: savedUpcomingText ? savedOpenText : '',
+            block_text: savedOpenText ? savedOpenText : '',
         },
         {
             survey_status: SubmissionStatus[SubmissionStatus.Closed],
-            block_text: savedUpcomingText ? savedClosedText : '',
+            block_text: savedClosedText ? savedClosedText : '',
         },
     ];
 

--- a/met-web/src/components/engagement/form/AddSurveyBlockTabs.tsx
+++ b/met-web/src/components/engagement/form/AddSurveyBlockTabs.tsx
@@ -43,16 +43,36 @@ const AddSurveyBlockTabs = ({
 
     // array to pass updated content to engagement context
     const surveyBlockContent = [
-        { survey_status: SubmissionStatus[SubmissionStatus.Upcoming], block_text: '' },
-        { survey_status: SubmissionStatus[SubmissionStatus.Open], block_text: '' },
-        { survey_status: SubmissionStatus[SubmissionStatus.Closed], block_text: '' },
+        {
+            survey_status: SubmissionStatus[SubmissionStatus.Upcoming],
+            block_text: savedUpcomingText ? savedUpcomingText : '',
+        },
+        {
+            survey_status: SubmissionStatus[SubmissionStatus.Open],
+            block_text: savedUpcomingText ? savedOpenText : '',
+        },
+        {
+            survey_status: SubmissionStatus[SubmissionStatus.Closed],
+            block_text: savedUpcomingText ? savedClosedText : '',
+        },
     ];
 
     // capture changes in richdescription
     const handleStatusBlockContentChange = (newState: string) => {
         surveyBlockContent.forEach((item) => {
             if (item.survey_status === value && newState) {
-                item.block_text = newState;
+                if (item.survey_status === SubmissionStatus[SubmissionStatus.Upcoming]) {
+                    setSavedUpcomingText(newState);
+                    item.block_text = savedUpcomingText;
+                }
+                if (item.survey_status === SubmissionStatus[SubmissionStatus.Open]) {
+                    setSavedOpenText(newState);
+                    item.block_text = savedOpenText;
+                }
+                if (item.survey_status === SubmissionStatus[SubmissionStatus.Closed]) {
+                    setSavedClosedText(newState);
+                    item.block_text = savedClosedText;
+                }
             }
         });
         handleChange(surveyBlockContent);


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/397

*Description of changes:*
Fix to save the state for each of the text that will appear in the survey block for each status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
