### PR TITLE
Add user guide logic and list item in sidenav

### DIFF
--- a/met-web/src/components/layout/SideNav/SideNav.tsx
+++ b/met-web/src/components/layout/SideNav/SideNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ListItemButton, List, ListItem, Box, Drawer, Toolbar } from '@mui/material';
+import { ListItemButton, List, ListItem, Box, Drawer, Toolbar, Divider } from '@mui/material';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Routes } from './SideNavElements';
 import { Palette } from '../../../styles/Theme';
@@ -7,6 +7,7 @@ import { SideNavProps } from './types';
 import { MetHeader4 } from 'components/common';
 import { When, Unless } from 'react-if';
 import { useAppSelector } from 'hooks';
+import UserGuideNav from './UserGuideNav';
 
 const DrawerBox = () => {
     const navigate = useNavigate();
@@ -58,6 +59,8 @@ const DrawerBox = () => {
                         </ListItemButton>
                     </ListItem>
                 ))}
+                <Divider sx={{ backgroundColor: 'white' }} />
+                <UserGuideNav />
             </List>
         </Box>
     );

--- a/met-web/src/components/layout/SideNav/UserGuideNav.tsx
+++ b/met-web/src/components/layout/SideNav/UserGuideNav.tsx
@@ -55,11 +55,11 @@ const UserGuideNav = () => {
     const openHelpPage = () => {
         const key = handleSimilarityScore();
         if (!key) {
-            window.open(DEFAULT_HELP_PATH, '_blank');
+            window.open(DEFAULT_HELP_PATH, '_blank', 'noopener');
             return;
         }
         const helpPagePath = key ? helpPaths[key] : DEFAULT_HELP_PATH;
-        window.open(helpPagePath, '_blank');
+        window.open(helpPagePath, '_blank', 'noopener');
     };
 
     return (

--- a/met-web/src/components/layout/SideNav/UserGuideNav.tsx
+++ b/met-web/src/components/layout/SideNav/UserGuideNav.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { ListItemButton, ListItem } from '@mui/material';
+import { useLocation } from 'react-router-dom';
+import { Palette } from '../../../styles/Theme';
+import { MetHeader4 } from 'components/common';
+import { levenshteinDistance } from 'helper';
+
+const THRESHOLD_SIMILARITY_SCORE = 10;
+const DEFAULT_HELP_PATH = 'https://www.example.com/help/dashboard';
+
+const UserGuideNav = () => {
+    const { pathname } = useLocation();
+
+    const helpPaths: { [key: string]: string } = {
+        '/': 'https://www.example.com/help/dashboard',
+        '/engagements': 'https://www.example.com/help/engagements',
+        '/surveys': 'https://www.example.com/help/surveys',
+        '/surveys/create': 'https://www.example.com/help/create-survey',
+        '/surveys/1/build': 'https://www.example.com/help/survey-builder',
+        '/surveys/1/submit': 'https://www.example.com/help/survey-submission',
+        '/surveys/1/comments': 'https://www.example.com/help/survey-comments',
+        '/surveys/1/comments/all': 'https://www.example.com/help/all-comments',
+        '/surveys/1/submissions/1/review': 'https://www.example.com/help/review-submission',
+        '/engagements/create/form': 'https://www.example.com/help/create-engagement',
+        '/engagements/1/form': 'https://www.example.com/help/edit-engagement',
+        '/engagements/1/view': 'https://www.example.com/help/view-engagement',
+        '/engagements/1/comments': 'https://www.example.com/help/engagement-comments',
+        '/engagements/1/dashboard': 'https://www.example.com/help/engagement-dashboard',
+        '/feedback': 'https://www.example.com/help/feedback',
+        '/calendar': 'https://www.example.com/help/calendar',
+        '/reporting': 'https://www.example.com/help/reporting',
+        '/usermanagement': 'https://www.example.com/help/user-management',
+        '/usermanagement/1/details': 'https://www.example.com/help/user-details',
+    };
+
+    const handleSimilarityScore = () => {
+        let leastDifferenceScore = THRESHOLD_SIMILARITY_SCORE * 10;
+        let keyWithLeastDifference = '';
+
+        Object.keys(helpPaths).forEach((key) => {
+            const differenceScore = levenshteinDistance(key, pathname);
+            if (differenceScore < leastDifferenceScore) {
+                leastDifferenceScore = differenceScore;
+                keyWithLeastDifference = key;
+            }
+        });
+
+        console.log('leastDifferenceScore', leastDifferenceScore);
+        if (leastDifferenceScore < THRESHOLD_SIMILARITY_SCORE) {
+            return keyWithLeastDifference;
+        } else {
+            return '';
+        }
+    };
+
+    const openHelpPage = () => {
+        const key = handleSimilarityScore();
+        if (!key) {
+            window.open(DEFAULT_HELP_PATH, '_blank');
+            return;
+        }
+        const helpPagePath = key ? helpPaths[key] : DEFAULT_HELP_PATH;
+        window.open(helpPagePath, '_blank');
+    };
+
+    return (
+        <ListItem key="user-guide">
+            <ListItemButton
+                onClick={openHelpPage}
+                sx={{
+                    '&:hover': {
+                        backgroundColor: Palette.hover.light,
+                    },
+                }}
+            >
+                <MetHeader4 color="white">User Guide</MetHeader4>
+            </ListItemButton>
+        </ListItem>
+    );
+};
+
+export default UserGuideNav;

--- a/met-web/src/components/layout/SideNav/UserGuideNav.tsx
+++ b/met-web/src/components/layout/SideNav/UserGuideNav.tsx
@@ -45,7 +45,6 @@ const UserGuideNav = () => {
             }
         });
 
