### PR TITLE
implement restrictions on edit template surveys

### DIFF
--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -21,6 +21,7 @@ from flask_restx import Namespace, Resource
 
 from met_api.auth import auth
 from met_api.auth import jwt as _jwt
+from met_api.exceptions.business_exception import BusinessException
 from met_api.models.pagination_options import PaginationOptions
 from met_api.models.survey_exclusion_option import SurveyExclusionOptions
 from met_api.schemas.survey import SurveySchema
@@ -133,6 +134,8 @@ class Surveys(Resource):
             return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
         except ValueError as err:
             return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
+        except BusinessException as err:
+            return {'message': err.error}, err.status_code
 
 
 @cors_preflight('PUT,OPTIONS')

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -1,4 +1,5 @@
 """Service for survey management."""
+from http import HTTPStatus
 
 from met_api.constants.engagement_status import Status
 from met_api.models import Engagement as EngagementModel
@@ -10,6 +11,8 @@ from met_api.schemas.survey import SurveySchema
 from met_api.services.object_storage_service import ObjectStorageService
 from met_api.utils.roles import Role
 from met_api.utils.token_info import TokenInfo
+
+from ..exceptions.business_exception import BusinessException
 
 
 class SurveyService:
@@ -78,6 +81,12 @@ class SurveyService:
         cls.validate_update_fields(data)
         survey = cls.get(data.get('id', None))
         engagement = survey.get('engagement', None)
+
+        # check if user has edit all surveys access to edit template surveys as well
+        user_roles = TokenInfo.get_user_roles()
+        is_template = survey.get('is_template', None)
+        cls.validate_template_surveys_edit_access(is_template, user_roles)
+
         if engagement and engagement.get('status_id', None) != Status.Draft.value:
             raise ValueError('Engagament already published')
         return SurveyModel.update_survey(data)
@@ -89,6 +98,14 @@ class SurveyService:
 
         if any(empty_fields):
             raise ValueError('Some required fields are empty')
+
+    @staticmethod
+    def validate_template_surveys_edit_access(is_template, user_roles):
+        """Validatef user has edit access on a template survey."""
+        if is_template and Role.EDIT_ALL_SURVEYS.value not in user_roles:
+            raise BusinessException(
+                error='Changes could not be saved due to restricted access on a template survey',
+                status_code=HTTPStatus.BAD_REQUEST)
 
     @staticmethod
     def validate_create_fields(data):

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -105,7 +105,7 @@ class SurveyService:
         if is_template and Role.EDIT_ALL_SURVEYS.value not in user_roles:
             raise BusinessException(
                 error='Changes could not be saved due to restricted access on a template survey',
-                status_code=HTTPStatus.BAD_REQUEST)
+                status_code=HTTPStatus.FORBIDDEN)
 
     @staticmethod
     def validate_create_fields(data):

--- a/met-api/src/met_api/utils/roles.py
+++ b/met-api/src/met_api/utils/roles.py
@@ -38,3 +38,4 @@ class Role(Enum):
     VIEW_MEMBERS = 'view_members'
     EDIT_MEMBERS = 'edit_members'
     VIEW_ALL_SURVEYS = 'view_all_surveys'
+    EDIT_ALL_SURVEYS = 'edit_all_surveys'

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -179,4 +179,4 @@ def test_edit_template_survey_for_team_member(client, jwt, session, survey_info)
     rv = client.put('/api/surveys/', data=json.dumps({'id': survey_id, 'name': new_survey_name}),
                     headers=headers, content_type=ContentType.JSON.value)
 
-    assert rv.status_code == 400, 'Team members are not able to edit template surveys, so throws exception.'
+    assert rv.status_code == 403, 'Team members are not able to edit template surveys, so throws exception.'

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -23,7 +23,8 @@ import pytest
 from met_api.utils.enums import ContentType
 from tests.utilities.factory_scenarios import TestJwtClaims, TestSurveyInfo
 from tests.utilities.factory_utils import (
-    factory_auth_header, factory_engagement_model, factory_hidden_survey_model, factory_survey_model)
+    factory_auth_header, factory_engagement_model, factory_hidden_survey_model, factory_survey_model,
+    factory_template_survey_model)
 
 
 @pytest.mark.parametrize('survey_info', [TestSurveyInfo.survey2])
