### PR TITLE
Update spacing for responsiveness in events widget

### DIFF
--- a/met-web/src/components/engagement/view/widgets/Events/InPersonEvent.tsx
+++ b/met-web/src/components/engagement/view/widgets/Events/InPersonEvent.tsx
@@ -20,7 +20,7 @@ const InPersonEvent = ({ eventItem }: EventProps) => {
                 <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Location:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={8} paddingLeft={2}>
                     <MetBody>{eventItem.location_name}</MetBody>
                 </Grid>
             </Grid>
@@ -28,7 +28,7 @@ const InPersonEvent = ({ eventItem }: EventProps) => {
                 <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Address:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={8} paddingLeft={2}>
                     <MetBody>{eventItem.location_address}</MetBody>
                 </Grid>
             </Grid>
@@ -36,7 +36,7 @@ const InPersonEvent = ({ eventItem }: EventProps) => {
                 <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Date:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={8} paddingLeft={2}>
                     <MetBody>{formatDate(eventItem.start_date, 'MMMM DD, YYYY')}</MetBody>
                 </Grid>
             </Grid>
@@ -44,7 +44,7 @@ const InPersonEvent = ({ eventItem }: EventProps) => {
                 <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Time:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={8} paddingLeft={2}>
                     <MetBody>
                         {`${formatDate(eventItem.start_date, 'h:mm a')} to ${formatDate(
                             eventItem.end_date,

--- a/met-web/src/components/engagement/view/widgets/Events/InPersonEvent.tsx
+++ b/met-web/src/components/engagement/view/widgets/Events/InPersonEvent.tsx
@@ -17,34 +17,34 @@ const InPersonEvent = ({ eventItem }: EventProps) => {
                 <MetBody>{eventItem.description}</MetBody>
             </Grid>
             <Grid container justifyContent={justifyContent} item xs={12}>
-                <Grid item xs={3}>
+                <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Location:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={6}>
                     <MetBody>{eventItem.location_name}</MetBody>
                 </Grid>
             </Grid>
             <Grid container justifyContent={justifyContent} item xs={12}>
-                <Grid item xs={3}>
+                <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Address:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={6}>
                     <MetBody>{eventItem.location_address}</MetBody>
                 </Grid>
             </Grid>
             <Grid item container justifyContent={justifyContent} xs={12}>
-                <Grid item xs={3}>
+                <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Date:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={8}>
+                <Grid item xs={6}>
                     <MetBody>{formatDate(eventItem.start_date, 'MMMM DD, YYYY')}</MetBody>
                 </Grid>
             </Grid>
             <Grid container justifyContent={justifyContent} item xs={12}>
-                <Grid item xs={3}>
+                <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Time:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={8}>
+                <Grid item xs={6}>
                     <MetBody>
                         {`${formatDate(eventItem.start_date, 'h:mm a')} to ${formatDate(
                             eventItem.end_date,

--- a/met-web/src/components/engagement/view/widgets/Events/VirtualSession.tsx
+++ b/met-web/src/components/engagement/view/widgets/Events/VirtualSession.tsx
@@ -15,7 +15,7 @@ const VirtualSession = ({ eventItem }: EventProps) => {
                 <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Date:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={8} paddingLeft={2}>
                     <MetBody>{formatDate(eventItem.start_date, 'MMMM DD, YYYY')}</MetBody>
                 </Grid>
             </Grid>
@@ -23,7 +23,7 @@ const VirtualSession = ({ eventItem }: EventProps) => {
                 <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Time:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={8} paddingLeft={2}>
                     <MetBody>
                         {`${formatDate(eventItem.start_date, 'h:mm a')} to ${formatDate(
                             eventItem.end_date,

--- a/met-web/src/components/engagement/view/widgets/Events/VirtualSession.tsx
+++ b/met-web/src/components/engagement/view/widgets/Events/VirtualSession.tsx
@@ -12,18 +12,18 @@ const VirtualSession = ({ eventItem }: EventProps) => {
                 <MetBody>{eventItem.description}</MetBody>
             </Grid>
             <Grid item container justifyContent={justifyContent} xs={12}>
-                <Grid item xs={3}>
+                <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Date:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={8}>
+                <Grid item xs={6}>
                     <MetBody>{formatDate(eventItem.start_date, 'MMMM DD, YYYY')}</MetBody>
                 </Grid>
             </Grid>
             <Grid container justifyContent={justifyContent} item xs={12}>
-                <Grid item xs={3}>
+                <Grid item xs={3} marginRight={2}>
                     <MetBody bold>Time:&nbsp;</MetBody>
                 </Grid>
-                <Grid item xs={8}>
+                <Grid item xs={6}>
                     <MetBody>
                         {`${formatDate(eventItem.start_date, 'h:mm a')} to ${formatDate(
                             eventItem.end_date,


### PR DESCRIPTION
*Issue #1184 :*
https://github.com/bcgov/met-public/issues/1184

-Make the event widget more responsiveness at different sizes

<img width="866" alt="image" src="https://user-images.githubusercontent.com/103138766/221985627-34a082e0-e08b-43a2-9833-50e735ffc6c7.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
