### PR TITLE
Make side nav cover banner on mobile

### DIFF
--- a/met-web/src/components/layout/Header/InternalHeader.tsx
+++ b/met-web/src/components/layout/Header/InternalHeader.tsx
@@ -23,7 +23,7 @@ const InternalHeader = ({ drawerWidth = 280 }) => {
                 position="fixed"
                 color="default"
                 sx={{
-                    zIndex: (theme) => theme.zIndex.drawer + 1,
+                    zIndex: (theme: Theme) => (isMediumScreen ? theme.zIndex.drawer + 1 : theme.zIndex.drawer),
                     color: Palette.text.primary,
                 }}
                 data-testid="appbar-header"

--- a/met-web/src/components/layout/SideNav/SideNav.tsx
+++ b/met-web/src/components/layout/SideNav/SideNav.tsx
@@ -80,7 +80,6 @@ const SideNav = ({ open, setOpen, isMediumScreen, drawerWidth = 280 }: SideNavPr
                     open={open}
                     hideBackdrop={!open}
                 >
-                    <Toolbar />
                     <DrawerBox />
                 </Drawer>
             )}


### PR DESCRIPTION
*Issue #990:*
https://github.com/bcgov/met-public/issues/990

-make side nav full screen on mobile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
