### PR TITLE
Downgrade maplibre library

### DIFF
--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -43,7 +43,7 @@
                 "jsonwebtoken": "^9.0.0",
                 "keycloak-js": "^10.0.2",
                 "lodash": "^4.17.21",
-                "mapbox-gl": "^1.13.3",
+                "mapbox-gl": "^2.13.0",
                 "maplibre-gl": "^2.4.0",
                 "met-formio": "^1.0.10-rc.2",
                 "mui-sx": "^1.0.0",
@@ -3223,11 +3223,6 @@
             "bin": {
                 "geojson-rewind": "geojson-rewind"
             }
-        },
-        "node_modules/@mapbox/geojson-types": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-            "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
         },
         "node_modules/@mapbox/jsonlint-lines-primitives": {
             "version": "2.0.2",
@@ -14068,54 +14063,37 @@
             }
         },
         "node_modules/mapbox-gl": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
-            "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.13.0.tgz",
+            "integrity": "sha512-G8pU1/I9HC7xNbhKPKFtRkdUDkWJBNbYPMeRjBig3lPaYtvHPIaFmXMR6BDyZ/gnwodElrwMZGdGsoH8kecX8w==",
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
-                "@mapbox/geojson-types": "^1.0.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-                "@mapbox/mapbox-gl-supported": "^1.5.0",
+                "@mapbox/mapbox-gl-supported": "^2.0.1",
                 "@mapbox/point-geometry": "^0.1.0",
-                "@mapbox/tiny-sdf": "^1.1.1",
-                "@mapbox/unitbezier": "^0.0.0",
+                "@mapbox/tiny-sdf": "^2.0.6",
+                "@mapbox/unitbezier": "^0.0.1",
                 "@mapbox/vector-tile": "^1.3.1",
                 "@mapbox/whoots-js": "^3.1.0",
                 "csscolorparser": "~1.0.3",
-                "earcut": "^2.2.2",
+                "earcut": "^2.2.4",
                 "geojson-vt": "^3.2.1",
-                "gl-matrix": "^3.2.1",
+                "gl-matrix": "^3.4.3",
                 "grid-index": "^1.1.0",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
-                "potpack": "^1.0.1",
+                "potpack": "^2.0.0",
                 "quickselect": "^2.0.0",
                 "rw": "^1.3.3",
-                "supercluster": "^7.1.0",
+                "supercluster": "^7.1.5",
                 "tinyqueue": "^2.0.3",
-                "vt-pbf": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6.4.0"
+                "vt-pbf": "^3.1.3"
             }
         },
-        "node_modules/mapbox-gl/node_modules/@mapbox/mapbox-gl-supported": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-            "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-            "peerDependencies": {
-                "mapbox-gl": ">=0.32.1 <2.0.0"
-            }
-        },
-        "node_modules/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-            "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
-        },
-        "node_modules/mapbox-gl/node_modules/@mapbox/unitbezier": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-            "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+        "node_modules/mapbox-gl/node_modules/potpack": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+            "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
         },
         "node_modules/maplibre-gl": {
             "version": "2.4.0",
@@ -24377,11 +24355,6 @@
                 "minimist": "^1.2.6"
             }
         },
-        "@mapbox/geojson-types": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-            "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
-        },
         "@mapbox/jsonlint-lines-primitives": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -32441,48 +32414,37 @@
             "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
         },
         "mapbox-gl": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
-            "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.13.0.tgz",
+            "integrity": "sha512-G8pU1/I9HC7xNbhKPKFtRkdUDkWJBNbYPMeRjBig3lPaYtvHPIaFmXMR6BDyZ/gnwodElrwMZGdGsoH8kecX8w==",
             "requires": {
                 "@mapbox/geojson-rewind": "^0.5.2",
-                "@mapbox/geojson-types": "^1.0.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-                "@mapbox/mapbox-gl-supported": "^1.5.0",
+                "@mapbox/mapbox-gl-supported": "^2.0.1",
                 "@mapbox/point-geometry": "^0.1.0",
-                "@mapbox/tiny-sdf": "^1.1.1",
-                "@mapbox/unitbezier": "^0.0.0",
+                "@mapbox/tiny-sdf": "^2.0.6",
+                "@mapbox/unitbezier": "^0.0.1",
                 "@mapbox/vector-tile": "^1.3.1",
                 "@mapbox/whoots-js": "^3.1.0",
                 "csscolorparser": "~1.0.3",
-                "earcut": "^2.2.2",
+                "earcut": "^2.2.4",
                 "geojson-vt": "^3.2.1",
-                "gl-matrix": "^3.2.1",
+                "gl-matrix": "^3.4.3",
                 "grid-index": "^1.1.0",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
-                "potpack": "^1.0.1",
+                "potpack": "^2.0.0",
                 "quickselect": "^2.0.0",
                 "rw": "^1.3.3",
-                "supercluster": "^7.1.0",
+                "supercluster": "^7.1.5",
                 "tinyqueue": "^2.0.3",
-                "vt-pbf": "^3.1.1"
+                "vt-pbf": "^3.1.3"
             },
             "dependencies": {
-                "@mapbox/mapbox-gl-supported": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-                    "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
-                },
-                "@mapbox/tiny-sdf": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-                    "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
-                },
-                "@mapbox/unitbezier": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-                    "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+                "potpack": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+                    "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
                 }
             }
         },

