### PR TITLE
Add unit tests for adding to kc group and creating memberships

### DIFF
--- a/met-api/src/met_api/utils/enums.py
+++ b/met-api/src/met_api/utils/enums.py
@@ -55,6 +55,7 @@ class KeycloakGroups(Enum):
     EAO_IT_ADMIN = 'Superuser'
     EAO_IT_VIEWER = 'Viewer'
     EAO_TEAM_MEMBER = 'Member'
+    EAO_REVIEWER = 'Reviewer'
 
 
 class KeycloakGroupName(Enum):
@@ -63,6 +64,7 @@ class KeycloakGroupName(Enum):
     EAO_IT_ADMIN = 'EAO_IT_ADMIN'
     EAO_IT_VIEWER = 'EAO_IT_VIEWER'
     EAO_TEAM_MEMBER = 'EAO_TEAM_MEMBER'
+    EAO_REVIEWER = 'EAO_REVIEWER'
 
 
 class SourceType(Enum):

--- a/met-api/tests/unit/api/test_engagement_membership.py
+++ b/met-api/tests/unit/api/test_engagement_membership.py
@@ -1,0 +1,100 @@
+"""
+Tests to verify the EngagementMembership API endpoints.
+
+Test-Suite to ensure that the /engagements/{engagement_id}/memberships endpoint is working as expected.
+"""
+from unittest.mock import MagicMock
+from http import HTTPStatus
+import json
+
+from met_api.constants.membership_type import MembershipType
+from met_api.utils.enums import ContentType, KeycloakGroupName, MembershipStatus
+from tests.utilities.factory_scenarios import TestJwtClaims
+from tests.utilities.factory_utils import (
+    factory_auth_header, factory_engagement_model, factory_staff_user_model
+)
+
+memberships_url = '/api/engagements/{}/members'
+
+def test_create_engagement_membership_team_member(mocker, client, jwt, session):
+    """Assert that a team member engagement membership can be created."""
+    engagement = factory_engagement_model()
+    staff_user = factory_staff_user_model()
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+
+    mock_add_user_to_group_keycloak_response = MagicMock()
+    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
+    mock_add_user_to_group_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.add_user_to_group',
+        return_value=mock_add_user_to_group_keycloak_response
+    )
+    mock_get_users_groups_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.get_users_groups',
+        return_value={staff_user.external_id: [KeycloakGroupName.EAO_TEAM_MEMBER.value]}
+    )
+
+    data = {'user_id': staff_user.external_id}
+
+    rv = client.post(
+        memberships_url.format(engagement.id),
+        data=json.dumps(data),
+        headers=headers,
+        content_type=ContentType.JSON.value
+    )
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('engagement_id') == engagement.id
+    assert rv.json.get('user_id') == staff_user.id
+    assert rv.json.get('type') == MembershipType.TEAM_MEMBER
+    assert rv.json.get('status') == str(MembershipStatus.ACTIVE.value)
+    mock_add_user_to_group_keycloak.assert_called()
+    mock_get_users_groups_keycloak.assert_called()
+
+
+def test_create_engagement_membership_reviewer(mocker, client, jwt, session):
+    """Assert that a reviewer engagement membership can be created."""
+    engagement = factory_engagement_model()
+    staff_user = factory_staff_user_model()
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+
+    mock_add_user_to_group_keycloak_response = MagicMock()
+    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
+    mock_add_user_to_group_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.add_user_to_group',
+        return_value=mock_add_user_to_group_keycloak_response
+    )
+    mock_get_users_groups_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.get_users_groups',
+        return_value={staff_user.external_id: [KeycloakGroupName.EAO_REVIEWER.value]}
+    )
+
+    data = {'user_id': staff_user.external_id}
+
+    rv = client.post(
+        memberships_url.format(engagement.id),
+        data=json.dumps(data),
+        headers=headers,
+        content_type=ContentType.JSON.value
+    )
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('engagement_id') == engagement.id
+    assert rv.json.get('user_id') == staff_user.id
+    assert rv.json.get('type') == MembershipType.REVIEWER
+    assert rv.json.get('status') == str(MembershipStatus.ACTIVE.value)
+    mock_add_user_to_group_keycloak.assert_called()
+    mock_get_users_groups_keycloak.assert_called()
+
+
+def test_create_engagement_membership_unauthorized(client, jwt, session):
+    """Assert that creating an engagement membership without proper authorization fails."""
+    engagement = factory_engagement_model()
+    staff_user = factory_staff_user_model()
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)
+    data = {'user_id': staff_user.external_id}
+
+    rv = client.post(
+        memberships_url.format(engagement.id),
+        data=json.dumps(data),
+        headers=headers,
+        content_type=ContentType.JSON.value
+    )
+    assert rv.status_code == HTTPStatus.UNAUTHORIZED

