### PR TITLE
Add survey status icons

### DIFF
--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -6,16 +6,15 @@ import { MetPageGridContainer, PrimaryButton } from 'components/common';
 import { Survey } from 'models/survey';
 import { createDefaultPageInfo, HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
 import { formatDate } from 'components/common/dateHelper';
-import { Link as MuiLink } from '@mui/material';
+import { Link as MuiLink, Tooltip } from '@mui/material';
 import TextField from '@mui/material/TextField';
 import SearchIcon from '@mui/icons-material/Search';
 import Stack from '@mui/material/Stack';
 import { getSurveysPage } from 'services/surveyService';
 import { useAppDispatch, useAppSelector } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { EngagementStatus, SubmissionStatus } from 'constants/engagementStatus';
+import { SubmissionStatus } from 'constants/engagementStatus';
 import { SCOPES } from 'components/permissionsGate/PermissionMaps';
-import CheckIcon from '@mui/icons-material/Check';
 import PriorityHighRoundedIcon from '@mui/icons-material/PriorityHighRounded';
 import { ApprovedIcon, NewIcon, NFRIcon, RejectedIcon } from 'components/engagement/listing/Icons';
 import CloseRounded from '@mui/icons-material/CloseRounded';
@@ -23,6 +22,11 @@ import FiberNewOutlined from '@mui/icons-material/FiberNewOutlined';
 import { PermissionsGate } from 'components/permissionsGate';
 import { CommentStatus } from 'constants/commentStatus';
 import { ActionsDropDown } from './ActionsDropDown';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import CheckIcon from '@mui/icons-material/Check';
+import LinkIcon from '@mui/icons-material/Link';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import { Palette } from 'styles/Theme';
 
 const SurveyListing = () => {
     const navigate = useNavigate();
@@ -130,26 +134,40 @@ const SurveyListing = () => {
             label: 'Status',
             allowSort: true,
             renderCell: (row: Survey) => {
-                const acceptable_status = [
-                    SubmissionStatus[SubmissionStatus.Open],
-                    SubmissionStatus[SubmissionStatus.Closed],
-                ];
-                if (
-                    row.engagement &&
-                    row.engagement.engagement_status.status_name === EngagementStatus[EngagementStatus.Published]
-                ) {
-                    if (acceptable_status.includes(SubmissionStatus[row.engagement.submission_status])) {
-                        return SubmissionStatus[row.engagement.submission_status];
-                    } else {
-                        return (
-                            EngagementStatus[EngagementStatus.Published].toString() +
-                            ' - ' +
-                            SubmissionStatus[row.engagement.submission_status]
-                        );
-                    }
+                if (row.is_hidden) {
+                    return (
+                        <Tooltip
+                            title="This survey is only visible to Superusers. Toggle off on the survey edit page to make it ready and available."
+                            placement="top"
+                        >
+                            <VisibilityOffIcon />
+                        </Tooltip>
+                    );
                 }
+
+                if (row.is_template) {
+                    return (
+                        <Tooltip title="Templates can be cloned and then edited" placement="top">
+                            <DashboardIcon />
+                        </Tooltip>
+                    );
+                }
+
+                if (row.engagement_id) {
+                    return (
+                        <Tooltip
+                            title="This survey is attached to an engagement. It can still be cloned and then edited."
+                            placement="top"
+                        >
+                            <LinkIcon />
+                        </Tooltip>
+                    );
+                }
+
                 return (
-                    row.engagement?.engagement_status.status_name || EngagementStatus[EngagementStatus.Draft].toString()
+                    <Tooltip title="This survey is ready to be cloned or attached to an engagement." placement="top">
+                        <CheckIcon sx={{ stroke: Palette.icons.surveyReady, strokeWidth: '2' }} />
+                    </Tooltip>
                 );
             },
         },

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -37,6 +37,9 @@ export const Palette = {
             border: '#F15A2C',
         },
     },
+    icons: {
+        surveyReady: '#77EB52',
+    },
 };
 
 export const BaseTheme = createTheme({


### PR DESCRIPTION
*Description of changes:*

- Replace status column in survey listing page with another with icons
- Add hidden, template, ready and linked icons


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
