### PR TITLE
Revert node-sass bump

### DIFF
--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -51,7 +51,7 @@
                 "maplibre-gl": "^1.15.3",
                 "met-formio": "^1.0.10",
                 "mui-sx": "^1.0.0",
-                "node-sass": "^9.0.0",
+                "node-sass": "^7.0.3",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0",
                 "react-draft-wysiwyg": "^1.14.7",
@@ -4281,6 +4281,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -7168,8 +7169,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
             "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^3.6.0"
@@ -7320,8 +7319,6 @@
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
@@ -7360,8 +7357,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -7481,8 +7476,6 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -7490,9 +7483,7 @@
         "node_modules/aws4": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "node_modules/axe-core": {
             "version": "4.6.3",
@@ -7833,8 +7824,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -8369,9 +8358,7 @@
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
         },
         "node_modules/chalk": {
             "version": "3.0.0",
@@ -9685,8 +9672,6 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -10406,8 +10391,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -11772,9 +11755,7 @@
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
             "engines": [
                 "node >=0.6.0"
-            ],
-            "optional": true,
-            "peer": true
+            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -12098,8 +12079,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -12411,8 +12390,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
             "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
                 "color-support": "^1.1.2",
@@ -12573,8 +12550,6 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
@@ -12788,8 +12763,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -12799,8 +12772,6 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
             "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "deprecated": "this library is no longer supported",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -13197,6 +13168,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -13244,8 +13216,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -13952,9 +13922,7 @@
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -15708,9 +15676,7 @@
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
         },
         "node_modules/jsdom": {
             "version": "19.0.0",
@@ -15797,9 +15763,7 @@
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -15875,8 +15839,6 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
             "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -16971,9 +16933,9 @@
             "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
         },
         "node_modules/node-sass": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
-            "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
+            "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
             "hasInstallScript": true,
             "dependencies": {
                 "async-foreach": "^0.1.3",
@@ -16983,98 +16945,20 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "lodash": "^4.17.15",
-                "make-fetch-happen": "^10.0.4",
                 "meow": "^9.0.0",
-                "nan": "^2.17.0",
+                "nan": "^2.13.2",
                 "node-gyp": "^8.4.1",
+                "npmlog": "^5.0.0",
+                "request": "^2.88.0",
                 "sass-graph": "^4.0.1",
                 "stdout-stream": "^1.4.0",
-                "true-case-path": "^2.2.1"
+                "true-case-path": "^1.0.2"
             },
             "bin": {
                 "node-sass": "bin/node-sass"
             },
             "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/node-sass/node_modules/@npmcli/fs": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-            "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-            "dependencies": {
-                "@gar/promisify": "^1.1.3",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/@npmcli/move-file": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-            "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-            "deprecated": "This functionality has been moved to @npmcli/fs",
-            "dependencies": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/cacache": {
-            "version": "16.1.3",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-            "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-            "dependencies": {
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/move-file": "^2.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "glob": "^8.0.1",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/cacache/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/node-sass/node_modules/chalk": {
@@ -17090,113 +16974,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/node-sass/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/node-sass/node_modules/make-fetch-happen": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-            "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
-            "dependencies": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^16.1.0",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^2.0.3",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^7.0.0",
-                "ssri": "^9.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-sass/node_modules/minipass-fetch": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-            "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-            "dependencies": {
-                "minipass": "^3.1.6",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.13"
-            }
-        },
-        "node_modules/node-sass/node_modules/socks-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-            "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "^4.3.3",
-                "socks": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/node-sass/node_modules/ssri": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-            "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
-            "dependencies": {
-                "minipass": "^3.1.1"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/unique-filename": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-            "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
-            "dependencies": {
-                "unique-slug": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/node-sass/node_modules/unique-slug": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-            "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/nopt": {
@@ -17274,8 +17051,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
             "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "are-we-there-yet": "^2.0.0",
                 "console-control-strings": "^1.1.0",
@@ -17303,8 +17078,6 @@
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -19294,8 +19067,6 @@
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
             "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -20870,37 +20641,6 @@
                 }
             }
         },
-        "node_modules/react-scripts/node_modules/node-sass": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
-            "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
-            "hasInstallScript": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "async-foreach": "^0.1.3",
-                "chalk": "^4.1.2",
-                "cross-spawn": "^7.0.3",
-                "gaze": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "glob": "^7.0.3",
-                "lodash": "^4.17.15",
-                "meow": "^9.0.0",
-                "nan": "^2.13.2",
-                "node-gyp": "^8.4.1",
-                "npmlog": "^5.0.0",
-                "request": "^2.88.0",
-                "sass-graph": "^4.0.1",
-                "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
-            },
-            "bin": {
-                "node-sass": "bin/node-sass"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/react-scripts/node_modules/sass-loader": {
             "version": "12.6.0",
             "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
@@ -20955,16 +20695,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/react-scripts/node_modules/true-case-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "glob": "^7.1.2"
             }
         },
         "node_modules/react-scripts/node_modules/v8-to-istanbul": {
@@ -21466,8 +21196,6 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -21498,8 +21226,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -21513,8 +21239,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -21528,8 +21252,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "optional": true,
-            "peer": true,
             "bin": {
                 "uuid": "bin/uuid"
             }
@@ -22430,8 +22152,6 @@
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
             "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -23435,9 +23155,12 @@
             }
         },
         "node_modules/true-case-path": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
