### PR TITLE
Add tooltips for comment icons in engagement and survey listing pages

### DIFF
--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -5,7 +5,7 @@ import Grid from '@mui/material/Grid';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Collapse from '@mui/material/Collapse';
 import { Link, useNavigate } from 'react-router-dom';
-import { MetPageGridContainer, PrimaryButton, SecondaryButton } from 'components/common';
+import { MetPageGridContainer, MetTooltip, PrimaryButton, SecondaryButton } from 'components/common';
 import { Engagement } from 'models/engagement';
 import { useAppDispatch, useAppSelector } from 'hooks';
 import { createDefaultPageInfo, HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
@@ -220,18 +220,22 @@ const EngagementListing = () => {
 
                 const { approved } = row.submissions_meta_data;
                 return (
-                    <ApprovedIcon
-                        onClick={() => {
-                            if (row.surveys.length === 0) return;
-                            navigate(`/surveys/${row.surveys[0].id}/comments`, {
-                                state: {
-                                    status: CommentStatus.Approved,
-                                },
-                            });
-                        }}
-                    >
-                        {approved || 0}
-                    </ApprovedIcon>
+                    <MetTooltip title={'Approved'} placement="right" arrow>
+                        <span>
+                            <ApprovedIcon
+                                onClick={() => {
+                                    if (row.surveys.length === 0) return;
+                                    navigate(`/surveys/${row.surveys[0].id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.Approved,
+                                        },
+                                    });
+                                }}
+                            >
+                                {approved}
+                            </ApprovedIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },
@@ -259,18 +263,22 @@ const EngagementListing = () => {
                 }
                 const { needs_further_review } = row.submissions_meta_data;
                 return (
-                    <NFRIcon
-                        onClick={() => {
-                            if (row.surveys.length === 0) return;
-                            navigate(`/surveys/${row.surveys[0].id}/comments`, {
-                                state: {
-                                    status: CommentStatus.NeedsFurtherReview,
-                                },
-                            });
-                        }}
-                    >
-                        {needs_further_review || 0}
-                    </NFRIcon>
+                    <MetTooltip title={'Need further review'} placement="right" arrow>
+                        <span>
+                            <NFRIcon
+                                onClick={() => {
+                                    if (row.surveys.length === 0) return;
+                                    navigate(`/surveys/${row.surveys[0].id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.NeedsFurtherReview,
+                                        },
+                                    });
+                                }}
+                            >
+                                {needs_further_review || 0}
+                            </NFRIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },
@@ -298,18 +306,22 @@ const EngagementListing = () => {
                 }
                 const { rejected } = row.submissions_meta_data;
                 return (
-                    <RejectedIcon
-                        onClick={() => {
-                            if (row.surveys.length === 0) return;
-                            navigate(`/surveys/${row.surveys[0].id}/comments`, {
-                                state: {
-                                    status: CommentStatus.Rejected,
-                                },
-                            });
-                        }}
-                    >
-                        {rejected || 0}
-                    </RejectedIcon>
+                    <MetTooltip title={'Rejected'} placement="right" arrow>
+                        <span>
+                            <RejectedIcon
+                                onClick={() => {
+                                    if (row.surveys.length === 0) return;
+                                    navigate(`/surveys/${row.surveys[0].id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.Rejected,
+                                        },
+                                    });
+                                }}
+                            >
+                                {rejected || 0}
+                            </RejectedIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },
@@ -337,18 +349,22 @@ const EngagementListing = () => {
                 }
                 const { pending } = row.submissions_meta_data;
                 return (
-                    <NewIcon
-                        onClick={() => {
-                            if (row.surveys.length === 0) return;
-                            navigate(`/surveys/${row.surveys[0].id}/comments`, {
-                                state: {
-                                    status: CommentStatus.Pending,
-                                },
-                            });
-                        }}
-                    >
-                        {pending || 0}
-                    </NewIcon>
+                    <MetTooltip title={'New comments'} placement="right" arrow>
+                        <span>
+                            <NewIcon
+                                onClick={() => {
+                                    if (row.surveys.length === 0) return;
+                                    navigate(`/surveys/${row.surveys[0].id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.Pending,
+                                        },
+                                    });
+                                }}
+                            >
+                                {pending || 0}
+                            </NewIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },

