### PR TITLE
adding logic to auto aprv submission without cmnt

### DIFF
--- a/met-api/src/met_api/models/submission.py
+++ b/met-api/src/met_api/models/submission.py
@@ -55,13 +55,13 @@ class Submission(BaseModel):  # pylint: disable=too-few-public-methods
         """Save submission."""
         has_comments = cls.__check_if_submission_has_comments(submission)
         if has_comments:
-            const_comment_status=Status.Pending.value
-            const_reviewed_by=None
-            const_review_date=None
+            const_comment_status = Status.Pending.value
+            const_reviewed_by = None
+            const_review_date = None
         else:
-            const_comment_status=Status.Approved.value
-            const_reviewed_by='System'
-            const_review_date=datetime.utcnow()
+            const_comment_status = Status.Approved.value
+            const_reviewed_by = 'System'
+            const_review_date = datetime.utcnow()
 
         new_submission = Submission(
             submission_json=submission.get('submission_json', None),
@@ -83,30 +83,30 @@ class Submission(BaseModel):  # pylint: disable=too-few-public-methods
             session.add(new_submission)
             session.flush()
         return new_submission
-    
+
     @staticmethod
     def __check_if_submission_has_comments(submission: SubmissionSchema):
         """Check if comment exists."""
         if 'simpletextarea' not in submission.get('submission_json', None) and \
-            'simpletextfield' not in submission.get('submission_json', None):
+           'simpletextfield' not in submission.get('submission_json', None):
             return False
-        
+
         if 'simpletextarea' in submission.get('submission_json', None) and \
-            'simpletextfield' in submission.get('submission_json', None):
+           'simpletextfield' in submission.get('submission_json', None):
             if len(submission.get('submission_json', None)['simpletextarea']) == 0 and \
                len(submission.get('submission_json', None)['simpletextfield']) == 0:
                 return False
 
         if 'simpletextarea' in submission.get('submission_json', None) and \
-            'simpletextfield' not in submission.get('submission_json', None):
+           'simpletextfield' not in submission.get('submission_json', None):
             if len(submission.get('submission_json', None)['simpletextarea']) == 0:
                 return False
 
         if 'simpletextarea' not in submission.get('submission_json', None) and \
-            'simpletextfield' in submission.get('submission_json', None):
+           'simpletextfield' in submission.get('submission_json', None):
             if len(submission.get('submission_json', None)['simpletextfield']) == 0:
                 return False
-            
+
         return True
 
     @classmethod
@@ -169,8 +169,8 @@ class Submission(BaseModel):  # pylint: disable=too-few-public-methods
     def get_by_survey_id_paginated(cls, survey_id, pagination_options: PaginationOptions, search_text=''):
         """Get submissions by survey id paginated."""
         query = db.session.query(Submission)\
-            .filter(Submission.survey_id == survey_id, 
-                    or_(Submission.reviewed_by!='System', Submission.reviewed_by == None))\
+            .filter(Submission.survey_id == survey_id,
+                    or_(Submission.reviewed_by != 'System', Submission.reviewed_by is None))\
 
         if search_text:
             # Remove all non-digit characters from search text

--- a/met-api/tests/unit/services/test_submission.py
+++ b/met-api/tests/unit/services/test_submission.py
@@ -83,7 +83,7 @@ def test_review_comment(client, jwt, session):  # pylint:disable=unused-argument
 
 
 def test_auto_approval_of_submissions_without_comment(session):  # pylint:disable=unused-argument
-    """Assert that a submission can be Created."""
+    """Assert that a submission without comment is auto approved."""
     survey, eng = factory_survey_and_eng_model()
     email_verification = factory_email_verification(survey.id)
     user_details = factory_user_model()

--- a/met-api/tests/unit/services/test_submission.py
+++ b/met-api/tests/unit/services/test_submission.py
@@ -98,3 +98,21 @@ def test_auto_approval_of_submissions_without_comment(session):  # pylint:disabl
 
     assert submission is not None
     assert submission.comment_status_id == Status.Approved.value
+
+
+def test_submissions_with_comment_are_not_auto_approved(session):  # pylint:disable=unused-argument
+    """Assert that a submission with comment is not auto approved."""
+    survey, eng = factory_survey_and_eng_model()
+    email_verification = factory_email_verification(survey.id)
+    user_details = factory_user_model()
+
+    submission_request: SubmissionSchema = {
+        'submission_json': {'simplepostalcode': 'abc', 'simpletextarea': 'Test Comment'},
+        'survey_id': survey.id,
+        'user_id': user_details.id,
+        'verification_token': email_verification.verification_token,
+    }
+    submission = SubmissionService().create(email_verification.verification_token, submission_request)
+
+    assert submission is not None
+    assert submission.comment_status_id == Status.Pending.value


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1370

*Description of changes:*
changes to auto approve submissions which:
- do not have a textarea or textfield in the submission json
- has textarea or textfield in the submission json but have a null value

changes to exclude auto approved submissions from comment listing page as they do not have a comment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