-            "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "dependencies": {
+                "glob": "^7.1.2"
+            }
         },
         "node_modules/tryer": {
             "version": "1.0.1",
@@ -23612,8 +23335,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -23629,9 +23350,7 @@
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -24030,8 +23749,6 @@
             "engines": [
                 "node >=0.6.0"
             ],
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -27794,7 +27511,8 @@
         "@tootallnate/once": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true
         },
         "@trysound/sax": {
             "version": "0.2.0",
@@ -30131,8 +29849,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
             "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^3.6.0"
@@ -30247,8 +29963,6 @@
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
@@ -30288,9 +30002,7 @@
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
         },
         "ast-types-flow": {
             "version": "0.0.7",
@@ -30363,16 +30075,12 @@
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
         },
         "aws4": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "axe-core": {
             "version": "4.6.3",
@@ -30640,8 +30348,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -31050,9 +30756,7 @@
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
         },
         "chalk": {
             "version": "3.0.0",
@@ -32058,8 +31762,6 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -32613,8 +32315,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -33616,9 +33316,7 @@
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -33884,9 +33582,7 @@
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
         },
         "fork-ts-checker-webpack-plugin": {
             "version": "6.5.3",
@@ -34112,8 +33808,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
             "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "aproba": "^1.0.3 || ^2.0.0",
                 "color-support": "^1.1.2",
@@ -34242,8 +33936,6 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -34403,16 +34095,12 @@
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
         },
         "har-validator": {
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
             "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -34714,6 +34402,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
             "requires": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -34743,8 +34432,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -35209,9 +34896,7 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
         },
         "istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -36540,9 +36225,7 @@
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
         },
         "jsdom": {
             "version": "19.0.0",
@@ -36612,9 +36295,7 @@
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
         "json5": {
             "version": "2.2.3",
@@ -36672,8 +36353,6 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
             "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -37560,9 +37239,9 @@
             "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
         },
         "node-sass": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
-            "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
+            "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
             "requires": {
                 "async-foreach": "^0.1.3",
                 "chalk": "^4.1.2",
@@ -37571,80 +37250,16 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "lodash": "^4.17.15",
-                "make-fetch-happen": "^10.0.4",
                 "meow": "^9.0.0",
-                "nan": "^2.17.0",
+                "nan": "^2.13.2",
                 "node-gyp": "^8.4.1",
+                "npmlog": "^5.0.0",
+                "request": "^2.88.0",
                 "sass-graph": "^4.0.1",
                 "stdout-stream": "^1.4.0",
-                "true-case-path": "^2.2.1"
+                "true-case-path": "^1.0.2"
             },
             "dependencies": {
-                "@npmcli/fs": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-                    "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-                    "requires": {
-                        "@gar/promisify": "^1.1.3",
-                        "semver": "^7.3.5"
-                    }
-                },
-                "@npmcli/move-file": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-                    "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-                    "requires": {
-                        "mkdirp": "^1.0.4",
-                        "rimraf": "^3.0.2"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "cacache": {
-                    "version": "16.1.3",
-                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-                    "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-                    "requires": {
-                        "@npmcli/fs": "^2.1.0",
-                        "@npmcli/move-file": "^2.0.0",
-                        "chownr": "^2.0.0",
-                        "fs-minipass": "^2.1.0",
-                        "glob": "^8.0.1",
-                        "infer-owner": "^1.0.4",
-                        "lru-cache": "^7.7.1",
-                        "minipass": "^3.1.6",
-                        "minipass-collect": "^1.0.2",
-                        "minipass-flush": "^1.0.5",
-                        "minipass-pipeline": "^1.2.4",
-                        "mkdirp": "^1.0.4",
-                        "p-map": "^4.0.0",
-                        "promise-inflight": "^1.0.1",
-                        "rimraf": "^3.0.2",
-                        "ssri": "^9.0.0",
-                        "tar": "^6.1.11",
-                        "unique-filename": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "8.1.0",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-                            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^5.0.1",
-                                "once": "^1.3.0"
-                            }
-                        }
-                    }
-                },
                 "chalk": {
                     "version": "4.1.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -37652,87 +37267,6 @@
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
-                    }
-                },
-                "lru-cache": {
-                    "version": "7.18.3",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
-                },
-                "make-fetch-happen": {
-                    "version": "10.2.1",
-                    "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-                    "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
-                    "requires": {
-                        "agentkeepalive": "^4.2.1",
-                        "cacache": "^16.1.0",
-                        "http-cache-semantics": "^4.1.0",
-                        "http-proxy-agent": "^5.0.0",
-                        "https-proxy-agent": "^5.0.0",
-                        "is-lambda": "^1.0.1",
-                        "lru-cache": "^7.7.1",
-                        "minipass": "^3.1.6",
-                        "minipass-collect": "^1.0.2",
-                        "minipass-fetch": "^2.0.3",
-                        "minipass-flush": "^1.0.5",
-                        "minipass-pipeline": "^1.2.4",
-                        "negotiator": "^0.6.3",
-                        "promise-retry": "^2.0.1",
-                        "socks-proxy-agent": "^7.0.0",
-                        "ssri": "^9.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "5.1.6",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                },
-                "minipass-fetch": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-                    "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-                    "requires": {
-                        "encoding": "^0.1.13",
-                        "minipass": "^3.1.6",
-                        "minipass-sized": "^1.0.3",
-                        "minizlib": "^2.1.2"
-                    }
-                },
-                "socks-proxy-agent": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-                    "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-                    "requires": {
-                        "agent-base": "^6.0.2",
-                        "debug": "^4.3.3",
-                        "socks": "^2.6.2"
-                    }
-                },
-                "ssri": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-                    "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
-                    "requires": {
-                        "minipass": "^3.1.1"
-                    }
-                },
-                "unique-filename": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-                    "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
-                    "requires": {
-                        "unique-slug": "^3.0.0"
-                    }
-                },
-                "unique-slug": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-                    "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-                    "requires": {
-                        "imurmurhash": "^0.1.4"
                     }
                 }
             }