@@ -134,7 +135,7 @@ def test_get_hidden_survey_for_team_member(client, jwt, session, survey_info):  
 def test_get_template_survey(client, jwt, session, survey_info):  # pylint:disable=unused-argument
     """Assert that a hidden survey cannot be fetched by team members."""
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
-    survey = factory_hidden_survey_model()
+    survey = factory_template_survey_model()
     survey_id = str(survey.id)
     new_survey_name = 'new_survey_name'
     rv = client.put('/api/surveys/', data=json.dumps({'id': survey_id, 'name': new_survey_name}),
@@ -153,3 +154,29 @@ def test_get_template_survey(client, jwt, session, survey_info):  # pylint:disab
                     headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == 200
     assert rv.json.get('total') == 1
+
+
+@pytest.mark.parametrize('survey_info', [TestSurveyInfo.survey4])
+def test_edit_template_survey_for_admins(client, jwt, session, survey_info):  # pylint:disable=unused-argument
+    """Assert that a hidden survey cannot be fetched by team members."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey = factory_template_survey_model()
+    survey_id = str(survey.id)
+    new_survey_name = 'new_survey_name'
+    rv = client.put('/api/surveys/', data=json.dumps({'id': survey_id, 'name': new_survey_name}),
+                    headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200, 'Admins are able to edit template surveys'
+
+
+@pytest.mark.parametrize('survey_info', [TestSurveyInfo.survey4])
+def test_edit_template_survey_for_team_member(client, jwt, session, survey_info):  # pylint:disable=unused-argument
+    """Assert that a hidden survey cannot be fetched by team members."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.team_member_role)
+    survey = factory_template_survey_model()
+    survey_id = str(survey.id)
+    new_survey_name = 'new_survey_name'
+    rv = client.put('/api/surveys/', data=json.dumps({'id': survey_id, 'name': new_survey_name}),
+                    headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 400, 'Team members are not able to edit template surveys, so throws exception.'

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -222,7 +222,8 @@ class TestJwtClaims(dict, Enum):
                 'view_users',
                 'view_private_engagements',
                 'create_admin_user',
-                'view_all_surveys'
+                'view_all_surveys',
+                'edit_all_surveys',
             ]
         }
     }

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -100,6 +100,23 @@ def factory_hidden_survey_model(survey_info: dict = TestSurveyInfo.survey3):
     return survey
 
 
+def factory_template_survey_model(survey_info: dict = TestSurveyInfo.survey4):
+    """Produce a survey model."""
+    survey = SurveyModel(
+        name=fake.name(),
+        form_json=survey_info.get('form_json'),
+        created_by=survey_info.get('created_by'),
+        updated_by=survey_info.get('updated_by'),
+        created_date=survey_info.get('created_date'),
+        updated_date=survey_info.get('updated_date'),
+        is_hidden=survey_info.get('is_hidden'),
+        is_template=survey_info.get('is_template'),
+    )
+    db.session.add(survey)
+    db.session.commit()
+    return survey
+
+
 def factory_email_verification(survey_id):
     """Produce a EmailVerification model."""
     email_verification = EmailVerificationModel(

--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -30,6 +30,7 @@ import { openNotificationModal } from 'services/notificationModalService/notific
 import { Palette } from 'styles/Theme';
 import { PermissionsGate } from 'components/permissionsGate';
 import { SCOPES } from 'components/permissionsGate/PermissionMaps';
+import axios from 'axios';
 
 const SurveyFormBuilder = () => {
     const navigate = useNavigate();
@@ -167,12 +168,21 @@ const SurveyFormBuilder = () => {
             navigate('/surveys');
         } catch (error) {
             setIsSaving(false);
-            dispatch(
-                openNotification({
-                    severity: 'error',
-                    text: 'Error occurred while saving survey',
-                }),
-            );
+            if (axios.isAxiosError(error)) {
+                dispatch(
+                    openNotification({
+                        severity: 'error',
+                        text: error.response?.data.message,
+                    }),
+                );
+            } else {
+                dispatch(
+                    openNotification({
+                        severity: 'error',
+                        text: 'Error occurred while saving survey',
+                    }),
+                );
+            }
         }
     };
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/met-ops-6254279dcfa60b0010ea5a0d/issues/gh/bcgov/met-public/1367
*Description of changes:*

- Added a new role to check user access while editing a template survey
- Logic to restrict users without a role to edit template surveys

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
