### PR TITLE
Filter engagements the user is already a part of for add engagement modal

### DIFF
--- a/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
+++ b/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
@@ -102,8 +102,9 @@ export const AddToEngagementModal = () => {
         dispatch(
             openNotification({
                 severity: 'success',
-                text: `You have successfully added ${savedUser?.first_name + ' ' + savedUser?.last_name
-                    } as a Team Member on ${data.engagement?.name}.`,
+                text: `You have successfully added ${
+                    savedUser?.first_name + ' ' + savedUser?.last_name
+                } as a Team Member on ${data.engagement?.name}.`,
             }),
         );
     };


### PR DESCRIPTION
UX Assurance for task #720 

-Add filter to remove engagements the user is already a part of

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
