### PR TITLE
Fix landing page scrolling to filters on initial mount 

### DIFF
--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -15,6 +15,7 @@ const LandingComponent = () => {
     const { searchFilters, setSearchFilters, setPage, page } = useContext(LandingContext);
     const [engagementOptionsLoading, setEngagementOptionsLoading] = useState(false);
     const [engagementOptions, setEngagementOptions] = useState<Engagement[]>([]);
+    const [didMount, setDidMount] = useState(false);
 
     const loadEngagementOptions = async (searchText: string) => {
         if (!searchText) {
@@ -41,8 +42,14 @@ const LandingComponent = () => {
     const tileBlockRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        const yOffset = tileBlockRef?.current?.offsetTop;
-        window.scrollTo({ top: yOffset || 0, behavior: 'smooth' });
+        setDidMount(true);
+        return () => setDidMount(false);
+    }, []);
+    useEffect(() => {
+        if (didMount) {
+            const yOffset = tileBlockRef?.current?.offsetTop;
+            window.scrollTo({ top: yOffset || 0, behavior: 'smooth' });
+        }
     }, [page]);
 
     return (


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1461
*Description of changes:*
- Add a didMount state initialized as false, set it to true after initial mount


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