--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -44,7 +44,7 @@
                 "keycloak-js": "^10.0.2",
                 "lodash": "^4.17.21",
                 "mapbox-gl": "^2.13.0",
-                "maplibre-gl": "^2.4.0",
+                "maplibre-gl": "^1.15.3",
                 "met-formio": "^1.0.10-rc.2",
                 "mui-sx": "^1.0.0",
                 "node-sass": "^7.0.3",
@@ -3224,6 +3224,11 @@
                 "geojson-rewind": "geojson-rewind"
             }
         },
+        "node_modules/@mapbox/geojson-types": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+            "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+        },
         "node_modules/@mapbox/jsonlint-lines-primitives": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -4534,21 +4539,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/mapbox__point-geometry": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-            "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
-        },
-        "node_modules/@types/mapbox__vector-tile": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-            "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
-            "dependencies": {
-                "@types/geojson": "*",
-                "@types/mapbox__point-geometry": "*",
-                "@types/pbf": "*"
-            }
-        },
         "node_modules/@types/mapbox-gl": {
             "version": "2.7.10",
             "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz",
@@ -4592,11 +4582,6 @@
             "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
             "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
             "dev": true
-        },
-        "node_modules/@types/pbf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-            "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
         },
         "node_modules/@types/prettier": {
             "version": "2.6.4",
@@ -14096,36 +14081,55 @@
             "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
         },
         "node_modules/maplibre-gl": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.4.0.tgz",
-            "integrity": "sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==",
-            "hasInstallScript": true,
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.3.tgz",
+            "integrity": "sha512-ZuOhLCNgp7Yl1L9uyKgZeuo7kKdewP0iWtmEXsZ/snp0JiVkR1Kl+m1rsfKT/wpm/O4zZ7mUGxF16cYbMIFDRA==",
             "dependencies": {
-                "@mapbox/geojson-rewind": "^0.5.2",
+                "@mapbox/geojson-rewind": "^0.5.0",
+                "@mapbox/geojson-types": "^1.0.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-                "@mapbox/mapbox-gl-supported": "^2.0.1",
+                "@mapbox/mapbox-gl-supported": "^1.5.0",
                 "@mapbox/point-geometry": "^0.1.0",
-                "@mapbox/tiny-sdf": "^2.0.5",
-                "@mapbox/unitbezier": "^0.0.1",
+                "@mapbox/tiny-sdf": "^1.1.1",
+                "@mapbox/unitbezier": "^0.0.0",
                 "@mapbox/vector-tile": "^1.3.1",
                 "@mapbox/whoots-js": "^3.1.0",
-                "@types/geojson": "^7946.0.10",
-                "@types/mapbox__point-geometry": "^0.1.2",
-                "@types/mapbox__vector-tile": "^1.3.0",
-                "@types/pbf": "^3.0.2",
                 "csscolorparser": "~1.0.3",
-                "earcut": "^2.2.4",
+                "earcut": "^2.2.2",
                 "geojson-vt": "^3.2.1",
-                "gl-matrix": "^3.4.3",
-                "global-prefix": "^3.0.0",
+                "gl-matrix": "^3.2.1",
+                "grid-index": "^1.1.0",
+                "minimist": "^1.2.6",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
-                "potpack": "^1.0.2",
+                "potpack": "^1.0.1",
                 "quickselect": "^2.0.0",
-                "supercluster": "^7.1.5",
+                "rw": "^1.3.3",
+                "supercluster": "^7.1.0",
                 "tinyqueue": "^2.0.3",
-                "vt-pbf": "^3.1.3"
+                "vt-pbf": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6.4.0"
             }
+        },
+        "node_modules/maplibre-gl/node_modules/@mapbox/mapbox-gl-supported": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+            "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+            "peerDependencies": {
+                "mapbox-gl": ">=0.32.1 <2.0.0"
+            }
+        },
+        "node_modules/maplibre-gl/node_modules/@mapbox/tiny-sdf": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+            "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+        },
+        "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+            "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
         },
         "node_modules/md5.js": {
             "version": "1.3.5",
@@ -24355,6 +24359,11 @@
                 "minimist": "^1.2.6"
             }
         },
