### PR TITLE
Restrict access to engagement form page for team members

### DIFF
--- a/met-api/src/met_api/resources/engagement_members.py
+++ b/met-api/src/met_api/resources/engagement_members.py
@@ -63,14 +63,14 @@ class EngagementMembership(Resource):
 
 @cors_preflight('GET,OPTIONS')
 @API.route('/<user_id>')
-class EngagementMembership(Resource):
-    """Resource for managing engagement's membership."""
+class EngagementMembershipUser(Resource):
+    """Resource for fetching memberships for user."""
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
     @_jwt.has_one_of_roles([Role.VIEW_ASSIGNED_ENGAGEMENTS_SELF.value])
-    def get(engagement_id, user_id):
-        """Create a new membership."""
+    def get(engagement_id, user_id): # pylint: disable=unused-argument
+        """Get membership by id."""
         try:
             members = MembershipService.get_assigned_engagements(user_id)
             return jsonify(MembershipSchema().dump(members, many=True)), HTTPStatus.OK

--- a/met-api/src/met_api/resources/engagement_members.py
+++ b/met-api/src/met_api/resources/engagement_members.py
@@ -60,3 +60,19 @@ class EngagementMembership(Resource):
             return MembershipSchema().dump(member), HTTPStatus.OK
         except BusinessException as err:
             return {'message': err.error}, err.status_code
+
+@cors_preflight('GET,OPTIONS')
+@API.route('/<user_id>')
+class EngagementMembership(Resource):
+    """Resource for managing engagement's membership."""
+
+    @staticmethod
+    @cross_origin(origins=allowedorigins())
+    @_jwt.has_one_of_roles([Role.VIEW_ASSIGNED_ENGAGEMENTS_SELF.value])
+    def get(engagement_id, user_id):
+        """Create a new membership."""
+        try:
+            members = MembershipService.get_assigned_engagements(user_id)
+            return jsonify(MembershipSchema().dump(members, many=True)), HTTPStatus.OK
+        except BusinessException as err:
+            return {'message': err.error}, err.status_code

