### PR TITLE
Align Widgets

### DIFF
--- a/met-web/src/components/engagement/view/EngagementView.tsx
+++ b/met-web/src/components/engagement/view/EngagementView.tsx
@@ -62,7 +62,7 @@ export const EngagementView = () => {
                     direction="row"
                     justifyContent={'flex-start'}
                     alignItems="flex-start"
-                    m={{ md: '2em', xs: '1em' }}
+                    m={{ md: '1em', xs: '1em' }}
                     rowSpacing={2}
                     columnSpacing={1}
                 >
@@ -89,7 +89,7 @@ export const EngagementView = () => {
                                 rowSpacing={2}
                                 columnSpacing={1}
                             >
-                                <Grid data-testid={'engagement-content'} item xs={12} mt={2}>
+                                <Grid data-testid={'engagement-content'} item xs={12}>
                                     <EngagementContent />
                                 </Grid>
                                 <Grid item xs={12}>

--- a/met-web/src/components/engagement/view/widgets/WhoIsListeningWidget.tsx
+++ b/met-web/src/components/engagement/view/widgets/WhoIsListeningWidget.tsx
@@ -95,7 +95,7 @@ const WhoIsListeningWidget = ({ widget }: WhoIsListeningWidgetProps) => {
                             direction="row"
                             rowSpacing={1}
                             xs={12}
-                            md={8}
+                            md={9}
                         >
                             <Grid item container justifyContent={{ xs: 'center', md: 'flex-start' }} xs={12}>
                                 <MetHeader3 bold>{contact.name}</MetHeader3>
@@ -111,7 +111,6 @@ const WhoIsListeningWidget = ({ widget }: WhoIsListeningWidgetProps) => {
                                     justifyContent={{ xs: 'center', md: 'flex-start' }}
                                     item
                                     xs={12}
-                                    sm={8}
                                     sx={{ whiteSpace: 'pre-line' }}
                                 >
                                     <MetSmallText


### PR DESCRIPTION
*Issue #1128:*
https://github.com/bcgov/met-public/issues/1128

-Remove some margin top on widget block

-Add more spacing for bio on who is listening widget


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