+        "@mapbox/geojson-types": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+            "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+        },
         "@mapbox/jsonlint-lines-primitives": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -25210,21 +25219,6 @@
                 "@types/lodash": "*"
             }
         },
-        "@types/mapbox__point-geometry": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-            "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
-        },
-        "@types/mapbox__vector-tile": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-            "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
-            "requires": {
-                "@types/geojson": "*",
-                "@types/mapbox__point-geometry": "*",
-                "@types/pbf": "*"
-            }
-        },
         "@types/mapbox-gl": {
             "version": "2.7.10",
             "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz",
@@ -25268,11 +25262,6 @@
             "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
             "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
             "dev": true
-        },
-        "@types/pbf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-            "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
         },
         "@types/prettier": {
             "version": "2.6.4",
@@ -32449,34 +32438,50 @@
             }
         },
         "maplibre-gl": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.4.0.tgz",
-            "integrity": "sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==",
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.3.tgz",
+            "integrity": "sha512-ZuOhLCNgp7Yl1L9uyKgZeuo7kKdewP0iWtmEXsZ/snp0JiVkR1Kl+m1rsfKT/wpm/O4zZ7mUGxF16cYbMIFDRA==",
             "requires": {
-                "@mapbox/geojson-rewind": "^0.5.2",
+                "@mapbox/geojson-rewind": "^0.5.0",
+                "@mapbox/geojson-types": "^1.0.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-                "@mapbox/mapbox-gl-supported": "^2.0.1",
+                "@mapbox/mapbox-gl-supported": "^1.5.0",
                 "@mapbox/point-geometry": "^0.1.0",
-                "@mapbox/tiny-sdf": "^2.0.5",
-                "@mapbox/unitbezier": "^0.0.1",
+                "@mapbox/tiny-sdf": "^1.1.1",
+                "@mapbox/unitbezier": "^0.0.0",
                 "@mapbox/vector-tile": "^1.3.1",
                 "@mapbox/whoots-js": "^3.1.0",
-                "@types/geojson": "^7946.0.10",
-                "@types/mapbox__point-geometry": "^0.1.2",
-                "@types/mapbox__vector-tile": "^1.3.0",
-                "@types/pbf": "^3.0.2",
                 "csscolorparser": "~1.0.3",
-                "earcut": "^2.2.4",
+                "earcut": "^2.2.2",
                 "geojson-vt": "^3.2.1",
-                "gl-matrix": "^3.4.3",
-                "global-prefix": "^3.0.0",
+                "gl-matrix": "^3.2.1",
+                "grid-index": "^1.1.0",
+                "minimist": "^1.2.6",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
-                "potpack": "^1.0.2",
+                "potpack": "^1.0.1",
                 "quickselect": "^2.0.0",
-                "supercluster": "^7.1.5",
+                "rw": "^1.3.3",
+                "supercluster": "^7.1.0",
                 "tinyqueue": "^2.0.3",
-                "vt-pbf": "^3.1.3"
+                "vt-pbf": "^3.1.1"
+            },
+            "dependencies": {
+                "@mapbox/mapbox-gl-supported": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+                    "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
+                },
+                "@mapbox/tiny-sdf": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+                    "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+                },
+                "@mapbox/unitbezier": {
+                    "version": "0.0.0",
+                    "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+                    "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+                }
             }
         },
         "md5.js": {

--- a/met-web/package.json
+++ b/met-web/package.json
@@ -39,7 +39,7 @@
         "keycloak-js": "^10.0.2",
         "lodash": "^4.17.21",
         "mapbox-gl": "^2.13.0",
-        "maplibre-gl": "^2.4.0",
+        "maplibre-gl": "^1.15.3",
         "met-formio": "^1.0.10-rc.2",
         "mui-sx": "^1.0.0",
         "node-sass": "^7.0.3",

--- a/met-web/package.json
+++ b/met-web/package.json
@@ -38,7 +38,7 @@
         "jsonwebtoken": "^9.0.0",
         "keycloak-js": "^10.0.2",
         "lodash": "^4.17.21",
-        "mapbox-gl": "^1.13.3",
+        "mapbox-gl": "^2.13.0",
         "maplibre-gl": "^2.4.0",
         "met-formio": "^1.0.10-rc.2",
         "mui-sx": "^1.0.0",


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1290

*Description of changes:*

- https://github.com/mapbox/mapbox-gl-js/issues/10240
- downgrade maplibre to older version where uglify v >2 wasn't used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
