### PR TITLE
changes for comments/dashboard access

### DIFF
--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -96,6 +96,8 @@ class _Config():  # pylint: disable=too-few-public-methods
     SUBMISSION_PATH = os.getenv('SUBMISSION_PATH', '/engagements/{engagement_id}/edit/{token}')
     SURVEY_PATH = os.getenv('SURVEY_PATH', '/surveys/submit/{survey_id}/{token}')
     SUBSCRIBE_PATH = os.getenv('SUBSCRIBE_PATH', '/engagements/{engagement_id}/subscribe/{token}')
+    # engagement dashboard path is used to pass the survey result to the public user.
+    # The link is changed such that public user can access the comments page from the email and not the dashboard.
     ENGAGEMENT_DASHBOARD_PATH = os.getenv('ENGAGEMENT_DASHBOARD_PATH', '/engagements/{engagement_id}/comments')
     USER_MANAGEMENT_PATH = os.getenv('USER_MANAGEMENT_PATH', '/usermanagement')
     SITE_URL = os.getenv('SITE_URL')

--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -96,7 +96,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     SUBMISSION_PATH = os.getenv('SUBMISSION_PATH', '/engagements/{engagement_id}/edit/{token}')
     SURVEY_PATH = os.getenv('SURVEY_PATH', '/surveys/submit/{survey_id}/{token}')
     SUBSCRIBE_PATH = os.getenv('SUBSCRIBE_PATH', '/engagements/{engagement_id}/subscribe/{token}')
-    ENGAGEMENT_DASHBOARD_PATH = os.getenv('ENGAGEMENT_DASHBOARD_PATH', '/engagements/{engagement_id}/dashboard')
+    ENGAGEMENT_DASHBOARD_PATH = os.getenv('ENGAGEMENT_DASHBOARD_PATH', '/engagements/{engagement_id}/comments')
     USER_MANAGEMENT_PATH = os.getenv('USER_MANAGEMENT_PATH', '/usermanagement')
     SITE_URL = os.getenv('SITE_URL')
 

--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -10,7 +10,6 @@ from sqlalchemy.sql import text
 from sqlalchemy.sql.schema import ForeignKey
 
 from met_api.constants.comment_status import Status
-from met_api.constants.engagement_status import Status as EngStatus
 from met_api.models.pagination_options import PaginationOptions
 from met_api.models.engagement import Engagement
 from met_api.models.submission import Submission
@@ -91,7 +90,6 @@ class Comment(db.Model):
             .filter(
                 and_(
                     Comment.survey_id == survey_id,
-                    Engagement.status_id == EngStatus.Closed.value,
                     CommentStatus.id == Status.Approved.value
                 ))\
 

--- a/met-api/src/met_api/utils/roles.py
+++ b/met-api/src/met_api/utils/roles.py
@@ -33,3 +33,4 @@ class Role(Enum):
     VIEW_ENGAGEMENT = 'view_engagement'
     EDIT_ENGAGEMENT = 'edit_engagement'
     REVIEW_COMMENTS = 'review_comments'
+    ACCESS_DASHBOARD = 'access_dashboard'

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -4,7 +4,6 @@ import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
-import { SubmissionStatus } from 'constants/engagementStatus';
 import { getErrorMessage } from 'utils';
 import { getCommentsPage } from 'services/commentService';
 import { Comment } from 'models/comment';
@@ -56,13 +55,6 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
 
     const { page, size } = paginationOptions;
 