--- a/met-api/tests/unit/api/test_engagement_membership.py
+++ b/met-api/tests/unit/api/test_engagement_membership.py
@@ -15,6 +15,7 @@ from tests.utilities.factory_utils import factory_auth_header, factory_engagemen
 
 memberships_url = '/api/engagements/{}/members'
 
+
 def test_create_engagement_membership_team_member(mocker, client, jwt, session):
     """Assert that a team member engagement membership can be created."""
     engagement = factory_engagement_model()

--- a/met-api/tests/unit/api/test_engagement_membership.py
+++ b/met-api/tests/unit/api/test_engagement_membership.py
@@ -3,16 +3,15 @@ Tests to verify the EngagementMembership API endpoints.
 
 Test-Suite to ensure that the /engagements/{engagement_id}/memberships endpoint is working as expected.
 """
-from unittest.mock import MagicMock
-from http import HTTPStatus
 import json
+from http import HTTPStatus
+from unittest.mock import MagicMock
 
 from met_api.constants.membership_type import MembershipType
 from met_api.utils.enums import ContentType, KeycloakGroupName, MembershipStatus
 from tests.utilities.factory_scenarios import TestJwtClaims
-from tests.utilities.factory_utils import (
-    factory_auth_header, factory_engagement_model, factory_staff_user_model
-)
+from tests.utilities.factory_utils import factory_auth_header, factory_engagement_model, factory_staff_user_model
+
 
 memberships_url = '/api/engagements/{}/members'
 

--- a/met-api/tests/unit/api/test_user.py
+++ b/met-api/tests/unit/api/test_user.py
@@ -79,3 +79,53 @@ def test_add_user_to_admin_group(mocker, client, jwt, session):  # pylint:disabl
     )
     assert rv.status_code == HTTPStatus.OK
     mock_add_user_to_group_keycloak.assert_called()
+
+def test_add_user_to_reviewer_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that you can add a user to the reviewer group."""
+    user = factory_staff_user_model()
+
+    mock_add_user_to_group_keycloak_response = MagicMock()
+    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
+    mock_add_user_to_group_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.add_user_to_group',
+        return_value=mock_add_user_to_group_keycloak_response
+    )
+    mock_get_user_groups_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.get_user_groups',
+        return_value=[{'name': KeycloakGroupName.EAO_REVIEWER.value}]
+    )
+
+    claims = TestJwtClaims.staff_admin_role
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.post(
+        f'/api/user/{user.external_id}/groups?group=Reviewer',
+        headers=headers, content_type=ContentType.JSON.value
+    )
+    assert rv.status_code == HTTPStatus.OK
+    mock_add_user_to_group_keycloak.assert_called()
+    mock_get_user_groups_keycloak.assert_called()
+
+def test_add_user_to_team_member_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that you can add a user to the team member group."""
+    user = factory_staff_user_model()
+
+    mock_add_user_to_group_keycloak_response = MagicMock()
+    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
+    mock_add_user_to_group_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.add_user_to_group',
+        return_value=mock_add_user_to_group_keycloak_response
+    )
+    mock_get_user_groups_keycloak = mocker.patch(
+        'met_api.services.keycloak.KeycloakService.get_user_groups',
+        return_value=[{'name': KeycloakGroupName.EAO_TEAM_MEMBER.value}]
+    )
+
+    claims = TestJwtClaims.staff_admin_role
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.post(
+        f'/api/user/{user.external_id}/groups?group=TeamMember',
+        headers=headers, content_type=ContentType.JSON.value
+    )
+    assert rv.status_code == HTTPStatus.OK
+    mock_add_user_to_group_keycloak.assert_called()
+    mock_get_user_groups_keycloak.assert_called()

--- a/met-api/tests/unit/api/test_user.py
+++ b/met-api/tests/unit/api/test_user.py
@@ -80,6 +80,7 @@ def test_add_user_to_admin_group(mocker, client, jwt, session):  # pylint:disabl
     assert rv.status_code == HTTPStatus.OK
     mock_add_user_to_group_keycloak.assert_called()
 
+
 def test_add_user_to_reviewer_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
     """Assert that you can add a user to the reviewer group."""
     user = factory_staff_user_model()
@@ -104,6 +105,7 @@ def test_add_user_to_reviewer_group(mocker, client, jwt, session):  # pylint:dis
     assert rv.status_code == HTTPStatus.OK
     mock_add_user_to_group_keycloak.assert_called()
     mock_get_user_groups_keycloak.assert_called()
+
 
 def test_add_user_to_team_member_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
     """Assert that you can add a user to the team member group."""

--- a/met-api/tests/unit/api/test_user.py
+++ b/met-api/tests/unit/api/test_user.py
@@ -30,10 +30,10 @@ from tests.utilities.factory_utils import factory_auth_header, factory_staff_use
 KEYCLOAK_SERVICE_MODULE = 'met_api.services.keycloak.KeycloakService'
 
 
-def mock_add_user_to_group(mocker, mock_response_status_code, mock_group_names):
+def mock_add_user_to_group(mocker, mock_group_names):
     """Mock the KeycloakService.add_user_to_group method."""
     mock_response = MagicMock()
-    mock_response.status_code = mock_response_status_code
+    mock_response.status_code = HTTPStatus.NO_CONTENT
 
     mock_add_user_to_group_keycloak = mocker.patch(
         f'{KEYCLOAK_SERVICE_MODULE}.add_user_to_group',
@@ -80,8 +80,7 @@ def test_add_user_to_admin_group(mocker, client, jwt, session):
 
     mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak = mock_add_user_to_group(
         mocker,
-        HTTPStatus.NO_CONTENT,
-        [KeycloakGroupName.EAO_IT_ADMIN.value]
+        [KeycloakGroupName.EAO_IT_VIEWER.value]
     )
 
     claims = TestJwtClaims.staff_admin_role
@@ -102,8 +101,7 @@ def test_add_user_to_reviewer_group(mocker, client, jwt, session):
 
     mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak = mock_add_user_to_group(
         mocker,
-        HTTPStatus.NO_CONTENT,
-        [KeycloakGroupName.EAO_REVIEWER.value]
+        [KeycloakGroupName.EAO_IT_VIEWER.value]
     )
 
     claims = TestJwtClaims.staff_admin_role
@@ -124,8 +122,7 @@ def test_add_user_to_team_member_group(mocker, client, jwt, session):
 
     mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak = mock_add_user_to_group(
         mocker,
-        HTTPStatus.NO_CONTENT,
-        [KeycloakGroupName.EAO_TEAM_MEMBER.value]
+        [KeycloakGroupName.EAO_IT_VIEWER.value]
     )
 
     claims = TestJwtClaims.staff_admin_role

--- a/met-api/tests/unit/api/test_user.py
+++ b/met-api/tests/unit/api/test_user.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests to verify the Engagement API end-point.
+"""
+Tests to verify the Engagement API end-point.
 
 Test-Suite to ensure that the /user endpoint is working as expected.
 """
@@ -26,13 +27,31 @@ from met_api.utils.enums import ContentType, KeycloakGroupName
 from tests.utilities.factory_scenarios import TestJwtClaims, TestUserInfo
 from tests.utilities.factory_utils import factory_auth_header, factory_staff_user_model
 
+KEYCLOAK_SERVICE_MODULE = 'met_api.services.keycloak.KeycloakService'
 
-def test_create_staff_user(client, jwt, session, ):  # pylint:disable=unused-argument
-    """Assert that an user can be POSTed."""
+
+def mock_add_user_to_group(mocker, mock_response_status_code, mock_group_names):
+    """Mock the KeycloakService.add_user_to_group method."""
+    mock_response = MagicMock()
+    mock_response.status_code = mock_response_status_code
+
+    mock_add_user_to_group_keycloak = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.add_user_to_group',
+        return_value=mock_response
+    )
+    mock_get_user_groups_keycloak = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.get_user_groups',
+        return_value=[{'name': group_name} for group_name in mock_group_names]
+    )
+
+    return mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak
+
+
+def test_create_staff_user(client, jwt, session):
+    """Assert that a user can be POSTed."""
     claims = TestJwtClaims.staff_admin_role
     headers = factory_auth_header(jwt=jwt, claims=claims)
-    rv = client.put('/api/user/',
-                    headers=headers, content_type=ContentType.JSON.value)
+    rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == HTTPStatus.OK
     assert rv.json.get('email_address') == claims.get('email')
     tenant_short_name = current_app.config.get('DEFAULT_TENANT_SHORT_NAME')
@@ -40,8 +59,8 @@ def test_create_staff_user(client, jwt, session, ):  # pylint:disable=unused-arg
     assert rv.json.get('tenant_id') == str(tenant.id)
 
 
-def test_get_staff_users(client, jwt, session, ):  # pylint:disable=unused-argument
-    """Assert that an user can be POSTed."""
+def test_get_staff_users(client, jwt, session):
+    """Assert that a user can be POSTed."""
     staff_1 = dict(TestUserInfo.user_staff_1)
     staff_2 = dict(TestUserInfo.user_staff_1)
     factory_staff_user_model(user_info=staff_1)
@@ -49,84 +68,72 @@ def test_get_staff_users(client, jwt, session, ):  # pylint:disable=unused-argum
 
     claims = TestJwtClaims.staff_admin_role
     headers = factory_auth_header(jwt=jwt, claims=claims)
-    rv = client.get('/api/user/',
-                    headers=headers, content_type=ContentType.JSON.value)
+    rv = client.get('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == HTTPStatus.OK
     assert rv.json.get('total') == 3
     assert len(rv.json.get('items')) == 3
 
 
-def test_add_user_to_admin_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that you can add a user to admin group."""
+def test_add_user_to_admin_group(mocker, client, jwt, session):
+    """Assert that a user can be added to the admin group."""
     user = factory_staff_user_model()
 
