### PR TITLE
Add multi page option in survey creation

### DIFF
--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -32,7 +32,7 @@ const SurveyFormBuilder = () => {
     const [savedEngagement, setSavedEngagement] = useState<Engagement | null>(null);
 
     const [formDefinition, setFormDefinition] = useState<FormBuilderData>({ display: 'form', components: [] });
-
+    const isMultiPage = formDefinition.display === 'wizard';
     const hasEngagement = Boolean(savedSurvey?.engagement_id);
     const isEngagementDraft = savedEngagement?.status_id === EngagementStatus.Draft;
     const hasPublishedEngagement = hasEngagement && !isEngagementDraft;
@@ -228,13 +228,9 @@ const SurveyFormBuilder = () => {
                                                 subText: [
                                                     {
                                                         text: `You will be changing the survey type from ${
-                                                            formDefinition.display === 'wizard'
-                                                                ? 'multi page'
-                                                                : 'single page'
-                                                        } to ${
-                                                            formDefinition.display === 'wizard'
-                                                                ? 'single page'
-                                                                : 'multi page'
+                                                            isMultiPage
+                                                                ? 'multi page to single page'
+                                                                : 'single page to multi page'
                                                         }.`,
                                                     },
                                                     {
@@ -247,8 +243,7 @@ const SurveyFormBuilder = () => {
                                                 ],
                                                 handleConfirm: () => {
                                                     setFormDefinition({
-                                                        display:
-                                                            formDefinition.display === 'wizard' ? 'form' : 'wizard',
+                                                        display: isMultiPage ? 'form' : 'wizard',
                                                         components: [],
                                                     });
                                                 },

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -218,7 +218,7 @@ const SurveyFormBuilder = () => {
                     <FormControlLabel
                         control={
                             <Switch
-                                checked={formDefinition.display === 'wizard'}
+                                checked={isMultiPage}
                                 onChange={(e) => {
                                     dispatch(
                                         openNotificationModal({
@@ -227,11 +227,10 @@ const SurveyFormBuilder = () => {
                                                 header: 'Change Survey Type',
                                                 subText: [
                                                     {
-                                                        text: `You will be changing the survey type from ${
-                                                            isMultiPage
-                                                                ? 'multi page to single page'
-                                                                : 'single page to multi page'
-                                                        }.`,
+                                                        text: `You will be changing the survey type from ${isMultiPage
+                                                            ? 'multi page to single page'
+                                                            : 'single page to multi page'
+                                                            }.`,
                                                     },
                                                     {
                                                         text: 'You will lose all current progress if you do.',

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -228,9 +228,13 @@ const SurveyFormBuilder = () => {
                                                 subText: [
                                                     {
                                                         text: `You will be changing the survey type from ${
-                                                            formDefinition.display === 'wizard' ? 'multi-page' : 'form'
+                                                            formDefinition.display === 'wizard'
+                                                                ? 'multi page'
+                                                                : 'single page'
                                                         } to ${
-                                                            formDefinition.display === 'wizard' ? 'form' : 'multi-page'
+                                                            formDefinition.display === 'wizard'
+                                                                ? 'single page'
+                                                                : 'multi page'
                                                         }.`,
                                                     },
                                                     {

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -227,10 +227,11 @@ const SurveyFormBuilder = () => {
                                                 header: 'Change Survey Type',
                                                 subText: [
                                                     {
-                                                        text: `You will be changing the survey type from ${isMultiPage
-                                                            ? 'multi page to single page'
-                                                            : 'single page to multi page'
-                                                            }.`,
+                                                        text: `You will be changing the survey type from ${
+                                                            isMultiPage
+                                                                ? 'multi page to single page'
+                                                                : 'single page to multi page'
+                                                        }.`,
                                                     },
                                                     {
                                                         text: 'You will lose all current progress if you do.',

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -15,6 +15,7 @@ import { FormBuilderData } from 'components/Form/types';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
+import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
 
 const SurveyFormBuilder = () => {
     const navigate = useNavigate();
@@ -219,11 +220,38 @@ const SurveyFormBuilder = () => {
                             <Switch
                                 checked={formDefinition.display === 'wizard'}
                                 onChange={(e) => {
-                                    if (e.target.checked) {
-                                        setFormDefinition({ display: 'wizard', components: [] });
-                                        return;
-                                    }
-                                    setFormDefinition({ display: 'form', components: [] });
+                                    dispatch(
+                                        openNotificationModal({
+                                            open: true,
+                                            data: {
+                                                header: 'Change Survey Type',
+                                                subText: [
+                                                    {
+                                                        text: `You will be changing the survey type from ${
+                                                            formDefinition.display === 'wizard' ? 'multi-page' : 'form'
+                                                        } to ${
+                                                            formDefinition.display === 'wizard' ? 'form' : 'multi-page'
+                                                        }.`,
+                                                    },
+                                                    {
+                                                        text: 'You will lose all current progress if you do.',
+                                                        bold: true,
+                                                    },
+                                                    {
+                                                        text: 'Do you want to change this survey type?',
+                                                    },
+                                                ],
+                                                handleConfirm: () => {
+                                                    setFormDefinition({
+                                                        display:
+                                                            formDefinition.display === 'wizard' ? 'form' : 'wizard',
+                                                        components: [],
+                                                    });
+                                                },
+                                            },
+                                            type: 'confirm',
+                                        }),
+                                    );
                                 }}
                             />
                         }

--- a/met-web/src/components/survey/create/CreateOptions.tsx
+++ b/met-web/src/components/survey/create/CreateOptions.tsx
@@ -1,16 +1,11 @@
 import React, { useContext, useState } from 'react';
-import { Grid, TextField, Stack, Autocomplete } from '@mui/material';
+import { Grid, TextField, Stack, FormGroup, FormControlLabel, Switch } from '@mui/material';
 import { CreateSurveyContext } from './CreateSurveyContext';
 import { useNavigate } from 'react-router-dom';
 import { postSurvey } from 'services/surveyService';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { MetLabel, PrimaryButton, SecondaryButton } from 'components/common';
-
-enum SurveyType {
-    Single = 'single',
-    Multi = 'multi',
-}
 
 export const CreateOptions = () => {
     const navigate = useNavigate();
@@ -20,7 +15,7 @@ export const CreateOptions = () => {
     const initialFormError = {
         name: false,
     };
-    const [surveyType, setSurveyType] = useState<SurveyType | null>(SurveyType.Single);
+    const [multiPageSurvey, setMultiPageSurvey] = useState<boolean>(true);
     const [formError, setFormError] = useState(initialFormError);
     const [isSaving, setIsSaving] = useState(false);
     const getErrorMessage = () => {
@@ -57,7 +52,7 @@ export const CreateOptions = () => {
                 name: surveyForm.name,
                 engagement_id: engagementToLink?.id ? String(engagementToLink.id) : undefined,
                 form_json: {
-                    display: surveyType === 'multi' ? 'wizard' : 'form',
+                    display: multiPageSurvey ? 'wizard' : 'form',
                     components: [],
                 },
             });
@@ -102,27 +97,19 @@ export const CreateOptions = () => {
             </Grid>
             <Grid item xs={6}></Grid>
             <Grid item xs={6}>
-                <MetLabel sx={{ marginBottom: '2px' }}>Select Survey Type</MetLabel>
-                <Autocomplete
-                    id="survey-type-selector"
-                    options={[SurveyType.Single, SurveyType.Multi]}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label=" "
-                            InputLabelProps={{
-                                shrink: false,
-                            }}
-                            fullWidth
-                        />
-                    )}
-                    size="small"
-                    getOptionLabel={(type: SurveyType) => type}
-                    value={surveyType}
-                    onChange={(_e: React.SyntheticEvent<Element, Event>, type: SurveyType | null) =>
-                        setSurveyType(type)
-                    }
-                />
+                <FormGroup>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={multiPageSurvey}
+                                onChange={(e) => {
+                                    setMultiPageSurvey(!multiPageSurvey);
+                                }}
+                            />
+                        }
+                        label="Multi-page"
+                    />
+                </FormGroup>
             </Grid>
             <Grid item xs={12}>
                 <Stack direction="row" spacing={2}>

--- a/met-web/src/components/survey/create/CreateOptions.tsx
+++ b/met-web/src/components/survey/create/CreateOptions.tsx
@@ -1,11 +1,16 @@
 import React, { useContext, useState } from 'react';
-import { Grid, TextField, Stack } from '@mui/material';
+import { Grid, TextField, Stack, Autocomplete } from '@mui/material';
 import { CreateSurveyContext } from './CreateSurveyContext';
 import { useNavigate } from 'react-router-dom';
 import { postSurvey } from 'services/surveyService';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { MetLabel, PrimaryButton, SecondaryButton } from 'components/common';
+
+enum SurveyType {
+    Single = 'single',
+    Multi = 'multi',
+}
 
 export const CreateOptions = () => {
     const navigate = useNavigate();
@@ -15,6 +20,7 @@ export const CreateOptions = () => {
     const initialFormError = {
         name: false,
     };
+    const [surveyType, setSurveyType] = useState<SurveyType | null>(SurveyType.Single);
     const [formError, setFormError] = useState(initialFormError);
     const [isSaving, setIsSaving] = useState(false);
     const getErrorMessage = () => {
@@ -51,7 +57,7 @@ export const CreateOptions = () => {
                 name: surveyForm.name,
                 engagement_id: engagementToLink?.id ? String(engagementToLink.id) : undefined,
                 form_json: {
-                    display: 'form',
+                    display: surveyType === 'multi' ? 'wizard' : 'form',
                     components: [],
                 },
             });
@@ -92,6 +98,30 @@ export const CreateOptions = () => {
                     onChange={handleChange}
                     error={formError.name || name.length > 50}
                     helperText={getErrorMessage()}
+                />
+            </Grid>
+            <Grid item xs={6}></Grid>
+            <Grid item xs={6}>
+                <MetLabel sx={{ marginBottom: '2px' }}>Select Survey Type</MetLabel>
+                <Autocomplete
+                    id="survey-type-selector"
+                    options={[SurveyType.Single, SurveyType.Multi]}
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            label=" "
+                            InputLabelProps={{
+                                shrink: false,
+                            }}
+                            fullWidth
+                        />
+                    )}
+                    size="small"
+                    getOptionLabel={(type: SurveyType) => type}
+                    value={surveyType}
+                    onChange={(_e: React.SyntheticEvent<Element, Event>, type: SurveyType | null) =>
+                        setSurveyType(type)
+                    }
                 />
             </Grid>
             <Grid item xs={12}>


### PR DESCRIPTION
*Issue #1453 :*
https://github.com/bcgov/met-public/issues/1453

-Added auto-complete component to start survey as multi-page

<img width="907" alt="image" src="https://user-images.githubusercontent.com/103138766/229562524-0d76487a-3892-4f14-b0d4-61a4ae4ca954.png">

-Added a modal to warn users that switching survey type will remove all their current progress

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/103138766/229562837-58bada0d-787b-4d26-b4ed-1d7e8f193043.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
