### PR TITLE
Exclude submission json during submission fetch

### DIFF
--- a/met-api/src/met_api/resources/submission.py
+++ b/met-api/src/met_api/resources/submission.py
@@ -132,7 +132,7 @@ class SurveySubmissions(Resource):
             pagination_options = PaginationOptions(
                 page=args.get('page', None, int),
                 size=args.get('size', None, int),
-                sort_key=args.get('sort_key', 'name', str),
+                sort_key=args.get('sort_key', 'submission.id', str),
                 sort_order=args.get('sort_order', 'asc', str),
             )
             submission_page = SubmissionService()\

--- a/met-api/src/met_api/services/submission_service.py
+++ b/met-api/src/met_api/services/submission_service.py
@@ -36,7 +36,7 @@ class SubmissionService:
     def get(cls, submission_id):
         """Get submission by the id."""
         db_data = Submission.get(submission_id)
-        return SubmissionSchema().dump(db_data)
+        return SubmissionSchema(exclude=['submission_json']).dump(db_data)
 
     @classmethod
     def get_by_token(cls, token):
@@ -232,7 +232,7 @@ class SubmissionService:
             search_text,
         )
         return {
-            'items': SubmissionSchema(many=True).dump(items),
+            'items': SubmissionSchema(many=True, exclude=['submission_json']).dump(items),
             'total': total
         }
 

--- a/met-api/tests/unit/api/test_submission.py
+++ b/met-api/tests/unit/api/test_submission.py
@@ -43,6 +43,7 @@ def test_valid_submission(client, jwt, session):  # pylint:disable=unused-argume
                      headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == 200
 
+
 @pytest.mark.parametrize('submission_info', [TestSubmissionInfo.submission1])
 def test_get_submission_by_id(client, jwt, session, submission_info):  # pylint:disable=unused-argument
     """Assert that an engagement can be fetched."""
@@ -55,9 +56,9 @@ def test_get_submission_by_id(client, jwt, session, submission_info):  # pylint:
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.get(f'/api/submissions/{submission.id}', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == 200
-    assert rv.json.get('submission_json', None) == None
-    
-## test get submission page
+    assert rv.json.get('submission_json', None) is None
+
+
 @pytest.mark.parametrize('submission_info', [TestSubmissionInfo.submission1])
 def test_get_submission_page(client, jwt, session, submission_info):  # pylint:disable=unused-argument
     """Assert that an engagement page can be fetched."""
@@ -70,7 +71,8 @@ def test_get_submission_page(client, jwt, session, submission_info):  # pylint:d
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.get(f'/api/submissions/survey/{survey.id}', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == 200
-    assert rv.json.get('items', [])[0].get('submission_json', None) == None
+    assert rv.json.get('items', [])[0].get('submission_json', None) is None
+
 
 def test_invalid_submission(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that an engagement can be POSTed."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/met-public/issues/1464

*Description of changes:*
- Pass exclude=['submission_json'] to submission schema during Marshalling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