--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -220,7 +220,7 @@ const EngagementListing = () => {
 
                 const { approved } = row.submissions_meta_data;
                 return (
-                    <MetTooltip title={'Approved'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'Approved'} placement="right" arrow>
                         <span>
                             <ApprovedIcon
                                 onClick={() => {
@@ -263,7 +263,7 @@ const EngagementListing = () => {
                 }
                 const { needs_further_review } = row.submissions_meta_data;
                 return (
-                    <MetTooltip title={'Need further review'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'Need further review'} placement="right" arrow>
                         <span>
                             <NFRIcon
                                 onClick={() => {
@@ -306,7 +306,7 @@ const EngagementListing = () => {
                 }
                 const { rejected } = row.submissions_meta_data;
                 return (
-                    <MetTooltip title={'Rejected'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'Rejected'} placement="right" arrow>
                         <span>
                             <RejectedIcon
                                 onClick={() => {
@@ -349,7 +349,7 @@ const EngagementListing = () => {
                 }
                 const { pending } = row.submissions_meta_data;
                 return (
-                    <MetTooltip title={'New comments'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'New comments'} placement="right" arrow>
                         <span>
                             <NewIcon
                                 onClick={() => {

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -288,7 +288,7 @@ const SurveyListing = () => {
                 }
                 const { needs_further_review } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'Approved'} placement="right" arrow>
+                    <MetTooltip title={'Need further review'} placement="right" arrow>
                         <span>
                             <NFRIcon
                                 onClick={() => {
@@ -330,7 +330,7 @@ const SurveyListing = () => {
                 }
                 const { rejected } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'Approved'} placement="right" arrow>
+                    <MetTooltip title={'Rejected'} placement="right" arrow>
                         <span>
                             <RejectedIcon
                                 onClick={() => {
@@ -372,7 +372,7 @@ const SurveyListing = () => {
                 }
                 const { pending } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'Approved'} placement="right" arrow>
+                    <MetTooltip title={'New comments'} placement="right" arrow>
                         <span>
                             <NewIcon
                                 onClick={() => {

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -246,17 +246,21 @@ const SurveyListing = () => {
                 }
                 const { approved } = row.comments_meta_data;
                 return (
-                    <ApprovedIcon
-                        onClick={() => {
-                            navigate(`/surveys/${row.id}/comments`, {
-                                state: {
-                                    status: CommentStatus.Approved,
-                                },
-                            });
-                        }}
-                    >
-                        {approved || 0}
-                    </ApprovedIcon>
+                    <MetTooltip title={'Approved'} placement="right" arrow>
+                        <span>
+                            <ApprovedIcon
+                                onClick={() => {
+                                    navigate(`/surveys/${row.id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.Approved,
+                                        },
+                                    });
+                                }}
+                            >
+                                {approved || 0}
+                            </ApprovedIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },
@@ -284,17 +288,21 @@ const SurveyListing = () => {
                 }
                 const { needs_further_review } = row.comments_meta_data;
                 return (
-                    <NFRIcon
-                        onClick={() => {
-                            navigate(`/surveys/${row.id}/comments`, {
-                                state: {
-                                    status: CommentStatus.NeedsFurtherReview,
-                                },
-                            });
-                        }}
-                    >
-                        {needs_further_review || 0}
-                    </NFRIcon>
+                    <MetTooltip title={'Approved'} placement="right" arrow>
+                        <span>
+                            <NFRIcon
+                                onClick={() => {
+                                    navigate(`/surveys/${row.id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.NeedsFurtherReview,
+                                        },
+                                    });
+                                }}
+                            >
+                                {needs_further_review || 0}
+                            </NFRIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },
@@ -322,17 +330,21 @@ const SurveyListing = () => {
                 }
                 const { rejected } = row.comments_meta_data;
                 return (
-                    <RejectedIcon
-                        onClick={() => {
-                            navigate(`/surveys/${row.id}/comments`, {
-                                state: {
-                                    status: CommentStatus.Rejected,
-                                },
-                            });
-                        }}
-                    >
-                        {rejected || 0}
-                    </RejectedIcon>
+                    <MetTooltip title={'Approved'} placement="right" arrow>
+                        <span>
+                            <RejectedIcon
+                                onClick={() => {
+                                    navigate(`/surveys/${row.id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.Rejected,
+                                        },
+                                    });
+                                }}
+                            >
+                                {rejected || 0}
+                            </RejectedIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },
@@ -360,17 +372,21 @@ const SurveyListing = () => {
                 }
                 const { pending } = row.comments_meta_data;
                 return (
-                    <NewIcon
-                        onClick={() => {
-                            navigate(`/surveys/${row.id}/comments`, {
-                                state: {
-                                    status: CommentStatus.Pending,
-                                },
-                            });
-                        }}
-                    >
-                        {pending || 0}
-                    </NewIcon>
+                    <MetTooltip title={'Approved'} placement="right" arrow>
+                        <span>
+                            <NewIcon
+                                onClick={() => {
+                                    navigate(`/surveys/${row.id}/comments`, {
+                                        state: {
+                                            status: CommentStatus.Pending,
+                                        },
+                                    });
+                                }}
+                            >
+                                {pending || 0}
+                            </NewIcon>
+                        </span>
+                    </MetTooltip>
                 );
             },
         },

--- a/met-web/src/components/survey/listing/index.tsx
+++ b/met-web/src/components/survey/listing/index.tsx
@@ -246,7 +246,7 @@ const SurveyListing = () => {
                 }
                 const { approved } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'Approved'} placement="right" arrow>
+                    <MetTooltip title={'Approved'} disableInteractive placement="right" arrow>
                         <span>
                             <ApprovedIcon
                                 onClick={() => {
@@ -288,7 +288,7 @@ const SurveyListing = () => {
                 }
                 const { needs_further_review } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'Need further review'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'Need further review'} placement="right" arrow>
                         <span>
                             <NFRIcon
                                 onClick={() => {
@@ -330,7 +330,7 @@ const SurveyListing = () => {
                 }
                 const { rejected } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'Rejected'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'Rejected'} placement="right" arrow>
                         <span>
                             <RejectedIcon
                                 onClick={() => {
@@ -372,7 +372,7 @@ const SurveyListing = () => {
                 }
                 const { pending } = row.comments_meta_data;
                 return (
-                    <MetTooltip title={'New comments'} placement="right" arrow>
+                    <MetTooltip disableInteractive title={'New comments'} placement="right" arrow>
                         <span>
                             <NewIcon
                                 onClick={() => {


### PR DESCRIPTION
*Description of changes:*

- Add tooltips for comments icons in engagement listing page
- Add tooltips for comments icons in survey listing page
- Disable interactivity on tooltips so they don't remain open when hovered over them


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
