### PR TITLE
fixes for saving a survey as hidden

### DIFF
--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -85,7 +85,7 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
             created_by=survey.get('created_by', None),
             updated_by=survey.get('updated_by', None),
             engagement_id=survey.get('engagement_id', None),
-            is_hidden=survey.get('is_hidden', False),
+            is_hidden=survey.get('is_hidden', True),
 
         )
         db.session.add(new_survey)

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -85,7 +85,7 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
             created_by=survey.get('created_by', None),
             updated_by=survey.get('updated_by', None),
             engagement_id=survey.get('engagement_id', None),
-            is_hidden=survey.get('is_hidden', True),
+            is_hidden=survey.get('is_hidden', False),
 
         )
         db.session.add(new_survey)

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -286,6 +286,7 @@ const SurveyFormBuilder = () => {
                                 <PermissionsGate scopes={[SCOPES.createSurvey]} errorProps={{ disabled: true }}>
                                     <Switch
                                         checked={isHiddenSurvey}
+                                        disabled={savedSurvey?.engagement_id ? true : false}
                                         onChange={(e) => {
                                             if (e.target.checked) {
                                                 setIsHiddenSurvey(true);


### PR DESCRIPTION
*Description of changes:*
https://app.zenhub.com/workspaces/met-ops-6254279dcfa60b0010ea5a0d/issues/gh/bcgov/met-public/1366

- disable is hidden switch on the screen if survey is linked to an engagement


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
