### PR TITLE
Comment user roles

### DIFF
--- a/met-web/src/components/comments/admin/review/CommentReview.tsx
+++ b/met-web/src/components/comments/admin/review/CommentReview.tsx
@@ -13,7 +13,7 @@ import {
     FormHelperText,
 } from '@mui/material';
 import { getSubmission, reviewComments } from 'services/submissionService';
-import { useAppDispatch } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { useParams, useNavigate } from 'react-router-dom';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import {
@@ -37,6 +37,7 @@ import { RejectEmailTemplate } from './emailPreview/EmailTemplates';
 import EmailPreview from './emailPreview/EmailPreview';
 import { Survey, createDefaultSurvey } from 'models/survey';
 import { getSurvey } from 'services/surveyService';
+import { PermissionsGate } from 'components/permissionsGate';
 
 const CommentReview = () => {
     const [submission, setSubmission] = useState<SurveySubmission>(createDefaultSubmission());
@@ -59,6 +60,7 @@ const CommentReview = () => {
     const { submissionId, surveyId } = useParams();
     const reviewNotes = updatedStaffNote.filter((staffNote) => staffNote.note_type == StaffNoteType.Review);
     const internalNotes = updatedStaffNote.filter((staffNote) => staffNote.note_type == StaffNoteType.Internal);
+    const { assignedEngagements } = useAppSelector((state) => state.user);
 
     const MAX_OTHER_REASON_CHAR = 500;
 
@@ -494,10 +496,13 @@ const CommentReview = () => {
                         </When>
                         <Grid item xs={12}>
                             <Stack direction="row" spacing={2}>
-                                <PrimaryButton loading={isSaving} onClick={handleSave}>
+                                <PrimaryButton
+                                    disabled={!assignedEngagements.includes(Number(survey.engagement_id))}
+                                    loading={isSaving}
+                                    onClick={handleSave}
+                                >
                                     {'Save & Continue'}
                                 </PrimaryButton>
-
                                 <SecondaryButton onClick={() => navigate(-1)}>Cancel</SecondaryButton>
                             </Stack>
                         </Grid>

--- a/met-web/src/components/comments/admin/review/CommentReview.tsx
+++ b/met-web/src/components/comments/admin/review/CommentReview.tsx
@@ -63,7 +63,7 @@ const CommentReview = () => {
     const { assignedEngagements } = useAppSelector((state) => state.user);
     const canEditComments =
         UserService.hasAdminRole() ||
-        !assignedEngagements.includes(survey.engagement_id) ||
+        assignedEngagements.includes(survey.engagement_id) ||
         UserService.hasRole('SuperUser');
     const MAX_OTHER_REASON_CHAR = 500;
 

--- a/met-web/src/components/comments/admin/review/CommentReview.tsx
+++ b/met-web/src/components/comments/admin/review/CommentReview.tsx
@@ -37,7 +37,6 @@ import { RejectEmailTemplate } from './emailPreview/EmailTemplates';
 import EmailPreview from './emailPreview/EmailPreview';
 import { Survey, createDefaultSurvey } from 'models/survey';
 import { getSurvey } from 'services/surveyService';
-import { PermissionsGate } from 'components/permissionsGate';
 
 const CommentReview = () => {
     const [submission, setSubmission] = useState<SurveySubmission>(createDefaultSubmission());

--- a/met-web/src/components/comments/admin/review/CommentReview.tsx
+++ b/met-web/src/components/comments/admin/review/CommentReview.tsx
@@ -37,6 +37,7 @@ import { RejectEmailTemplate } from './emailPreview/EmailTemplates';
 import EmailPreview from './emailPreview/EmailPreview';
 import { Survey, createDefaultSurvey } from 'models/survey';
 import { getSurvey } from 'services/surveyService';
+import UserService from 'services/userService';
 
 const CommentReview = () => {
     const [submission, setSubmission] = useState<SurveySubmission>(createDefaultSubmission());
@@ -60,7 +61,10 @@ const CommentReview = () => {
     const reviewNotes = updatedStaffNote.filter((staffNote) => staffNote.note_type == StaffNoteType.Review);
     const internalNotes = updatedStaffNote.filter((staffNote) => staffNote.note_type == StaffNoteType.Internal);
     const { assignedEngagements } = useAppSelector((state) => state.user);
-
+    const canEditComments =
+        UserService.hasAdminRole() ||
+        !assignedEngagements.includes(survey.engagement_id) ||
+        UserService.hasRole('SuperUser');
     const MAX_OTHER_REASON_CHAR = 500;
 
     const getEmailPreview = () => {
@@ -495,11 +499,7 @@ const CommentReview = () => {
                         </When>
                         <Grid item xs={12}>
                             <Stack direction="row" spacing={2}>
-                                <PrimaryButton
-                                    disabled={!assignedEngagements.includes(Number(survey.engagement_id))}
-                                    loading={isSaving}
-                                    onClick={handleSave}
-                                >
+                                <PrimaryButton disabled={!canEditComments} loading={isSaving} onClick={handleSave}>
                                     {'Save & Continue'}
                                 </PrimaryButton>
                                 <SecondaryButton onClick={() => navigate(-1)}>Cancel</SecondaryButton>

--- a/met-web/src/components/comments/admin/reviewListing/CommentListingContext.tsx
+++ b/met-web/src/components/comments/admin/reviewListing/CommentListingContext.tsx
@@ -105,7 +105,7 @@ export const CommentListingContextProvider = ({ children }: CommentListingContex
     const [survey, setSurvey] = useState<Survey>(createDefaultSurvey());
     const canViewAllComments =
         UserService.hasAdminRole() ||
-        !assignedEngagements.includes(survey.engagement_id) ||
+        assignedEngagements.includes(survey.engagement_id) ||
         UserService.hasRole('SuperUser');
     const [submissions, setSubmissions] = useState<SurveySubmission[]>([]);
     const [paginationOptions, setPagination] = useState<PaginationOptions<SurveySubmission>>({
@@ -159,7 +159,7 @@ export const CommentListingContextProvider = ({ children }: CommentListingContex
             const filterCondition = (submission: SurveySubmission) =>
                 submission.comment_status_id === CommentStatus.Approved;
 
-            const filteredSubmissions = canViewAllComments ? response.items.filter(filterCondition) : response.items;
+            const filteredSubmissions = !canViewAllComments ? response.items.filter(filterCondition) : response.items;
 
             setSubmissions(filteredSubmissions);
             setPageInfo({ total: response.total });

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -5,7 +5,7 @@ import { MetPageGridContainer, PrimaryButton, MetParagraph, MetLabel } from 'com
 import { HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { Link as MuiLink, Grid, Stack, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import { useAppDispatch } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { CommentStatusChip } from '../../status';
 import { CommentStatus } from 'constants/commentStatus';
@@ -15,6 +15,7 @@ import { SurveySubmission } from 'models/surveySubmission';
 import { formatDate } from 'components/common/dateHelper';
 
 const CommentTextListing = () => {
+    const { assignedEngagements } = useAppSelector((state) => state.user);
     const badgeStyle: React.CSSProperties = {
         padding: 0,
         margin: 0,
@@ -53,10 +54,12 @@ const CommentTextListing = () => {
                 sort_order,
                 search_text: searchFilter.value,
             };
+
             const response = await getSubmissionPage({
                 survey_id: Number(surveyId),
                 queryParams,
             });
+
             const filterCondition = (submission: SurveySubmission) =>
                 submission.comment_status_id === CommentStatus.Approved;
 

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -57,7 +57,14 @@ const CommentTextListing = () => {
                 survey_id: Number(surveyId),
                 queryParams,
             });
-            setSubmissions(response.items);
+            const filterCondition = (submission: SurveySubmission) =>
+                submission.comment_status_id === CommentStatus.Approved;
+
+            const filteredSubmissions = !assignedEngagements.includes(Number(survey.engagement_id))
+                ? response.items.filter(filterCondition)
+                : response.items;
+
+            setSubmissions(filteredSubmissions);
             setPageInfo({
                 total: response.total,
             });

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -13,6 +13,7 @@ import { When } from 'react-if';
 import { getSubmissionPage } from 'services/submissionService';
 import { SurveySubmission } from 'models/surveySubmission';
 import { formatDate } from 'components/common/dateHelper';
+import { getSurvey } from 'services/surveyService';
 
 const CommentTextListing = () => {
     const { assignedEngagements } = useAppSelector((state) => state.user);
@@ -60,10 +61,12 @@ const CommentTextListing = () => {
                 queryParams,
             });
 
+            const survey = await getSurvey(Number(surveyId));
+
             const filterCondition = (submission: SurveySubmission) =>
                 submission.comment_status_id === CommentStatus.Approved;
 
-            const filteredSubmissions = !assignedEngagements.includes(Number(survey.engagement_id))
+            const filteredSubmissions = !assignedEngagements.includes(survey.engagement_id)
                 ? response.items.filter(filterCondition)
                 : response.items;
 


### PR DESCRIPTION
-only display approved comments to users that are not a team member of an engagement

-Dont allow non team members to edit comment status(approved, rejected, etc)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
