### PR TITLE
Update form io text & link color

### DIFF
--- a/met-web/src/components/Form/formio-bootstrap.scss
+++ b/met-web/src/components/Form/formio-bootstrap.scss
@@ -399,6 +399,11 @@
 	}
 
 }
+
+.formio-component-paragraph {
+    color: #494949;
+}
+
 @media (min-width:576px){
     .container,.container-sm{
         max-width:540px

--- a/met-web/src/components/Form/formio-bootstrap.scss
+++ b/met-web/src/components/Form/formio-bootstrap.scss
@@ -103,12 +103,12 @@
 		top:-.5em
 	}
 	a{
-		color:#007bff;
-		text-decoration:none;
+		color:#1a5a96;
+		text-decoration:underline;
 		background-color:transparent
 	}
 	a:hover{
-		color:#0056b3;
+		color:#1a5a96;
 		text-decoration:underline
 	}
 	a:not([href]):not([class]){

--- a/met-web/src/components/survey/submit/Stepper.tsx
+++ b/met-web/src/components/survey/submit/Stepper.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Stepper, Step, StepLabel, Box } from '@mui/material';
-import { ThemeProvider } from '@mui/material/styles';
 import { FormInfo } from 'components/Form/types';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -16,17 +15,15 @@ function FormStepper({ currentPage, totalPages, pages }: ProgressBarProps) {
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     return (
-        <ThemeProvider theme={theme}>
-            <Box sx={{ pb: 2 }}>
-                <Stepper activeStep={currentPage} alternativeLabel>
-                    {pages.map((page: FormInfo, index: number) => (
-                        <Step key={index}>
-                            <StepLabel> {(!isMobile || index === currentPage) && page.title}</StepLabel>
-                        </Step>
-                    ))}
-                </Stepper>
-            </Box>
-        </ThemeProvider>
+        <Box sx={{ pb: 2 }}>
+            <Stepper activeStep={currentPage} alternativeLabel>
+                {pages.map((page: FormInfo, index: number) => (
+                    <Step key={index}>
+                        <StepLabel> {(!isMobile || index === currentPage) && page.title}</StepLabel>
+                    </Step>
+                ))}
+            </Stepper>
+        </Box>
     );
 }
 

--- a/met-web/src/components/survey/submit/Stepper.tsx
+++ b/met-web/src/components/survey/submit/Stepper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Stepper, Step, StepLabel, Box } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
 import { FormInfo } from 'components/Form/types';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -15,15 +16,17 @@ function FormStepper({ currentPage, totalPages, pages }: ProgressBarProps) {
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     return (
-        <Box sx={{ pb: 2 }}>
-            <Stepper activeStep={currentPage} alternativeLabel>
-                {pages.map((page: FormInfo, index: number) => (
-                    <Step key={index}>
-                        <StepLabel> {(!isMobile || index === currentPage) && page.title}</StepLabel>
-                    </Step>
-                ))}
-            </Stepper>
-        </Box>
+        <ThemeProvider theme={theme}>
+            <Box sx={{ pb: 2 }}>
+                <Stepper activeStep={currentPage} alternativeLabel>
+                    {pages.map((page: FormInfo, index: number) => (
+                        <Step key={index}>
+                            <StepLabel> {(!isMobile || index === currentPage) && page.title}</StepLabel>
+                        </Step>
+                    ))}
+                </Stepper>
+            </Box>
+        </ThemeProvider>
     );
 }
 

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -90,6 +90,18 @@ export const BaseTheme = createTheme({
                 focused: false,
             },
         },
+        MuiStepLabel: {
+            styleOverrides: {
+                label: {
+                    color: '#494949 !important',
+                    opacity: '100% !important',
+                },
+                labelContainer: {
+                    color: '#494949 !important',
+                    opacity: '100% !important',
+                },
+            },
+        },
     },
     typography: {
         fontFamily: "'BCSans', 'Noto Sans', Verdana, Arial, sans-serif",


### PR DESCRIPTION
Task:
The current color for paragraph is set to #666666 and the unvisited page name is #000000 at 60% opacity.

All text has to be #494949

-updated form stepper & paragraph to be #494949 

-update form io links to always be underlined & to be the color #1a5a96

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