-    mock_add_user_to_group_keycloak_response = MagicMock()
-    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
-    mock_add_user_to_group_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.add_user_to_group',
-        return_value=mock_add_user_to_group_keycloak_response
-    )
-    mock_add_user_to_group_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.get_user_groups',
-        return_value=[{'name': KeycloakGroupName.EAO_IT_VIEWER.value}]
+    mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak = mock_add_user_to_group(
+        mocker,
+        HTTPStatus.NO_CONTENT,
+        [KeycloakGroupName.EAO_IT_ADMIN.value]
     )
 
     claims = TestJwtClaims.staff_admin_role
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.post(
-        f'/api/user/{user.external_id}/groups?group=Adminstrator',
-        headers=headers, content_type=ContentType.JSON.value
-    )
-    assert rv.status_code == HTTPStatus.OK
-    mock_add_user_to_group_keycloak.assert_called()
-
-
-def test_add_user_to_reviewer_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that you can add a user to the reviewer group."""
-    user = factory_staff_user_model()
-
-    mock_add_user_to_group_keycloak_response = MagicMock()
-    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
-    mock_add_user_to_group_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.add_user_to_group',
-        return_value=mock_add_user_to_group_keycloak_response
-    )
-    mock_get_user_groups_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.get_user_groups',
-        return_value=[{'name': KeycloakGroupName.EAO_REVIEWER.value}]
-    )
-
-    claims = TestJwtClaims.staff_admin_role
-    headers = factory_auth_header(jwt=jwt, claims=claims)
-    rv = client.post(
-        f'/api/user/{user.external_id}/groups?group=Reviewer',
-        headers=headers, content_type=ContentType.JSON.value
+        f'/api/user/{user.external_id}/groups?group=Administrator',
+        headers=headers,
+        content_type=ContentType.JSON.value
     )
     assert rv.status_code == HTTPStatus.OK
     mock_add_user_to_group_keycloak.assert_called()
     mock_get_user_groups_keycloak.assert_called()
 
 
-def test_add_user_to_team_member_group(mocker, client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that you can add a user to the team member group."""
+def test_add_user_to_reviewer_group(mocker, client, jwt, session):
+    """Assert that a user can be added to the reviewer group."""
     user = factory_staff_user_model()
 
