### PR TITLE
display shapefiles with only lines

### DIFF
--- a/met-web/src/components/map/index.tsx
+++ b/met-web/src/components/map/index.tsx
@@ -25,6 +25,16 @@ const layerStyle: AnyLayer = {
     },
 };
 
+const lineStyle: AnyLayer = {
+    id: 'lines',
+    type: 'line',
+    source: 'lines',
+    paint: {
+        'line-width': 1,
+        'line-color': '#00ffff',
+    },
+};
+
 const MetMap = ({ geojson, latitude, longitude, markerLabel }: MapProps) => {
     return (
         <ReactMapGL
@@ -44,6 +54,7 @@ const MetMap = ({ geojson, latitude, longitude, markerLabel }: MapProps) => {
             <When condition={Boolean(geojson)}>
                 <Source id="geojson-data" type="geojson" data={geojson}>
                     <Layer {...layerStyle} />
+                    <Layer {...lineStyle} />
                 </Source>
             </When>
             <Marker latitude={latitude} longitude={longitude} anchor="bottom">


### PR DESCRIPTION
*Issue #1446 :*
https://github.com/bcgov/met-public/issues/1446

-Add layer line layer to map widget

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
