### PR TITLE
Make public widget link open a new tab

### DIFF
--- a/met-web/src/components/engagement/view/widgets/Events/VirtualSession.tsx
+++ b/met-web/src/components/engagement/view/widgets/Events/VirtualSession.tsx
@@ -33,7 +33,9 @@ const VirtualSession = ({ eventItem }: EventProps) => {
                 </Grid>
             </Grid>
             <Grid container justifyContent={justifyContent} item xs={12} sx={{ whiteSpace: 'pre-line' }}>
-                <Link href={`${eventItem.url}`}>{eventItem.url_label}</Link>
+                <Link target="_blank" href={`${eventItem.url}`}>
+                    {eventItem.url_label}
+                </Link>
             </Grid>
         </>
     );


### PR DESCRIPTION
*Issue #1184 :*
https://github.com/bcgov/met-public/issues/1184

-make url open a new tab


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
