### PR TITLE
fix for edit contact profile picture

### DIFF
--- a/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/AddContactDrawer.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/AddContactDrawer.tsx
@@ -19,6 +19,7 @@ import { Contact } from 'models/contact';
 
 const schema = yup
     .object({
+        avatar_filename: yup.string(),
         name: yup.string().max(50, 'Name should not exceed 50 characters').required(),
         title: yup.string().max(50, 'Title should not exceed 50 characters'),
         phone_number: yup.string().max(50, 'Phone Number should not exceed 50 characters'),
@@ -50,6 +51,7 @@ const AddContactDrawer = () => {
     });
 
     useEffect(() => {
+        methods.setValue('avatar_filename', contactToEdit?.avatar_filename || '');
         methods.setValue('name', contactToEdit?.name || '');
         methods.setValue('phone_number', contactToEdit?.phone_number || '');
         methods.setValue('title', contactToEdit?.title || '');
@@ -78,7 +80,7 @@ const AddContactDrawer = () => {
             const uploadedAvatarImageFileName = await handleUploadAvatarImage();
             const contactUpdatesToPatch = updatedDiff(contactToEdit, {
                 ...data,
-                avatar_filename: uploadedAvatarImageFileName,
+                avatar_filename: data.avatar_filename ? data.avatar_filename : uploadedAvatarImageFileName,
             }) as PatchContactRequest;
 
             await patchContact({


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/991

*Description of changes:*
Changes made to check if edited contact has the image file name in the form then use it else use fetched data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
