### PR TITLE
handle empty comment listing

### DIFF
--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -91,7 +91,7 @@ function MetTable<T>({
     pageInfo = {
         total: rows.length,
     },
-    emptyText = 'No data to display',
+    emptyText = 'No records were found',
 }: MetTableProps<T>) {
     const { page = 1, size, sort_key, sort_order, nested_sort_key } = paginationOptions;
     const { total } = pageInfo;

--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -183,7 +183,9 @@ function MetTable<T>({
                             })}
                             {rows.length == 0 && (
                                 <TableRow>
-                                    <TableCell align={'center'}>{emptyText}</TableCell>
+                                    <TableCell colSpan={headCells.length} align={'center'}>
+                                        {emptyText}
+                                    </TableCell>
                                 </TableRow>
                             )}
                             {emptyRows > 0 && (

--- a/met-web/src/components/common/Table/index.tsx
+++ b/met-web/src/components/common/Table/index.tsx
@@ -73,6 +73,7 @@ interface MetTableProps<T> {
     paginationOptions?: PaginationOptions<T>;
     pageInfo?: PageInfo;
     noPagination?: boolean;
+    emptyText?: string;
 }
 function MetTable<T>({
     hideHeader = false,
@@ -90,6 +91,7 @@ function MetTable<T>({
     pageInfo = {
         total: rows.length,
     },
+    emptyText = 'No data to display',
 }: MetTableProps<T>) {
     const { page = 1, size, sort_key, sort_order, nested_sort_key } = paginationOptions;
     const { total } = pageInfo;
@@ -179,6 +181,11 @@ function MetTable<T>({
                                     </TableRow>
                                 );
                             })}
+                            {rows.length == 0 && (
+                                <TableRow>
+                                    <TableCell align={'center'}>{emptyText}</TableCell>
+                                </TableRow>
+                            )}
                             {emptyRows > 0 && (
                                 <TableRow
                                     style={{

--- a/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentTable.tsx
@@ -45,6 +45,7 @@ const CommentTable = () => {
                 paginationOptions={paginationOptions}
                 pageInfo={pageInfo}
                 loading={tableLoading}
+                emptyText={'Engagement does not have any published comments'}
             />
         </>
     );

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -8,6 +8,7 @@ import { getErrorMessage } from 'utils';
 import { getCommentsPage } from 'services/commentService';
 import { Comment } from 'models/comment';
 import { createDefaultPageInfo, PageInfo, PaginationOptions } from 'components/common/Table/types';
+import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
 
 export interface EngagementCommentContextProps {
     engagement: Engagement | null;
@@ -55,6 +56,27 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
 
     const { page, size } = paginationOptions;
 
+    const validateEngagement = (commentsToValidate: Comment[]) => {
+        const hasApprovedComments = commentsToValidate.length > 0;
+
+        if (!hasApprovedComments) {
+            dispatch(
+                openNotificationModal({
+                    open: true,
+                    data: {
+                        header: 'View Comments',
+                        subText: [
+                            {
+                                text: 'Engagement does not have any published comments',
+                            },
+                        ],
+                    },
+                    type: 'update',
+                }),
+            );
+        }
+    };
+
     useEffect(() => {
         const fetchEngagement = async () => {
             if (isNaN(Number(engagementId))) {
@@ -91,6 +113,7 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                 page,
                 size,
             });
+            validateEngagement(response.items);
             setComments(response.items);
             setPageInfo({
                 total: response.total,

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -8,7 +8,6 @@ import { getErrorMessage } from 'utils';
 import { getCommentsPage } from 'services/commentService';
 import { Comment } from 'models/comment';
 import { createDefaultPageInfo, PageInfo, PaginationOptions } from 'components/common/Table/types';
-import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
 
 export interface EngagementCommentContextProps {
     engagement: Engagement | null;
@@ -56,27 +55,6 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
 
     const { page, size } = paginationOptions;
 
-    const validateComments = (commentsToValidate: Comment[]) => {
-        const hasApprovedComments = commentsToValidate.length > 0;
-
-        if (!hasApprovedComments) {
-            dispatch(
-                openNotificationModal({
-                    open: true,
-                    data: {
-                        header: 'View Comments',
-                        subText: [
-                            {
-                                text: 'Engagement does not have any published comments',
-                            },
-                        ],
-                    },
-                    type: 'update',
-                }),
-            );
-        }
-    };
-
     useEffect(() => {
         const fetchEngagement = async () => {
             if (isNaN(Number(engagementId))) {
@@ -113,7 +91,6 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                 page,
                 size,
             });
-            validateComments(response.items);
             setComments(response.items);
             setPageInfo({
                 total: response.total,

--- a/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
+++ b/met-web/src/components/engagement/dashboard/comment/CommentViewContext.tsx
@@ -56,7 +56,7 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
 
     const { page, size } = paginationOptions;
 
-    const validateEngagement = (commentsToValidate: Comment[]) => {
+    const validateComments = (commentsToValidate: Comment[]) => {
         const hasApprovedComments = commentsToValidate.length > 0;
 
         if (!hasApprovedComments) {
@@ -113,7 +113,7 @@ export const CommentViewProvider = ({ children }: { children: JSX.Element | JSX.
                 page,
                 size,
             });
-            validateEngagement(response.items);
+            validateComments(response.items);
             setComments(response.items);
             setPageInfo({
                 total: response.total,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1022

*Description of changes:*
Changes to pop up a message to inform public user that there are no approved comments on the engagement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
