### PR TITLE
Prevent empty folders in Document Widget

### DIFF
--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -22,11 +22,11 @@ const CreateFolderForm = () => {
     const [formError, setFormError] = useState(initialFormError);
     const widget = widgets.find((widget) => widget.widget_type_id === WidgetType.Document);
 
-    const validate = () => {
+    const valid = () => {
         setFormError({
             name: !folderName || folderName.length > 50,
         });
-        return Object.values(formError).every((errorExists) => errorExists);
+        return !Object.values(formError).every((errorExists) => errorExists);
     };
 
     const getErrorMessage = () => {
@@ -40,7 +40,7 @@ const CreateFolderForm = () => {
 
     const handleCreateFolder = async () => {
         try {
-            if (!validate()) {
+            if (!valid()) {
                 return;
             }
             setCreatingFolder(true);
@@ -60,7 +60,7 @@ const CreateFolderForm = () => {
     };
 
     const handleFolderNameChange = (name: string) => {
-        validate();
+        valid();
         setFolderName(name);
     };
 

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -44,11 +44,13 @@ const CreateFolderForm = () => {
                 return;
             }
             setCreatingFolder(true);
+            /* tslint:disable */
             await postDocument(widget.id, {
                 title: folderName,
                 widget_id: widget.id,
                 type: DOCUMENT_TYPE.FOLDER,
             });
+            /* tslint:enable */
             await loadDocuments();
             setCreatingFolder(false);
             setCreateFolderMode(false);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -39,10 +39,10 @@ const CreateFolderForm = () => {
     };
 
     const handleCreateFolder = async () => {
+        if (!widget || !validateForm()) {
+            return;
+        }
         try {
-            if (!widget || !validateForm()) {
-                return;
-            }
             setCreatingFolder(true);
             await postDocument(widget.id, {
                 title: folderName,

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -40,17 +40,16 @@ const CreateFolderForm = () => {
 
     const handleCreateFolder = async () => {
         try {
-            if (!widget && !validate()) {
+            if (!validate()) {
                 return;
             }
             setCreatingFolder(true);
-            /* tslint:disable */
-            await postDocument(widget.id, {
-                title: folderName,
-                widget_id: widget.id,
-                type: DOCUMENT_TYPE.FOLDER,
-            });
-            /* tslint:enable */
+            if (widget)
+                await postDocument(widget.id, {
+                    title: folderName,
+                    widget_id: widget.id,
+                    type: DOCUMENT_TYPE.FOLDER,
+                });
             await loadDocuments();
             setCreatingFolder(false);
             setCreateFolderMode(false);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -22,7 +22,7 @@ const CreateFolderForm = () => {
     const [formError, setFormError] = useState(initialFormError);
     const widget = widgets.find((widget) => widget.widget_type_id === WidgetType.Document);
 
-    const isValid = () => {
+    const validateForm = () => {
         setFormError({
             name: !folderName || folderName.length > 50,
         });
@@ -40,7 +40,7 @@ const CreateFolderForm = () => {
 
     const handleCreateFolder = async () => {
         try {
-            if (!widget || !isValid()) {
+            if (!widget || !validateForm()) {
                 return;
             }
             setCreatingFolder(true);
@@ -59,7 +59,7 @@ const CreateFolderForm = () => {
     };
 
     const handleFolderNameChange = (name: string) => {
-        isValid();
+        validateForm();
         setFolderName(name);
     };
 

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -22,7 +22,7 @@ const CreateFolderForm = () => {
     const [formError, setFormError] = useState(initialFormError);
     const widget = widgets.find((widget) => widget.widget_type_id === WidgetType.Document);
 
-    const valid = () => {
+    const isValid = () => {
         setFormError({
             name: !folderName || folderName.length > 50,
         });
@@ -40,7 +40,7 @@ const CreateFolderForm = () => {
 
     const handleCreateFolder = async () => {
         try {
-            if (!valid()) {
+            if (!isValid()) {
                 return;
             }
             setCreatingFolder(true);
@@ -60,7 +60,7 @@ const CreateFolderForm = () => {
     };
 
     const handleFolderNameChange = (name: string) => {
-        valid();
+        isValid();
         setFolderName(name);
     };
 

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -40,16 +40,15 @@ const CreateFolderForm = () => {
 
     const handleCreateFolder = async () => {
         try {
-            if (!isValid()) {
+            if (!widget || !isValid()) {
                 return;
             }
             setCreatingFolder(true);
-            if (widget)
-                await postDocument(widget.id, {
-                    title: folderName,
-                    widget_id: widget.id,
-                    type: DOCUMENT_TYPE.FOLDER,
-                });
+            await postDocument(widget.id, {
+                title: folderName,
+                widget_id: widget.id,
+                type: DOCUMENT_TYPE.FOLDER,
+            });
             await loadDocuments();
             setCreatingFolder(false);
             setCreateFolderMode(false);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -39,17 +39,18 @@ const CreateFolderForm = () => {
     };
 
     const handleCreateFolder = async () => {
-        if (!widget || validate()) {
-            return;
-        }
-
         try {
+            if (validate()) {
+                return;
+            }
             setCreatingFolder(true);
-            await postDocument(widget.id, {
-                title: folderName,
-                widget_id: widget.id,
-                type: DOCUMENT_TYPE.FOLDER,
-            });
+            if (widget) {
+                await postDocument(widget.id, {
+                    title: folderName,
+                    widget_id: widget.id,
+                    type: DOCUMENT_TYPE.FOLDER,
+                });
+            }
             await loadDocuments();
             setCreatingFolder(false);
             setCreateFolderMode(false);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -26,7 +26,7 @@ const CreateFolderForm = () => {
         setFormError({
             name: !folderName || folderName.length > 50,
         });
-        return Object.values(formError).some((errorExists) => errorExists);
+        return Object.values(formError).every((errorExists) => errorExists);
     };
 
     const getErrorMessage = () => {
@@ -40,17 +40,15 @@ const CreateFolderForm = () => {
 
     const handleCreateFolder = async () => {
         try {
-            if (validate()) {
+            if (!widget && !validate()) {
                 return;
             }
             setCreatingFolder(true);
-            if (widget) {
-                await postDocument(widget.id, {
-                    title: folderName,
-                    widget_id: widget.id,
-                    type: DOCUMENT_TYPE.FOLDER,
-                });
-            }
+            await postDocument(widget.id, {
+                title: folderName,
+                widget_id: widget.id,
+                type: DOCUMENT_TYPE.FOLDER,
+            });
             await loadDocuments();
             setCreatingFolder(false);
             setCreateFolderMode(false);


### PR DESCRIPTION
*Issue #1116 :*
https://github.com/bcgov/met-public/issues/1116

Currently in the document widget, if you do not add a name to a folder it can still be created

- move the validation check into the try catch block

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
