### PR TITLE
No migration needed since this project no longer connects to DB

### DIFF
--- a/met-cron/pre-hook-update-db.sh
+++ b/met-cron/pre-hook-update-db.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 cd /opt/app-root
-echo 'starting upgrade'
-python3 manage.py db upgrade
+#echo 'starting upgrade'
+#python3 manage.py db upgrade


### PR DESCRIPTION
*Description of changes:*


MET-CRON project no longer connects to DB directly.. so no need to run the migration scripts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