-    const validateEngagement = (engagementToValidate: Engagement) => {
-        const isClosed = engagementToValidate?.submission_status === SubmissionStatus.Closed;
-
-        if (!isClosed) {
-            throw new Error('Engagement is not yet closed');
-        }
-    };
     useEffect(() => {
         const fetchEngagement = async () => {
             if (isNaN(Number(engagementId))) {
@@ -71,7 +63,6 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
             }
             try {
                 const result = await getEngagement(Number(engagementId));
-                validateEngagement(result);
                 setEngagement({ ...result });
                 setEngagementLoading(false);
             } catch (error) {

--- a/met-web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
@@ -12,14 +12,16 @@ export const CommentsBlock = () => {
     const { engagement, isEngagementLoading } = useContext(CommentViewContext);
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
-    const roles = useAppSelector((state) => state.user.roles);
+    const canAccessDashboard = useAppSelector((state) => state.user.roles.includes('access_dashboard'));
 
     const handleViewDashboard = () => {
-        if (roles.includes('access_dashboard')) {
+        /* check to ensure that users with role access_dashboard can access the dashboard while engagement not closed*/
+        if (canAccessDashboard) {
             navigate(`/engagements/${engagement?.id}/dashboard`);
             return;
         }
 
+        /* check to ensure that all other users can access the dashboard only after the engagement is closed*/
         if (engagement?.submission_status === SubmissionStatus.Closed) {
             navigate(`/engagements/${engagement.id}/dashboard`);
             return;

--- a/met-web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
@@ -15,7 +15,7 @@ export const CommentsBlock = () => {
     const roles = useAppSelector((state) => state.user.roles);
 
     const handleViewDashboard = () => {
-        if (roles.length !== 0) {
+        if (roles.includes('access_dashboard')) {
             navigate(`/engagements/${engagement?.id}/dashboard`);
             return;
         }

--- a/met-web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
@@ -1,12 +1,45 @@
 import React, { useContext } from 'react';
 import { Grid, Skeleton } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { CommentViewContext } from './CommentViewContext';
 import { PrimaryButton, MetPaper, MetHeader4 } from 'components/common';
 import CommentTable from './CommentTable';
+import { useAppSelector, useAppDispatch } from 'hooks';
+import { SubmissionStatus } from 'constants/engagementStatus';
+import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
 
 export const CommentsBlock = () => {
     const { engagement, isEngagementLoading } = useContext(CommentViewContext);
+    const navigate = useNavigate();
+    const dispatch = useAppDispatch();
+    const roles = useAppSelector((state) => state.user.roles);
+
+    const handleViewDashboard = () => {
+        if (roles.length !== 0) {
+            navigate(`/engagements/${engagement?.id}/dashboard`);
+            return;
+        }
+
+        if (engagement?.submission_status === SubmissionStatus.Closed) {
+            navigate(`/engagements/${engagement.id}/dashboard`);
+            return;
+        }
+
+        dispatch(
+            openNotificationModal({
+                open: true,
+                data: {
+                    header: 'View Report',
+                    subText: [
+                        {
+                            text: 'The report will only be available to view after the engagement period is over and the engagement is closed.',
+                        },
+                    ],
+                },
+                type: 'update',
+            }),
+        );
+    };
 
     if (isEngagementLoading || !engagement) {
         return <Skeleton width="100%" height="40em" />;
@@ -35,8 +68,7 @@ export const CommentsBlock = () => {
                         >
                             <PrimaryButton
                                 data-testid="SurveyBlock/take-me-to-survey-button"
-                                component={Link}
-                                to={`/engagements/${engagement.id}/dashboard`}
+                                onClick={handleViewDashboard}
                             >
                                 View Report
                             </PrimaryButton>

--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -9,8 +9,7 @@ import { SubmissionStatus } from 'constants/engagementStatus';
 import { getEngagement } from 'services/engagementService';
 import { getErrorMessage } from 'utils';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { useAppDispatch } from 'hooks';
-import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
+import { useAppSelector, useAppDispatch } from 'hooks';
 
 export type EngagementParams = {
     engagementId: string;
@@ -21,6 +20,7 @@ export const EngagementDashboard = () => {
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
     const urlpath = AppConfig.redashDashboardUrl;
+    const roles = useAppSelector((state) => state.user.roles);
 
     const [engagement, setEngagement] = useState<Engagement>(createDefaultEngagement());
     const [isEngagementLoading, setEngagementLoading] = useState(true);
@@ -33,6 +33,16 @@ export const EngagementDashboard = () => {
             throw new Error('Engagement has not yet been opened');
         }
     };
+
+    const validateEngagement = (engagementToValidate: Engagement) => {
+        const isClosed = engagementToValidate?.submission_status === SubmissionStatus.Closed;
+        const isPublicUser = roles.length === 0;
+
+        if (!isClosed && isPublicUser) {
+            throw new Error('Engagement is not yet closed');
+        }
+    };
+
     useEffect(() => {
         const fetchEngagement = async () => {
             if (isNaN(Number(engagementId))) {
@@ -42,6 +52,7 @@ export const EngagementDashboard = () => {
             try {
                 const result = await getEngagement(Number(engagementId));
                 failIfInvalidEngagement(result);
+                validateEngagement(result);
                 setEngagement({ ...result });
                 setEngagementLoading(false);
             } catch (error) {
@@ -58,25 +69,8 @@ export const EngagementDashboard = () => {
     }, [engagementId]);
 
     const handleReadComments = () => {
-        if (engagement.submission_status === SubmissionStatus.Closed) {
-            navigate(`/engagements/${engagement.id}/comments`);
-            return;
-        }
-
-        dispatch(
-            openNotificationModal({
-                open: true,
-                data: {
-                    header: 'View Comments',
-                    subText: [
-                        {
-                            text: 'The comments will only be available to view after the engagement period is over and the engagement is closed.',
-                        },
-                    ],
-                },
-                type: 'update',
-            }),
-        );
+        navigate(`/engagements/${engagement.id}/comments`);
+        return;
     };
 
     if (isEngagementLoading) {

--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -36,7 +36,7 @@ export const EngagementDashboard = () => {
 
     const validateEngagement = (engagementToValidate: Engagement) => {
         const isClosed = engagementToValidate?.submission_status === SubmissionStatus.Closed;
-        const isPublicUser = roles.length === 0;
+        const isPublicUser = !roles.includes('access_dashboard');
 
         if (!isClosed && isPublicUser) {
             throw new Error('Engagement is not yet closed');

--- a/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
+++ b/met-web/src/components/engagement/dashboard/report/EngagementDashboard.tsx
@@ -36,9 +36,11 @@ export const EngagementDashboard = () => {
 
     const validateEngagement = (engagementToValidate: Engagement) => {
         const isClosed = engagementToValidate?.submission_status === SubmissionStatus.Closed;
-        const isPublicUser = !roles.includes('access_dashboard');
+        const canAccessDashboard = !roles.includes('access_dashboard');
 
-        if (!isClosed && isPublicUser) {
+        /* check to ensure that users without the role access_dashboard can access the dashboard only after 
+        the engagement is closed*/
+        if (!isClosed && canAccessDashboard) {
             throw new Error('Engagement is not yet closed');
         }
     };


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1022

*Description of changes:*
- Add new role for dashboard access
- Survey email to have the link for comments
- Dashboard access to public should be restricted until engagement is closed.
- Both dashboard and comments should be accessible to users having dashboard access role

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
