### PR TITLE
Externalize engagement project types to env variable

### DIFF
--- a/met-web/sample.env
+++ b/met-web/sample.env
@@ -4,3 +4,4 @@ REACT_APP_KEYCLOAK_URL=
 REACT_APP_FORMIO_JWT_SECRET=
 REACT_APP_FORM_ID=
 REACT_APP_API_URL=http://localhost:5000/api
+REACT_APP_ENGAGEMENT_PROJECT_TYPES=Energy-Electricity,Energy - Petroleum & Natural Gas,Food Processing,Industrial,Mines,Other,Tourist Destination Resorts,Transportation,Waste Disposal,Water Management

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementSettings.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementSettings.tsx
@@ -7,12 +7,13 @@ import { ActionContext } from '../ActionContext';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { EngagementTabsContext } from './EngagementTabsContext';
-import { ENGAGEMENT_PROJECT_TYPES } from './constants';
+import { AppConfig } from 'config';
 
 const EngagementSettings = () => {
     const { savedEngagement } = useContext(ActionContext);
     const { engagementFormData, setEngagementFormData } = useContext(EngagementTabsContext);
     const { project_id, project_metadata } = engagementFormData;
+    const { engagementProjectTypes } = AppConfig.constants;
 
     const dispatch = useAppDispatch();
 
@@ -124,7 +125,7 @@ const EngagementSettings = () => {
                         <MenuItem value={''} sx={{ fontStyle: 'italic', height: '2em' }}>
                             none
                         </MenuItem>
-                        {ENGAGEMENT_PROJECT_TYPES.map((type) => {
+                        {engagementProjectTypes.map((type: string) => {
                             return (
                                 <MenuItem key={type} value={type}>
                                     {type}

--- a/met-web/src/components/engagement/form/EngagementFormTabs/constants.ts
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/constants.ts
@@ -8,16 +8,3 @@ export const ENGAGEMENT_FORM_TABS: { [x: string]: EngagementFormTabValues } = {
 
 export const ENGAGMENET_UPLOADER_HEIGHT = '360px';
 export const ENGAGEMENT_CROPPER_ASPECT_RATIO = 1920 / 700;
-
-export const ENGAGEMENT_PROJECT_TYPES: string[] = [
-    'Energy-Electricity',
-    'Energy - Petroleum & Natural Gas',
-    'Food Processing',
-    'Industrial',
-    'Mines',
-    'Other',
-    'Tourist Destination Resorts',
-    'Transportation',
-    'Waste disposal',
-    'Water Management',
-];

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -6,15 +6,17 @@ import TileBlock from './TileBlock';
 import { Engagement } from 'models/engagement';
 import { debounce } from 'lodash';
 import { getEngagements } from 'services/engagementService';
-import { ENGAGEMENT_PROJECT_TYPES } from 'components/engagement/form/EngagementFormTabs/constants';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { LandingContext } from './LandingContext';
 import { Container } from '@mui/system';
+import { AppConfig } from 'config';
 
 const LandingComponent = () => {
     const { searchFilters, setSearchFilters, setPage, page } = useContext(LandingContext);
     const [engagementOptionsLoading, setEngagementOptionsLoading] = useState(false);
     const [engagementOptions, setEngagementOptions] = useState<Engagement[]>([]);
+
+    const { engagementProjectTypes } = AppConfig.constants;
 
     const loadEngagementOptions = async (searchText: string) => {
         if (!searchText) {
@@ -210,7 +212,7 @@ const LandingComponent = () => {
                                 <MenuItem value={''} sx={{ fontStyle: 'italic', height: '2em' }}>
                                     {' '}
                                 </MenuItem>
-                                {ENGAGEMENT_PROJECT_TYPES.map((type) => {
+                                {engagementProjectTypes.map((type: string) => {
                                     return (
                                         <MenuItem key={type} value={type}>
                                             {type}

--- a/met-web/src/config.ts
+++ b/met-web/src/config.ts
@@ -55,7 +55,18 @@ const KC_REALM = getEnv('REACT_APP_KEYCLOAK_REALM');
 const KC_ADMIN_ROLE = getEnv('REACT_APP_KEYCLOAK_ADMIN_ROLE');
 
 // App constants
-const ENGAGEMENT_PROJECT_TYPES: string[] = getEnv('REACT_APP_ENGAGEMENT_PROJECT_TYPES', '').split(',');
+const ENGAGEMENT_PROJECT_TYPES: string[] = getEnv(
+    'REACT_APP_ENGAGEMENT_PROJECT_TYPES',
+    'Energy-Electricity,Energy - Petroleum & Natural Gas,' +
+        'Food Processing,' +
+        'Industrial,' +
+        'Mines,' +
+        'Other,' +
+        'Tourist Destination Resorts,' +
+        'Transportation,' +
+        'Waste Disposal,' +
+        'Water Management',
+).split(',');
 
 export const AppConfig = {
     apiUrl: API_URL,

--- a/met-web/src/config.ts
+++ b/met-web/src/config.ts
@@ -20,6 +20,9 @@ declare global {
             REACT_APP_KEYCLOAK_CLIENT: string;
             REACT_APP_KEYCLOAK_REALM: string;
             REACT_APP_KEYCLOAK_ADMIN_ROLE: string;
+
+            // Constants
+            REACT_APP_ENGAGEMENT_PROJECT_TYPES: string;
         };
     }
 }
@@ -51,6 +54,9 @@ const KC_CLIENT = getEnv('REACT_APP_KEYCLOAK_CLIENT');
 const KC_REALM = getEnv('REACT_APP_KEYCLOAK_REALM');
 const KC_ADMIN_ROLE = getEnv('REACT_APP_KEYCLOAK_ADMIN_ROLE');
 
+// App constants
+const ENGAGEMENT_PROJECT_TYPES: string[] = getEnv('REACT_APP_ENGAGEMENT_PROJECT_TYPES', '').split(',');
+
 export const AppConfig = {
     apiUrl: API_URL,
     publicUrl: PUBLIC_URL,
@@ -71,5 +77,8 @@ export const AppConfig = {
         clientId: KC_CLIENT || '',
         realm: KC_REALM || '',
         adminRole: KC_ADMIN_ROLE || 'admin',
+    },
+    constants: {
+        engagementProjectTypes: ENGAGEMENT_PROJECT_TYPES,
     },
 };


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1450

*Description of changes:*

- Add an engagement project types variable in config
- Add project types in met-web config maps for dev, test, and prod
- Add project types in local sample.env

![image](https://user-images.githubusercontent.com/91914654/229876028-938a3e09-7fb4-4cd4-a996-15624a4bcff6.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