-        console.log('leastDifferenceScore', leastDifferenceScore);
         if (leastDifferenceScore < THRESHOLD_SIMILARITY_SCORE) {
             return keyWithLeastDifference;
         } else {

--- a/met-web/src/helper/index.ts
+++ b/met-web/src/helper/index.ts
@@ -31,3 +31,25 @@ export const filterQueryParams = (queryParams: { [x: string]: unknown }) => {
     });
     return filteredQueryParams;
 };
+
+// used to measure the distance (similarity/difference) between two strings
+export const levenshteinDistance = (string1: string, string2: string): number => {
+    if (string1.length < string2.length) {
+        return levenshteinDistance(string2, string1);
+    }
+    if (string2.length === 0) {
+        return string1.length;
+    }
+    const previousRow = Array.from({ length: string2.length + 1 }, (_, i) => i);
+    for (let i = 0; i < string1.length; i++) {
+        const currentRow = [i + 1];
+        for (let j = 0; j < string2.length; j++) {
+            const insertions = previousRow[j + 1] + 1;
+            const deletions = currentRow[j] + 1;
+            const substitutions = previousRow[j] + (string1[i] !== string2[j] ? 1 : 0);
+            currentRow.push(Math.min(insertions, deletions, substitutions));
+        }
+        previousRow.splice(0, previousRow.length, ...currentRow);
+    }
+    return previousRow[string2.length];
+};

--- a/met-web/src/routes/AuthenticatedRoutes.tsx
+++ b/met-web/src/routes/AuthenticatedRoutes.tsx
@@ -29,6 +29,7 @@ const AuthenticatedRoutes = () => {
             <ScrollToTop />
             <Routes>
                 <Route path="/" element={<Dashboard />} />
+                <Route path="/asdasds" element={<Dashboard />} />
                 <Route path="/engagements" element={<EngagementListing />} />
                 <Route path="/surveys" element={<SurveyListing />} />
                 <Route path="/surveys/create" element={<CreateSurvey />} />

--- a/met-web/src/routes/AuthenticatedRoutes.tsx
+++ b/met-web/src/routes/AuthenticatedRoutes.tsx
@@ -29,7 +29,6 @@ const AuthenticatedRoutes = () => {
             <ScrollToTop />
             <Routes>
                 <Route path="/" element={<Dashboard />} />
-                <Route path="/asdasds" element={<Dashboard />} />
                 <Route path="/engagements" element={<EngagementListing />} />
                 <Route path="/surveys" element={<SurveyListing />} />
                 <Route path="/surveys/create" element={<CreateSurvey />} />


### PR DESCRIPTION
*Description of changes:*
- Add example help paths
- Use Levenshtein distance to determine the help page that corresponds to the current route
- Add user guide list item in side nav


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
