### PR TITLE
Update home page statuses to open, upcoming & closed

### DIFF
--- a/met-web/src/components/engagement/status/index.tsx
+++ b/met-web/src/components/engagement/status/index.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { Chip } from '@mui/material';
 import { SubmissionStatus } from 'constants/engagementStatus';
-import { Engagement } from 'models/engagement';
-import { formatToUTC } from 'components/common/dateHelper';
-import dayjs from 'dayjs';
-
 const Chip_Font_Weight = { fontWeight: 'bold' };
 
 const Open = ({ preview }: { preview?: boolean }) => {

--- a/met-web/src/components/engagement/status/index.tsx
+++ b/met-web/src/components/engagement/status/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Chip } from '@mui/material';
 import { SubmissionStatus } from 'constants/engagementStatus';
+import { Engagement } from 'models/engagement';
+import { formatToUTC } from 'components/common/dateHelper';
+import dayjs from 'dayjs';
 
 const Chip_Font_Weight = { fontWeight: 'bold' };
 
@@ -35,6 +38,34 @@ export const EngagementStatusChip = ({
         case SubmissionStatus.Open:
             // Engagement is published and open for submission.
             return <Open preview={preview} />;
+        case SubmissionStatus.Closed:
+            // Engagement is published but it's past the submission date.
+            return <Closed preview={preview} />;
+        default:
+            return null;
+    }
+};
+
+export const HomepageEngagementStatusChip = ({
+    engagement,
+    preview,
+}: {
+    engagement: Engagement;
+    preview?: boolean;
+}) => {
+    const engagementStartDateUTC = dayjs(formatToUTC(engagement.start_date));
+    const now = dayjs();
+
+    switch (engagement.status_id) {
+        case SubmissionStatus.Upcoming:
+            // Engagement is published but submission start date is not due yet.
+            return <Upcoming preview={preview} />;
+        case SubmissionStatus.Open:
+            // Engagement is published and open for submission.
+            if (engagementStartDateUTC.isAfter(now)) return <Upcoming preview={preview} />;
+            else {
+                return <Open preview={preview} />;
+            }
         case SubmissionStatus.Closed:
             // Engagement is published but it's past the submission date.
             return <Closed preview={preview} />;

--- a/met-web/src/components/engagement/status/index.tsx
+++ b/met-web/src/components/engagement/status/index.tsx
@@ -45,31 +45,3 @@ export const EngagementStatusChip = ({
             return null;
     }
 };
-
-export const HomepageEngagementStatusChip = ({
-    engagement,
-    preview,
-}: {
-    engagement: Engagement;
-    preview?: boolean;
-}) => {
-    const engagementStartDateUTC = dayjs(formatToUTC(engagement.start_date));
-    const now = dayjs();
-
-    switch (engagement.status_id) {
-        case SubmissionStatus.Upcoming:
-            // Engagement is published but submission start date is not due yet.
-            return <Upcoming preview={preview} />;
-        case SubmissionStatus.Open:
-            // Engagement is published and open for submission.
-            if (engagementStartDateUTC.isAfter(now)) return <Upcoming preview={preview} />;
-            else {
-                return <Open preview={preview} />;
-            }
-        case SubmissionStatus.Closed:
-            // Engagement is published but it's past the submission date.
-            return <Closed preview={preview} />;
-        default:
-            return null;
-    }
-};

--- a/met-web/src/components/landing/EngagementTile.tsx
+++ b/met-web/src/components/landing/EngagementTile.tsx
@@ -9,7 +9,7 @@ import { MetBody, MetHeader4, MetLabel, MetParagraph, PrimaryButton, SecondaryBu
 import { getEngagement } from 'services/engagementService';
 import { Else, If, Then, When } from 'react-if';
 import dayjs from 'dayjs';
-import { HomepageEngagementStatusChip } from 'components/engagement/status';
+import { EngagementStatusChip } from 'components/engagement/status';
 import { SubmissionStatus } from 'constants/engagementStatus';
 import { TileSkeleton } from './TileSkeleton';
 import { AppConfig } from 'config';
@@ -58,7 +58,7 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
         return <MetLabel>error Loading</MetLabel>;
     }
 
-    const { name, end_date, start_date, description, status_id, banner_url } = loadedEngagement;
+    const { name, end_date, start_date, description, status_id, banner_url, submission_status } = loadedEngagement;
     const EngagementDate = `${dayjs(start_date).format(dateFormat)} to ${dayjs(end_date).format(dateFormat)}`;
     return (
         <Card sx={{ maxWidth: 345 }}>
@@ -86,7 +86,7 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
                 </MetBody>
                 <Stack direction="row" alignItems={'center'} spacing={1} mt="0.5em">
                     <MetBody bold>Status:</MetBody>
-                    <HomepageEngagementStatusChip engagement={loadedEngagement} />
+                    <EngagementStatusChip submissionStatus={submission_status} />
                 </Stack>
             </CardContent>
             <CardActions>

--- a/met-web/src/components/landing/EngagementTile.tsx
+++ b/met-web/src/components/landing/EngagementTile.tsx
@@ -9,7 +9,7 @@ import { MetBody, MetHeader4, MetLabel, MetParagraph, PrimaryButton, SecondaryBu
 import { getEngagement } from 'services/engagementService';
 import { Else, If, Then, When } from 'react-if';
 import dayjs from 'dayjs';
-import { EngagementStatusChip } from 'components/engagement/status';
+import { HomepageEngagementStatusChip } from 'components/engagement/status';
 import { SubmissionStatus } from 'constants/engagementStatus';
 import { TileSkeleton } from './TileSkeleton';
 import { AppConfig } from 'config';
@@ -86,7 +86,7 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
                 </MetBody>
                 <Stack direction="row" alignItems={'center'} spacing={1} mt="0.5em">
                     <MetBody bold>Status:</MetBody>
-                    <EngagementStatusChip submissionStatus={status_id} />
+                    <HomepageEngagementStatusChip engagement={loadedEngagement} />
                 </Stack>
             </CardContent>
             <CardActions>

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -178,7 +178,6 @@ const LandingComponent = () => {
                                     setSearchFilters({
                                         ...searchFilters,
                                         status: event.target.value ? [Number(event.target.value)] : [],
-
                                     });
                                     setPage(1);
                                 }}

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -189,7 +189,8 @@ const LandingComponent = () => {
                                 <MenuItem value={0} sx={{ fontStyle: 'italic', height: '2em' }}>
                                     {''}
                                 </MenuItem>
-                                <MenuItem value={EngagementStatus.Published}>Published</MenuItem>
+                                <MenuItem value={EngagementStatus.Published}>Open</MenuItem>
+                                <MenuItem value={EngagementStatus.Scheduled}>Upcoming</MenuItem>
                                 <MenuItem value={EngagementStatus.Closed}>Closed</MenuItem>
                             </TextField>
                         </Grid>

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -6,7 +6,7 @@ import TileBlock from './TileBlock';
 import { Engagement } from 'models/engagement';
 import { debounce } from 'lodash';
 import { getEngagements } from 'services/engagementService';
-import { SubmissionStatus } from 'constants/engagementStatus';
+import { EngagementDisplayStatus } from 'constants/engagementStatus';
 import { LandingContext } from './LandingContext';
 import { Container } from '@mui/system';
 import { AppConfig } from 'config';
@@ -189,9 +189,9 @@ const LandingComponent = () => {
                                 <MenuItem value={0} sx={{ fontStyle: 'italic', height: '2em' }}>
                                     {''}
                                 </MenuItem>
-                                <MenuItem value={SubmissionStatus.Open}>Open</MenuItem>
-                                <MenuItem value={SubmissionStatus.Upcoming}>Upcoming</MenuItem>
-                                <MenuItem value={SubmissionStatus.Closed}>Closed</MenuItem>
+                                <MenuItem value={EngagementDisplayStatus.Open}>Open</MenuItem>
+                                <MenuItem value={EngagementDisplayStatus.Upcoming}>Upcoming</MenuItem>
+                                <MenuItem value={EngagementDisplayStatus.Closed}>Closed</MenuItem>
                             </TextField>
                         </Grid>
                         <Grid item xs={12} sm={6} md={4} lg={4}>

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -6,7 +6,7 @@ import TileBlock from './TileBlock';
 import { Engagement } from 'models/engagement';
 import { debounce } from 'lodash';
 import { getEngagements } from 'services/engagementService';
-import { EngagementStatus } from 'constants/engagementStatus';
+import { SubmissionStatus } from 'constants/engagementStatus';
 import { LandingContext } from './LandingContext';
 import { Container } from '@mui/system';
 import { AppConfig } from 'config';
@@ -189,9 +189,9 @@ const LandingComponent = () => {
                                 <MenuItem value={0} sx={{ fontStyle: 'italic', height: '2em' }}>
                                     {''}
                                 </MenuItem>
-                                <MenuItem value={EngagementStatus.Published}>Open</MenuItem>
-                                <MenuItem value={EngagementStatus.Scheduled}>Upcoming</MenuItem>
-                                <MenuItem value={EngagementStatus.Closed}>Closed</MenuItem>
+                                <MenuItem value={SubmissionStatus.Open}>Open</MenuItem>
+                                <MenuItem value={SubmissionStatus.Upcoming}>Upcoming</MenuItem>
+                                <MenuItem value={SubmissionStatus.Closed}>Closed</MenuItem>
                             </TextField>
                         </Grid>
                         <Grid item xs={12} sm={6} md={4} lg={4}>

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -35,7 +35,7 @@ const LandingComponent = () => {
         }
     };
 
-    const debounceLoadEngagments = useRef(
+    const debounceLoadEngagements = useRef(
         debounce((searchText: string) => {
             loadEngagementOptions(searchText);
         }, 1000),
@@ -120,11 +120,11 @@ const LandingComponent = () => {
                         ref={tileBlockRef}
                     >
                         <Grid item xs={12} sm={6} md={4} lg={4}>
-                            <MetLabel sx={{ marginBottom: '2px', display: 'flex' }}>Engagment name</MetLabel>
+                            <MetLabel sx={{ marginBottom: '2px', display: 'flex' }}>Engagement name</MetLabel>
                             <Autocomplete
                                 options={engagementOptions || []}
                                 onInputChange={(_event, newInputValue) => {
-                                    debounceLoadEngagments(newInputValue);
+                                    debounceLoadEngagements(newInputValue);
                                 }}
                                 renderInput={(params) => (
                                     <TextField
@@ -178,6 +178,7 @@ const LandingComponent = () => {
                                     setSearchFilters({
                                         ...searchFilters,
                                         status: event.target.value ? [Number(event.target.value)] : [],
+
                                     });
                                     setPage(1);
                                 }}

--- a/met-web/src/components/landing/LandingContext.tsx
+++ b/met-web/src/components/landing/LandingContext.tsx
@@ -61,7 +61,7 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
             setEngagements(loadedEngagements.items);
             setTotalEngagements(loadedEngagements.total);
             setLoadingEngagements(false);
-        } catch (error) { }
+        } catch (error) {}
     };
 
     useEffect(() => {

--- a/met-web/src/components/landing/LandingContext.tsx
+++ b/met-web/src/components/landing/LandingContext.tsx
@@ -8,6 +8,7 @@ interface SearchFilters {
     status: number[];
     project_type: string;
 }
+
 export interface LandingContextProps {
     engagements: Engagement[];
     loadingEngagements: boolean;
@@ -60,7 +61,7 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
             setEngagements(loadedEngagements.items);
             setTotalEngagements(loadedEngagements.total);
             setLoadingEngagements(false);
-        } catch (error) {}
+        } catch (error) { }
     };
 
     useEffect(() => {


### PR DESCRIPTION
-change the status drop down on homepage to handle Upcoming, Open & Closed engagements

-added a time calculation to display upcoming engagements vs open engagements


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
