### PR TITLE
Add comment count badges to survey listing page

### DIFF
--- a/met-api/src/met_api/schemas/survey.py
+++ b/met-api/src/met_api/schemas/survey.py
@@ -38,7 +38,7 @@ class SurveySchema(Schema):
                 obj.submissions,
                 Status.Needs_further_review.value)
         }
-        
+
     def _count_comments_by_status(self, submissios, status):
         return len([submission for submission in submissios
                     if submission.comment_status_id == status])

--- a/met-api/src/met_api/schemas/survey.py
+++ b/met-api/src/met_api/schemas/survey.py
@@ -31,6 +31,14 @@ class SurveySchema(Schema):
         """Get the meta data of the comments made in the survey."""
         return {
             'total': len(obj.submissions),
-            'pending': len([submission for submission in obj.submissions
-                            if submission.comment_status_id == Status.Pending.value])
+            'pending': self._count_comments_by_status(obj.submissions, Status.Pending.value),
+            'approved': self._count_comments_by_status(obj.submissions, Status.Approved.value),
+            'rejected': self._count_comments_by_status(obj.submissions, Status.Rejected.value),
+            'needs_further_review': self._count_comments_by_status(
+                obj.submissions,
+                Status.Needs_further_review.value)
         }
+        
+    def _count_comments_by_status(self, submissios, status):
+        return len([submission for submission in submissios
+                    if submission.comment_status_id == status])

--- a/met-web/src/models/survey.ts
+++ b/met-web/src/models/survey.ts
@@ -17,6 +17,9 @@ export interface Survey {
 export interface SurveyCommentData {
     total: number;
     pending: number;
+    approved: number;
+    rejected: number;
+    needs_further_review: number;
 }
 
 export interface SurveySubmissionData {
@@ -37,6 +40,9 @@ export const createDefaultSurvey = (): Survey => {
         comments_meta_data: {
             total: 0,
             pending: 0,
+            approved: 0,
+            rejected: 0,
+            needs_further_review: 0,
         },
         engagement_id: 0,
     };

--- a/met-web/tests/unit/components/surveyListing.test.tsx
+++ b/met-web/tests/unit/components/surveyListing.test.tsx
@@ -10,6 +10,7 @@ import { createDefaultSurvey } from 'models/survey';
 import { createDefaultEngagement } from 'models/engagement';
 import { EngagementStatus } from 'constants/engagementStatus';
 import assert from 'assert';
+import { SCOPES } from 'components/permissionsGate/PermissionMaps';
 
 const mockEngagementOne = {
     ...createDefaultEngagement(),
@@ -65,8 +66,11 @@ const mockSurveyTwo = {
     engagement: mockEngagementTwo,
     created_date: '2022-09-15 10:00:00',
     comments_meta_data: {
-        pending: 1,
         total: 12,
+        pending: 1,
+        approved: 4,
+        rejected: 3,
+        needs_further_review: 4,
     },
 };
 
@@ -82,6 +86,16 @@ jest.mock('components/common', () => ({
     PrimaryButton: ({ children, ...rest }: { children: ReactNode; [prop: string]: unknown }) => {
         return <button {...rest}>{children}</button>;
     },
+}));
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [SCOPES.viewPrivateEngagement, SCOPES.editEngagement, SCOPES.createEngagement],
+            assignedEngagements: [mockEngagementOne.id, mockEngagementTwo.id],
+        };
+    }),
 }));
 
 describe('Survey form page tests', () => {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1418

*Description of changes:*
- Add comment count badges to survey listing page
![image](https://user-images.githubusercontent.com/91914654/229850792-05e735c1-fbb9-4ec8-b5f4-08034e9c7f47.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
