### PR TITLE
Remove new create survey option from engagement

### DIFF
--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -47,7 +47,7 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
 
     @classmethod
     def get_surveys_paginated(cls, pagination_options: PaginationOptions, search_text='', unlinked=False,
-                              exclude_hidden=False):
+                              exclude_hidden=False, template=False):
         """Get surveys paginated."""
         query = db.session.query(Survey).join(Engagement, isouter=True).join(EngagementStatus, isouter=True)
 
@@ -56,6 +56,11 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
 
         if unlinked:
             query = query.filter(Survey.engagement_id.is_(None))
+
+        if template is not None:
+            query = query.filter()
+            # TODO: add is template column
+            # query = query.filter(Survey.is_template.is_(template))
 
         if search_text:
             query = query.filter(Survey.name.ilike('%' + search_text + '%'))

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -81,13 +81,17 @@ class Surveys(Resource):
                 sort_order=args.get('sort_order', 'asc', str),
             )
 
+            search_options = {
+                'search_text': args.get('search_text', '', type=str),
+                'unlinked': args.get('unlinked', False, bool),
+                'exclude_hidden': args.get('exclude_hidden', False, bool),
+                'template': args.get('template', None, bool),
+            }
+
             survey_records = SurveyService()\
                 .get_surveys_paginated(
                     pagination_options,
-                    args.get('search_text', '', str),
-                    args.get('unlinked', False, bool),
-                    args.get('exclude_hidden', False, bool),
-                    args.get('template', None, bool),
+                    search_options,
             )
             return survey_records, HTTPStatus.OK
         except ValueError as err:

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -87,6 +87,7 @@ class Surveys(Resource):
                     args.get('search_text', '', str),
                     args.get('unlinked', False, bool),
                     args.get('exclude_hidden', False, bool),
+                    args.get('template', None, bool),
             )
             return survey_records, HTTPStatus.OK
         except ValueError as err:

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -36,7 +36,7 @@ class SurveyService:
 
     @staticmethod
     def get_surveys_paginated(pagination_options: PaginationOptions, search_text='', unlinked=False,
-                              exclude_hidden=False):
+                              exclude_hidden=False, template=None):
         """Get engagements paginated."""
         # check if user has view all surveys access to view hidden surveys as well
         user_roles = TokenInfo.get_user_roles()
@@ -50,6 +50,7 @@ class SurveyService:
             search_text,
             unlinked,
             exclude_hidden,
+            template,
         )
         surveys_schema = SurveySchema(many=True)
 

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -35,22 +35,18 @@ class SurveyService:
         return survey
 
     @staticmethod
-    def get_surveys_paginated(pagination_options: PaginationOptions, search_text='', unlinked=False,
-                              exclude_hidden=False, template=None):
+    def get_surveys_paginated(pagination_options: PaginationOptions, search_options=None):
         """Get engagements paginated."""
         # check if user has view all surveys access to view hidden surveys as well
         user_roles = TokenInfo.get_user_roles()
         has_access_to_hidden_surveys = SurveyService._can_user_access_hidden_surveys(user_roles)
 
         if not has_access_to_hidden_surveys:
-            exclude_hidden = True
+            search_options['exclude_hidden'] = True
 
         items, total = SurveyModel.get_surveys_paginated(
             pagination_options,
-            search_text,
-            unlinked,
-            exclude_hidden,
-            template,
+            search_options,
         )
         surveys_schema = SurveySchema(many=True)
 

--- a/met-web/src/components/survey/create/LinkOptions.tsx
+++ b/met-web/src/components/survey/create/LinkOptions.tsx
@@ -28,6 +28,7 @@ const LinkOptions = () => {
             const fetchedSurveys = await fetchSurveys({
                 unlinked: true,
                 exclude_hidden: true,
+                template: false,
             });
             setAvailableSurveys(fetchedSurveys);
             setLoadingSurveys(false);

--- a/met-web/src/components/survey/create/OptionsForm.tsx
+++ b/met-web/src/components/survey/create/OptionsForm.tsx
@@ -47,7 +47,9 @@ const OptionsForm = () => {
                         value={value}
                         onChange={handleChange}
                     >
-                        <FormControlLabel value="CREATE" control={<Radio />} label="Create a new Survey" />
+                        <When condition={!engagementToLink}>
+                            <FormControlLabel value="CREATE" control={<Radio />} label="Create a new Survey" />
+                        </When>
                         <FormControlLabel value="CLONE" control={<Radio />} label="Clone an existing Survey" />
                         <When condition={!!engagementToLink}>
                             <FormControlLabel

--- a/met-web/src/services/surveyService/index.ts
+++ b/met-web/src/services/surveyService/index.ts
@@ -7,6 +7,7 @@ import { Page } from 'services/type';
 interface FetchSurveyParams {
     unlinked?: boolean;
     exclude_hidden?: boolean;
+    template?: boolean;
 }
 export const fetchSurveys = async (params: FetchSurveyParams = {}): Promise<Survey[]> => {
     const responseData = await http.GetRequest<Page<Survey>>(Endpoints.Survey.GET_LIST, { ...params });


### PR DESCRIPTION
*Description of changes:*
Remove templates from attach to engagement
Remove new create survey option from engagement


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