-    mock_add_user_to_group_keycloak_response = MagicMock()
-    mock_add_user_to_group_keycloak_response.status_code = HTTPStatus.NO_CONTENT
-    mock_add_user_to_group_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.add_user_to_group',
-        return_value=mock_add_user_to_group_keycloak_response
+    mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak = mock_add_user_to_group(
+        mocker,
+        HTTPStatus.NO_CONTENT,
+        [KeycloakGroupName.EAO_REVIEWER.value]
     )
-    mock_get_user_groups_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.get_user_groups',
-        return_value=[{'name': KeycloakGroupName.EAO_TEAM_MEMBER.value}]
+
+    claims = TestJwtClaims.staff_admin_role
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.post(
+        f'/api/user/{user.external_id}/groups?group=Reviewer',
+        headers=headers,
+        content_type=ContentType.JSON.value
+    )
+    assert rv.status_code == HTTPStatus.OK
+    mock_add_user_to_group_keycloak.assert_called()
+    mock_get_user_groups_keycloak.assert_called()
+
+
+def test_add_user_to_team_member_group(mocker, client, jwt, session):
+    """Assert that a user can be added to the team member group."""
+    user = factory_staff_user_model()
+
+    mock_add_user_to_group_keycloak, mock_get_user_groups_keycloak = mock_add_user_to_group(
+        mocker,
+        HTTPStatus.NO_CONTENT,
+        [KeycloakGroupName.EAO_TEAM_MEMBER.value]
     )
 
     claims = TestJwtClaims.staff_admin_role
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.post(
         f'/api/user/{user.external_id}/groups?group=TeamMember',
-        headers=headers, content_type=ContentType.JSON.value
+        headers=headers,
+        content_type=ContentType.JSON.value
     )
     assert rv.status_code == HTTPStatus.OK
     mock_add_user_to_group_keycloak.assert_called()

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -260,7 +260,8 @@ class TestJwtClaims(dict, Enum):
                 'view_all_surveys',
                 'edit_all_surveys',
                 'view_unapproved_comments',
-                'clone_survey'
+                'clone_survey',
+                'edit_members'
             ]
         }
     }


### PR DESCRIPTION
*Description of changes:*

- Add a test for adding reviewer to KC group
- Add test_engagement_membership test
- Add tests for creating memberships for team member and reviewer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
