### PR TITLE
Make Styling Consistent and Remove Document Widget bugs

### DIFF
--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -26,6 +26,8 @@ export const RoundedButton = styled(MuiButton)(() => ({
 export const StyledPrimaryButton = styled(LoadingButton)(() => ({
     backgroundColor: Palette.primary.main,
     color: '#fff',
+    minHeight: '40px',
+    maxHeight: '40px',
     '&:hover': {
         opacity: '0.8',
         backgroundColor: Palette.primary.main,
@@ -38,6 +40,8 @@ export const StyledSecondaryButton = styled(MuiButton)(() => ({
     backgroundColor: 'transparent',
     color: Palette.primary.main,
     border: `2px solid ${Palette.primary.main}`,
+    minHeight: '40px',
+    maxHeight: '40px',
     '&:hover': {
         opacity: '0.8',
         textDecoration: 'underline',
@@ -51,6 +55,8 @@ export const StyledWidgetButton = styled(MuiButton)(() => ({
     backgroundColor: 'transparent',
     color: '#494949',
     border: `2px solid ${'#707070'}`,
+    minHeight: '40px',
+    maxHeight: '40px',
     '&:hover': {
         opacity: '0.8',
         textDecoration: 'underline',
@@ -60,23 +66,22 @@ export const StyledWidgetButton = styled(MuiButton)(() => ({
     },
 }));
 
-export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledWidgetButton {...rest} sx={{ minHeight: '40px', maxHeight: '40px' }} variant="outlined">
+export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => (
+    <StyledWidgetButton {...rest} variant="outlined">
         {children}
     </StyledWidgetButton>
 );
 
-export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledSecondaryButton {...rest} sx={{ minHeight: '40px', maxHeight: '40px' }} variant="outlined">
+export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => (
+    <StyledSecondaryButton {...rest} variant="outlined">
         {children}
     </StyledSecondaryButton>
 );
 
-export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
+export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => (
     <StyledPrimaryButton
         {...rest}
         variant="contained"
-        sx={{ minHeight: '40px', maxHeight: '40px' }}
         loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
     >
         {children}
@@ -88,7 +93,7 @@ export const StyledPaper = styled(MuiPaper)(() => ({
     borderRadius: '4px',
 }));
 
-export const MetPaper = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => {
+export const MetPaper = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => {
     return (
         <StyledPaper elevation={0} {...rest}>
             {children}

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -60,19 +60,19 @@ export const StyledWidgetButton = styled(MuiButton)(() => ({
     },
 }));
 
-export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => (
+export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
     <StyledWidgetButton {...rest} variant="outlined">
         {children}
     </StyledWidgetButton>
 );
 
-export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => (
+export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
     <StyledSecondaryButton {...rest} variant="outlined">
         {children}
     </StyledSecondaryButton>
 );
 
-export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => (
+export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
     <StyledPrimaryButton
         {...rest}
         variant="contained"
@@ -87,7 +87,7 @@ export const StyledPaper = styled(MuiPaper)(() => ({
     borderRadius: '4px',
 }));
 
-export const MetPaper = ({ children, ...rest }: { children: React.ReactNode;[prop: string]: unknown }) => {
+export const MetPaper = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => {
     return (
         <StyledPaper elevation={0} {...rest}>
             {children}

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -31,8 +31,6 @@ export const StyledPrimaryButton = styled(LoadingButton)(() => ({
         backgroundColor: Palette.primary.main,
         color: '#fff',
         textDecoration: 'underline',
-        minHeight: '40px',
-        maxHeight: '40px',
     },
 }));
 
@@ -46,8 +44,6 @@ export const StyledSecondaryButton = styled(MuiButton)(() => ({
         backgroundColor: Palette.primary.main,
         color: '#FFFFFF',
         border: `2px solid ${Palette.primary.main}`,
-        minHeight: '40px',
-        maxHeight: '40px',
     },
 }));
 
@@ -61,19 +57,17 @@ export const StyledWidgetButton = styled(MuiButton)(() => ({
         backgroundColor: '#f2f2f2',
         color: '#494949',
         border: `2px solid ${'#f2f2f2'}`,
-        minHeight: '40px',
-        maxHeight: '40px',
     },
 }));
 
 export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledWidgetButton {...rest} variant="outlined">
+    <StyledWidgetButton {...rest} sx={{ minHeight: '40px', maxHeight: '40px' }} variant="outlined">
         {children}
     </StyledWidgetButton>
 );
 
 export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledSecondaryButton {...rest} variant="outlined">
+    <StyledSecondaryButton {...rest} sx={{ minHeight: '40px', maxHeight: '40px' }} variant="outlined">
         {children}
     </StyledSecondaryButton>
 );
@@ -82,6 +76,7 @@ export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode
     <StyledPrimaryButton
         {...rest}
         variant="contained"
+        sx={{ minHeight: '40px', maxHeight: '40px' }}
         loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
     >
         {children}

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -31,6 +31,8 @@ export const StyledPrimaryButton = styled(LoadingButton)(() => ({
         backgroundColor: Palette.primary.main,
         color: '#fff',
         textDecoration: 'underline',
+        minHeight: '40px',
+        maxHeight: '40px',
     },
 }));
 
@@ -44,6 +46,8 @@ export const StyledSecondaryButton = styled(MuiButton)(() => ({
         backgroundColor: Palette.primary.main,
         color: '#FFFFFF',
         border: `2px solid ${Palette.primary.main}`,
+        minHeight: '40px',
+        maxHeight: '40px',
     },
 }));
 
@@ -57,6 +61,8 @@ export const StyledWidgetButton = styled(MuiButton)(() => ({
         backgroundColor: '#f2f2f2',
         color: '#494949',
         border: `2px solid ${'#f2f2f2'}`,
+        minHeight: '40px',
+        maxHeight: '40px',
     },
 }));
 
@@ -67,7 +73,7 @@ export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode;
 );
 
 export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledSecondaryButton {...rest} sx={{ minHeight: '40px', maxHeight: '40px' }} variant="outlined">
+    <StyledSecondaryButton {...rest} variant="outlined">
         {children}
     </StyledSecondaryButton>
 );
@@ -76,7 +82,6 @@ export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode
     <StyledPrimaryButton
         {...rest}
         variant="contained"
-        sx={{ minHeight: '40px', maxHeight: '40px' }}
         loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
     >
         {children}

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -26,8 +26,6 @@ export const RoundedButton = styled(MuiButton)(() => ({
 export const StyledPrimaryButton = styled(LoadingButton)(() => ({
     backgroundColor: Palette.primary.main,
     color: '#fff',
-    minHeight: '40px',
-    maxHeight: '40px',
     '&:hover': {
         opacity: '0.8',
         backgroundColor: Palette.primary.main,
@@ -40,8 +38,6 @@ export const StyledSecondaryButton = styled(MuiButton)(() => ({
     backgroundColor: 'transparent',
     color: Palette.primary.main,
     border: `2px solid ${Palette.primary.main}`,
-    minHeight: '40px',
-    maxHeight: '40px',
     '&:hover': {
         opacity: '0.8',
         textDecoration: 'underline',
@@ -55,8 +51,6 @@ export const StyledWidgetButton = styled(MuiButton)(() => ({
     backgroundColor: 'transparent',
     color: '#494949',
     border: `2px solid ${'#707070'}`,
-    minHeight: '40px',
-    maxHeight: '40px',
     '&:hover': {
         opacity: '0.8',
         textDecoration: 'underline',

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -67,7 +67,7 @@ export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode;
 );
 
 export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledSecondaryButton {...rest} variant="outlined">
+    <StyledSecondaryButton {...rest} sx={{ minHeight: '40px', maxHeight: '40px' }} variant="outlined">
         {children}
     </StyledSecondaryButton>
 );
@@ -76,6 +76,7 @@ export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode
     <StyledPrimaryButton
         {...rest}
         variant="contained"
+        sx={{ minHeight: '40px', maxHeight: '40px' }}
         loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
     >
         {children}

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Grid, TextField } from '@mui/material';
+import { Grid, TextField, Stack } from '@mui/material';
 import { MetLabel, PrimaryButton, SecondaryButton, WidgetButton } from 'components/common';
 import { When } from 'react-if';
 import { DocumentsContext } from './DocumentsContext';
@@ -9,6 +9,7 @@ import { postDocument } from 'services/widgetService/DocumentService.tsx';
 import { WidgetDrawerContext } from '../WidgetDrawerContext';
 import { WidgetType } from 'models/widget';
 import { DOCUMENT_TYPE } from 'models/document';
+
 const CreateFolderForm = () => {
     const { loadDocuments, handleFileDrawerOpen } = useContext(DocumentsContext);
     const { widgets } = useContext(WidgetDrawerContext);
@@ -66,15 +67,7 @@ const CreateFolderForm = () => {
 
     return (
         <>
-            <Grid
-                item
-                xs={12}
-                container
-                direction="row"
-                justifyContent={'flex-start'}
-                spacing={1}
-                sx={{ marginBottom: '3em' }}
-            >
+            <Grid item xs={12} container direction="row" justifyContent={'flex-start'} spacing={1} sx={{ mb: 5 }}>
                 <Grid item>
                     <WidgetButton onClick={() => setCreateFolderMode(true)}>Create Folder</WidgetButton>
                 </Grid>
@@ -84,30 +77,45 @@ const CreateFolderForm = () => {
             </Grid>
 
             <When condition={createFolderMode}>
-                <Grid item xs={12} container direction="row" justifyContent={'flex-start'} mb={5}>
+                <Grid item xs={12} container direction="row" justifyContent={'center'} mb={5}>
                     <Grid item xs={12}>
                         <MetLabel>Folder name</MetLabel>
                     </Grid>
-                    <Grid container item justifyContent={'flex-start'} alignItems="space-between" spacing={3} xs={12}>
-                        <Grid item xs={5}>
+                    <Grid
+                        container
+                        item
+                        justifyContent={'flex-start'}
+                        alignItems={formError.name || folderName.length > 50 ? 'center' : 'flex-end'}
+                        spacing={2}
+                        xs={12}
+                        sx={{ p: 0 }}
+                    >
+                        <Grid item xs={8} sx={{ p: 0 }}>
                             <TextField
                                 label=" "
                                 InputLabelProps={{
                                     shrink: false,
                                 }}
-                                sx={{ width: '100%' }}
+                                sx={{ width: '100%', p: 0, m: 0 }}
                                 onChange={(e) => handleFolderNameChange(e.target.value)}
                                 error={formError.name || folderName.length > 50}
                                 helperText={getErrorMessage()}
                             />
                         </Grid>
-                        <Grid item xs={1}>
-                            <PrimaryButton loading={creatingFolder} onClick={handleCreateFolder}>
-                                Save
-                            </PrimaryButton>
-                        </Grid>
-                        <Grid item xs={1}>
-                            <SecondaryButton onClick={() => setCreateFolderMode(false)}>Cancel</SecondaryButton>
+                        <Grid item lg={2.5} md={5}>
+                            <Stack
+                                direction={{ md: 'column', lg: 'row' }}
+                                spacing={1.5}
+                                width="100%"
+                                justifyContent="flex-end"
+                            >
+                                <PrimaryButton sx={{ mb: 1 }} loading={creatingFolder} onClick={handleCreateFolder}>
+                                    Save
+                                </PrimaryButton>
+                                <SecondaryButton sx={{ mb: 1 }} onClick={() => setCreateFolderMode(false)}>
+                                    Cancel
+                                </SecondaryButton>
+                            </Stack>
                         </Grid>
                     </Grid>
                 </Grid>

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -85,7 +85,7 @@ const CreateFolderForm = () => {
                         container
                         item
                         justifyContent={'flex-start'}
-                        alignItems={formError.name || folderName.length > 50 ? 'center' : 'flex-end'}
+                        alignItems={formError.name || folderName.length > 50 ? 'center' : 'flex-start'}
                         spacing={2}
                         xs={12}
                         sx={{ p: 0 }}

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -47,6 +47,11 @@ export const BaseTheme = createTheme({
                 disableRipple: true,
             },
         },
+        MuiTextField: {
+            defaultProps: {
+                size: 'small',
+            },
+        },
         MuiLink: {
             defaultProps: {
                 color: Palette.action.active,

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -43,6 +43,9 @@ export const BaseTheme = createTheme({
     },
     components: {
         MuiButton: {
+            styleOverrides: {
+                root: { height: '40px' },
+            },
             defaultProps: {
                 disableRipple: true,
             },


### PR DESCRIPTION
*Issue #1027 :*
 *Issue #1102 :*

https://github.com/bcgov/met-public/issues/1027
https://github.com/bcgov/met-public/issues/1102

-Make all text fields and buttons 40px height & width

-Remove button overlap for document widget


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