@@ -37788,8 +37322,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
             "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "are-we-there-yet": "^2.0.0",
                 "console-control-strings": "^1.1.0",
@@ -37813,9 +37345,7 @@
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -39085,9 +38615,7 @@
         "qs": {
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
         },
         "querystring": {
             "version": "0.2.0",
@@ -40283,30 +39811,6 @@
                         "xml-name-validator": "^3.0.0"
                     }
                 },
-                "node-sass": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
-                    "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "async-foreach": "^0.1.3",
-                        "chalk": "^4.1.2",
-                        "cross-spawn": "^7.0.3",
-                        "gaze": "^1.0.0",
-                        "get-stdin": "^4.0.1",
-                        "glob": "^7.0.3",
-                        "lodash": "^4.17.15",
-                        "meow": "^9.0.0",
-                        "nan": "^2.13.2",
-                        "node-gyp": "^8.4.1",
-                        "npmlog": "^5.0.0",
-                        "request": "^2.88.0",
-                        "sass-graph": "^4.0.1",
-                        "stdout-stream": "^1.4.0",
-                        "true-case-path": "^1.0.2"
-                    }
-                },
                 "sass-loader": {
                     "version": "12.6.0",
                     "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
@@ -40327,16 +39831,6 @@
                     "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
                     "requires": {
                         "punycode": "^2.1.1"
-                    }
-                },
-                "true-case-path": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-                    "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "glob": "^7.1.2"
                     }
                 },
                 "v8-to-istanbul": {
@@ -40737,8 +40231,6 @@
             "version": "2.88.2",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -40766,8 +40258,6 @@
                     "version": "2.3.3",
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
                     "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.6",
@@ -40778,8 +40268,6 @@
                     "version": "2.5.0",
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
                     "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "psl": "^1.1.28",
                         "punycode": "^2.1.1"
@@ -40788,9 +40276,7 @@
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-                    "optional": true,
-                    "peer": true
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -41502,8 +40988,6 @@
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
             "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -42273,9 +41757,12 @@
             "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
         },
         "true-case-path": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
-            "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "requires": {
+                "glob": "^7.1.2"
+            }
         },
         "tryer": {
             "version": "1.0.1",
@@ -42391,8 +41878,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -42405,9 +41890,7 @@
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "optional": true,
-            "peer": true
+            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
         },
         "type-check": {
             "version": "0.4.0",
@@ -42704,8 +42187,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "optional": true,
-            "peer": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",

--- a/met-web/package.json
+++ b/met-web/package.json
@@ -46,7 +46,7 @@
         "maplibre-gl": "^1.15.3",
         "met-formio": "^1.0.10",
         "mui-sx": "^1.0.0",
-        "node-sass": "^9.0.0",
+        "node-sass": "^7.0.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-draft-wysiwyg": "^1.14.7",


### PR DESCRIPTION
*Description of changes:*

- revert node-sass bump back to "^7.0.3" because it is compatible with node 14 and that is what we are using in our deployment


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
