### PR TITLE
UI Tweaks to Preview Status Box

### DIFF
--- a/met-web/src/components/engagement/view/PreviewBanner.tsx
+++ b/met-web/src/components/engagement/view/PreviewBanner.tsx
@@ -145,8 +145,10 @@ export const PreviewBanner = () => {
                     </When>
                 </Grid>
                 <Grid item container direction="row" alignItems="flex-end" justifyContent="flex-end" xs={4}>
-                    <MetPaper sx={{ p: 1 }}>
-                        <Typography sx={{ fontWeight: 'bold', pb: 2 }}>View Different Engagement Status:</Typography>
+                    <MetPaper sx={{ p: 1, borderColor: '#cdcdcd' }}>
+                        <Typography sx={{ fontSize: '13px', fontWeight: 'bold', pb: '8px' }}>
+                            Click to View Different Engagement Status:
+                        </Typography>
                         <Stack spacing={1} direction={{ md: 'row' }} alignItems="center" justifyContent="center">
                             <IconButton onClick={() => updateMockStatus(SubmissionStatus.Upcoming)}>
                                 <EngagementStatusChip


### PR DESCRIPTION
*Issue #398 :*
https://github.com/bcgov/met-public/issues/398

-Change text to "Click to View Different Engagement status"

-Change label size to 13px

-Change padding to 8px

-Change border color to #cdcdcd

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