--- a/met-api/src/met_api/resources/engagement_members.py
+++ b/met-api/src/met_api/resources/engagement_members.py
@@ -69,7 +69,6 @@ class EngagementMembershipUser(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
-    @_jwt.has_one_of_roles([Role.VIEW_ASSIGNED_ENGAGEMENTS_SELF.value])
     def get(engagement_id, user_id):  # pylint: disable=unused-argument
         """Get membership by id."""
         try:

--- a/met-api/src/met_api/resources/engagement_members.py
+++ b/met-api/src/met_api/resources/engagement_members.py
@@ -61,6 +61,7 @@ class EngagementMembership(Resource):
         except BusinessException as err:
             return {'message': err.error}, err.status_code
 
+
 @cors_preflight('GET,OPTIONS')
 @API.route('/<user_id>')
 class EngagementMembershipUser(Resource):
@@ -69,7 +70,7 @@ class EngagementMembershipUser(Resource):
     @staticmethod
     @cross_origin(origins=allowedorigins())
     @_jwt.has_one_of_roles([Role.VIEW_ASSIGNED_ENGAGEMENTS_SELF.value])
-    def get(engagement_id, user_id): # pylint: disable=unused-argument
+    def get(engagement_id, user_id):  # pylint: disable=unused-argument
         """Get membership by id."""
         try:
             members = MembershipService.get_assigned_engagements(user_id)

--- a/met-api/src/met_api/services/membership_service.py
+++ b/met-api/src/met_api/services/membership_service.py
@@ -66,7 +66,7 @@ class MembershipService:
 
     @staticmethod
     def get_memberships(engagement_id):
-        """Create membership."""
+        """Get memberships by engagement id."""
         # get user to be added from request json
 
         memberships = MembershipModel.find_by_engagement(engagement_id)
@@ -75,8 +75,5 @@ class MembershipService:
 
     @staticmethod
     def get_assigned_engagements(user_id):
-        """Create membership."""
-        # get user to be added from request json
-
-        memberships = MembershipModel.find_by_user_id(user_id)
-        return [membership.engagement_id for membership in memberships]
+        """Get memberships by user id."""
+        return MembershipModel.find_by_user_id(user_id)

--- a/met-api/src/met_api/utils/roles.py
+++ b/met-api/src/met_api/utils/roles.py
@@ -36,5 +36,4 @@ class Role(Enum):
     REVIEW_COMMENTS = 'review_comments'
     ACCESS_DASHBOARD = 'access_dashboard'
     VIEW_MEMBERS = 'view_members'
-    VIEW_ASSIGNED_ENGAGEMENTS_SELF = 'view_assigned_engagements_self'
     EDIT_MEMBERS = 'edit_members'

--- a/met-api/src/met_api/utils/roles.py
+++ b/met-api/src/met_api/utils/roles.py
@@ -36,4 +36,5 @@ class Role(Enum):
     REVIEW_COMMENTS = 'review_comments'
     ACCESS_DASHBOARD = 'access_dashboard'
     VIEW_MEMBERS = 'view_members'
+    VIEW_ASSIGNED_ENGAGEMENTS_SELF = 'view_assigned_engagements_self'
     EDIT_MEMBERS = 'edit_members'

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -70,6 +70,7 @@ const Endpoints = {
     },
     EngagementTeamMembers: {
         GET_LIST: `${AppConfig.apiUrl}/engagements/engagement_id/members`,
+        GET_LIST_BY_USER: `${AppConfig.apiUrl}/engagements/all/members/user_id`,
         CREATE: `${AppConfig.apiUrl}/engagements/engagement_id/members`,
     },
     Events: {

--- a/met-web/src/components/engagement/form/ActionContext.tsx
+++ b/met-web/src/components/engagement/form/ActionContext.tsx
@@ -35,8 +35,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
 
-    const roles = useAppSelector((state) => state.user.roles);
-    const assignedEngagements = useAppSelector((state) => state.user.assignedEngagements);
+    const { roles, assignedEngagements } = useAppSelector((state) => state.user);
 
     const [isSaving, setSaving] = useState(false);
     const [loadingSavedEngagement, setLoadingSavedEngagement] = useState(true);

--- a/met-web/src/components/engagement/form/ActionContext.tsx
+++ b/met-web/src/components/engagement/form/ActionContext.tsx
@@ -5,10 +5,11 @@ import { EngagementContext, EngagementForm, EngagementFormUpdate, EngagementPara
 import { createDefaultEngagement, Engagement } from '../../../models/engagement';
 import { saveDocument } from 'services/objectStorageService';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { useAppDispatch } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { getErrorMessage } from 'utils';
 import { updatedDiff } from 'deep-object-diff';
 import { PatchEngagementRequest } from 'services/engagementService/types';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 export const ActionContext = createContext<EngagementContext>({
     handleCreateEngagementRequest: (_engagement: EngagementForm): Promise<Engagement> => {
@@ -33,6 +34,10 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
     const { engagementId } = useParams<EngagementParams>();
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
+
+    const roles = useAppSelector((state) => state.user.roles);
+    const assignedEngagements = useAppSelector((state) => state.user.assignedEngagements);
+
     const [isSaving, setSaving] = useState(false);
     const [loadingSavedEngagement, setLoadingSavedEngagement] = useState(true);
 
@@ -53,7 +58,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
 
     const fetchEngagement = async () => {
         if (engagementId !== 'create' && isNaN(Number(engagementId))) {
-            navigate('/engagements/create/form');
+            navigate('/');
         }
 
         if (engagementId === 'create') {
@@ -77,7 +82,18 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
         if (bannerImage) setBannerImage(null);
     };
 
+    const verifyUserAuthorization = () => {
+        if (roles.includes(SCOPES.viewPrivateEngagements)) {
+            return;
+        }
+
+        if (!assignedEngagements.includes(Number(engagementId))) {
+            navigate('/unauthorized');
+        }
+    };
+
     useEffect(() => {
+        verifyUserAuthorization();
         fetchEngagement();
     }, [engagementId]);
 

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementForm.tsx
@@ -11,6 +11,8 @@ import { EngagementTabsContext } from './EngagementTabsContext';
 import { SUBMISSION_STATUS } from 'constants/engagementStatus';
 import DayCalculatorModal from '../DayCalculator';
 import { ENGAGEMENT_CROPPER_ASPECT_RATIO, ENGAGMENET_UPLOADER_HEIGHT } from './constans';
+import { useAppSelector } from 'hooks';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const EngagementForm = () => {
     const {
@@ -36,6 +38,8 @@ const EngagementForm = () => {
 
     const [initialRichDescription, setInitialRichDescription] = useState('');
     const [initialRichContent, setInitialRichContent] = useState('');
+
+    const [isOpen, setIsOpen] = useState(false);
 
     const navigate = useNavigate();
 
@@ -171,8 +175,6 @@ const EngagementForm = () => {
         navigate(`/engagements/${engagement.id}/view`);
         window.scrollTo(0, 0);
     };
-
-    const [isOpen, setIsOpen] = useState(false);
 
     return (
         <MetPaper elevation={1}>

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementForm.tsx
@@ -11,8 +11,6 @@ import { EngagementTabsContext } from './EngagementTabsContext';
 import { SUBMISSION_STATUS } from 'constants/engagementStatus';
 import DayCalculatorModal from '../DayCalculator';
 import { ENGAGEMENT_CROPPER_ASPECT_RATIO, ENGAGMENET_UPLOADER_HEIGHT } from './constans';
-import { useAppSelector } from 'hooks';
-import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const EngagementForm = () => {
     const {

--- a/met-web/src/components/permissionsGate/PermissionMaps.tsx
+++ b/met-web/src/components/permissionsGate/PermissionMaps.tsx
@@ -14,4 +14,5 @@ export const SCOPES: { [scope: string]: string } = {
     viewMembers: 'view_members',
     editMembers: 'edit_members',
     appAdmin: 'app-admin',
+    viewPrivateEngagements: 'view_private_engagements',
 };

--- a/met-web/src/services/membershipService/index.tsx
+++ b/met-web/src/services/membershipService/index.tsx
@@ -24,3 +24,17 @@ export const addTeamMemberToEngagement = async ({
     const responseData = await http.PostRequest<EngagementTeamMember>(url, { user_id });
     return responseData.data;
 };
+
+interface GetMembershipsByUserParams {
+    user_id?: string;
+}
+export const getMembershipsByUser = async ({
+    user_id,
+}: GetMembershipsByUserParams): Promise<EngagementTeamMember[]> => {
+    if (!user_id) {
+        return [];
+    }
+    const url = replaceUrl(Endpoints.EngagementTeamMembers.GET_LIST_BY_USER, 'user_id', String(user_id));
+    const responseData = await http.GetRequest<EngagementTeamMember[]>(url);
+    return responseData.data ?? [];
+};

--- a/met-web/src/services/userService/types.ts
+++ b/met-web/src/services/userService/types.ts
@@ -1,3 +1,4 @@
+import { Engagement } from 'models/engagement';
 import { User } from 'models/user';
 
 export interface UserDetail {
@@ -19,4 +20,5 @@ export interface UserState {
     authentication: UserAuthentication;
     currentPage: string;
     isAuthorized: boolean;
+    assignedEngagements: number[];
 }

--- a/met-web/src/services/userService/types.ts
+++ b/met-web/src/services/userService/types.ts
@@ -1,4 +1,3 @@
-import { Engagement } from 'models/engagement';
 import { User } from 'models/user';
 
 export interface UserDetail {

--- a/met-web/src/services/userService/userSlice.ts
+++ b/met-web/src/services/userService/userSlice.ts
@@ -15,6 +15,7 @@ const initialState: UserState = {
     },
     currentPage: '',
     isAuthorized: false,
+    assignedEngagements: [],
 };
 
 export const userSlice = createSlice({
@@ -43,10 +44,14 @@ export const userSlice = createSlice({
                 loading: false,
             };
         },
+        assignedEngagements: (state, action: PayloadAction<number[]>) => {
+            state.assignedEngagements = action.payload;
+        },
     },
 });
 
 // Action creators are generated for each case reducer function
-export const { userToken, userRoles, userDetails, userAuthorization, userAuthentication } = userSlice.actions;
+export const { userToken, userRoles, userDetails, userAuthorization, userAuthentication, assignedEngagements } =
+    userSlice.actions;
 
 export default userSlice.reducer;

--- a/met-web/tests/unit/components/engagement/EngagementForm.test.tsx
+++ b/met-web/tests/unit/components/engagement/EngagementForm.test.tsx
@@ -12,6 +12,7 @@ import { createDefaultSurvey, Survey } from 'models/survey';
 import { WidgetType } from 'models/widget';
 import { Box } from '@mui/material';
 import { draftEngagement } from '../factory';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const survey: Survey = {
     ...createDefaultSurvey(),
@@ -21,6 +22,16 @@ const survey: Survey = {
 };
 
 const surveys = [survey];
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [draftEngagement.id],
+        };
+    }),
+}));
 
 jest.mock('components/common/Dragdrop', () => ({
     ...jest.requireActual('components/common/Dragdrop'),
@@ -53,7 +64,6 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 }));
 
 describe('Engagement form page tests', () => {
-    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const openNotificationMock = jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());

--- a/met-web/tests/unit/components/engagement/EngagementFormUserTab.test.tsx
+++ b/met-web/tests/unit/components/engagement/EngagementFormUserTab.test.tsx
@@ -11,6 +11,7 @@ import { Box } from '@mui/material';
 import { draftEngagement } from '../factory';
 import { initialDefaultUser, USER_GROUP } from 'models/user';
 import { EngagementTeamMember, initialDefaultTeamMember } from 'models/engagementTeamMember';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const mockTeamMember1: EngagementTeamMember = {
     ...initialDefaultTeamMember,
@@ -23,6 +24,16 @@ const mockTeamMember1: EngagementTeamMember = {
         groups: [USER_GROUP.VIEWER.label],
     },
 };
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [draftEngagement.id],
+        };
+    }),
+}));
 
 jest.mock('components/common/Dragdrop', () => ({
     ...jest.requireActual('components/common/Dragdrop'),
@@ -62,7 +73,6 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 }));
 
 describe('Engagement form page tests', () => {
-    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     jest.spyOn(teamMemberService, 'getTeamMembers').mockReturnValue(Promise.resolve([mockTeamMember1]));

--- a/met-web/tests/unit/components/widgets/DocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/DocumentWidget.test.tsx
@@ -13,6 +13,7 @@ import { createDefaultEngagement, Engagement } from 'models/engagement';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { Widget, WidgetType } from 'models/widget';
 import { DocumentItem } from 'models/document';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const engagement: Engagement = {
     ...createDefaultEngagement(),
@@ -54,6 +55,16 @@ const documentWidget: Widget = {
     items: [],
 };
 
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [engagement.id],
+        };
+    }),
+}));
+
 jest.mock('@reduxjs/toolkit/query/react', () => ({
     ...jest.requireActual('@reduxjs/toolkit/query/react'),
     fetchBaseQuery: jest.fn(),
@@ -74,7 +85,6 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 }));
 
 describe('Document widget in engagement page tests', () => {
-    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());

--- a/met-web/tests/unit/components/widgets/EventsWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/EventsWidget.test.tsx
@@ -10,6 +10,17 @@ import * as widgetService from 'services/widgetService';
 import { Box } from '@mui/material';
 import { WidgetType } from 'models/widget';
 import { draftEngagement, surveys, mockEvent, eventWidget } from '../factory';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [draftEngagement.id],
+        };
+    }),
+}));
 
 jest.mock('@reduxjs/toolkit/query/react', () => ({
     ...jest.requireActual('@reduxjs/toolkit/query/react'),
@@ -58,7 +69,6 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 }));
 
 describe('Event Widget tests', () => {
-    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');

--- a/met-web/tests/unit/components/widgets/PhasesWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/PhasesWidget.test.tsx
@@ -10,6 +10,7 @@ import * as widgetService from 'services/widgetService';
 import { createDefaultSurvey, Survey } from 'models/survey';
 import { Widget, WidgetItem, WidgetType } from 'models/widget';
 import { draftEngagement } from '../factory';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const survey: Survey = {
     ...createDefaultSurvey(),
@@ -34,6 +35,16 @@ const phasesWidget: Widget = {
     items: [],
 };
 
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [draftEngagement.id],
+        };
+    }),
+}));
+
 jest.mock('@reduxjs/toolkit/query/react', () => ({
     ...jest.requireActual('@reduxjs/toolkit/query/react'),
     fetchBaseQuery: jest.fn(),
@@ -54,7 +65,6 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 }));
 
 describe('Phases widget tests', () => {
-    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');

--- a/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
@@ -12,6 +12,7 @@ import { Widget, WidgetItem, WidgetType } from 'models/widget';
 import { Contact } from 'models/contact';
 import { Box } from '@mui/material';
 import { draftEngagement } from '../factory';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const survey: Survey = {
     ...createDefaultSurvey(),
@@ -47,6 +48,16 @@ const whoIsListeningWidget: Widget = {
     engagement_id: 1,
     items: [contactWidgetItem],
 };
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [draftEngagement.id],
+        };
+    }),
+}));
 
 jest.mock('@reduxjs/toolkit/query/react', () => ({
     ...jest.requireActual('@reduxjs/toolkit/query/react'),
@@ -103,7 +114,6 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 }));
 
 describe('Who is Listening widget  tests', () => {
-    jest.spyOn(reactRedux, 'useSelector').mockImplementation(() => jest.fn());
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
     jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1281

*Description of changes:*

- Allow team members to visit engagement form page for their engagements only
- fix team members draft engagement filter
- Add assigned engagement ids to redux
- Mock use selector in unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
