### PR TITLE
Dashboard Touch ups for ultra small screen

### DIFF
--- a/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
+++ b/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
@@ -47,7 +47,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
     const marginXStyling = { marginX: isTablet ? 1 : 0 };
     const extraSmallStyling = {
         fontSize: isExtraSmall ? '12px' : 'inherit',
-        width: isExtraSmall ? '80%' : 'auto',
+        width: isExtraSmall ? '40%' : 'auto',
     };
 
     const fetchData = async () => {
@@ -210,7 +210,8 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                 <SecondaryButton
                                     sx={{
                                         ...dashboardCustomStyles.primaryButton,
-                                        ...extraSmallStyling
+                                        ...extraSmallStyling,
+                                        width: isExtraSmall ? '80%' : '100%',
                                     }}
                                     onClick={clearDates}
                                 >
@@ -242,16 +243,10 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                         ...marginXStyling,
                                     }}
                                 >
-                                    <MetToggleButton
-                                        value="weekly"
-                                        sx={extraSmallStyling}
-                                    >
+                                    <MetToggleButton value="weekly" sx={extraSmallStyling}>
                                         Weekly
                                     </MetToggleButton>
-                                    <MetToggleButton
-                                        value="monthly"
-                                        sx={extraSmallStyling}
-                                    >
+                                    <MetToggleButton value="monthly" sx={extraSmallStyling}>
                                         Monthly
                                     </MetToggleButton>
                                 </ToggleButtonGroup>

--- a/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
+++ b/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
@@ -44,6 +44,12 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
     const [chartBy, setChartBy] = React.useState('monthly');
     const [fromDate, setFromDate] = React.useState<Dayjs | null>(null);
     const [toDate, setToDate] = React.useState<Dayjs | null>(null);
+    const marginXStyling = { marginX: isTablet ? 1 : 0 };
+    const extraSmallStyling = {
+        fontSize: isExtraSmall ? '12px' : 'inherit',
+        width: isExtraSmall ? '80%' : 'auto',
+    };
+
     const fetchData = async () => {
         setIsLoading(true);
         try {
@@ -144,14 +150,14 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                 alignItems={'center'}
                                 justifyContent={'center'}
                                 xs={12}
-                                sx={{ marginX: 1, mb: 1 }}
+                                sx={{ ...marginXStyling, mb: 1 }}
                             >
                                 <MetLabel>Select Date Range </MetLabel>
                             </Grid>
                             <Grid
                                 container
                                 item
-                                sx={{ mb: 1, marginX: isTablet ? 1 : 0 }}
+                                sx={{ mb: 1, ...marginXStyling }}
                                 direction="column"
                                 alignItems="center"
                             >
@@ -177,7 +183,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                             <Grid
                                 container
                                 item
-                                sx={{ mb: 1, marginX: isTablet ? 1 : 0 }}
+                                sx={{ mb: 1, ...marginXStyling }}
                                 direction="column"
                                 alignItems="center"
                             >
@@ -204,8 +210,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                 <SecondaryButton
                                     sx={{
                                         ...dashboardCustomStyles.primaryButton,
-                                        fontSize: isExtraSmall ? '12px' : 'inherit',
-                                        width: isExtraSmall ? '80%' : 'auto',
+                                        ...extraSmallStyling
                                     }}
                                     onClick={clearDates}
                                 >
@@ -234,24 +239,18 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                     size={isTablet ? 'small' : 'medium'}
                                     sx={{
                                         ...dashboardCustomStyles.toggleGroup,
-                                        marginX: isTablet ? 1 : 0,
+                                        ...marginXStyling,
                                     }}
                                 >
                                     <MetToggleButton
                                         value="weekly"
-                                        sx={{
-                                            fontSize: isExtraSmall ? '12px' : 'inherit',
-                                            width: isExtraSmall ? '40%' : '100%',
-                                        }}
+                                        sx={extraSmallStyling}
                                     >
                                         Weekly
                                     </MetToggleButton>
                                     <MetToggleButton
                                         value="monthly"
-                                        sx={{
-                                            fontSize: isExtraSmall ? '12px' : 'inherit',
-                                            width: isExtraSmall ? '40%' : '100%',
-                                        }}
+                                        sx={extraSmallStyling}
                                     >
                                         Monthly
                                     </MetToggleButton>

--- a/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
+++ b/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
@@ -35,6 +35,7 @@ export const dashboardCustomStyles = {
 
 const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendProps) => {
     const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+    const isExtraSmall = useMediaQuery('(max-width:299px)');
     const isBetweenMdAndLg = useMediaQuery((theme: Theme) => theme.breakpoints.between('lg', 'xl'));
     const HEIGHT = isTablet ? 200 : 250;
     const [data, setData] = useState(createDefaultByMonthData());
@@ -137,13 +138,20 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                             rowSpacing={isTablet ? 1 : 0}
                             md={isBetweenMdAndLg ? 3 : 4}
                         >
-                            <Grid container item alignItems={'center'} justifyContent={'center'} xs={12} sx={{ mb: 1 }}>
+                            <Grid
+                                container
+                                item
+                                alignItems={'center'}
+                                justifyContent={'center'}
+                                xs={12}
+                                sx={{ marginX: 1, mb: 1 }}
+                            >
                                 <MetLabel>Select Date Range </MetLabel>
                             </Grid>
                             <Grid
                                 container
                                 item
-                                sx={{ mb: 1, marginX: isTablet ? 2 : 0 }}
+                                sx={{ mb: 1, marginX: isTablet ? 1 : 0 }}
                                 direction="column"
                                 alignItems="center"
                             >
@@ -169,7 +177,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                             <Grid
                                 container
                                 item
-                                sx={{ mb: 1, marginX: isTablet ? 2 : 0 }}
+                                sx={{ mb: 1, marginX: isTablet ? 1 : 0 }}
                                 direction="column"
                                 alignItems="center"
                             >
@@ -194,7 +202,11 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                             </Grid>
                             <Grid container item justifyContent="center" alignItems="center">
                                 <SecondaryButton
-                                    sx={{ ...dashboardCustomStyles.primaryButton, width: 'auto' }}
+                                    sx={{
+                                        ...dashboardCustomStyles.primaryButton,
+                                        fontSize: isExtraSmall ? '10px' : 'inherit',
+                                        width: isExtraSmall ? '80%' : 'auto',
+                                    }}
                                     onClick={clearDates}
                                 >
                                     Reset All Filters
@@ -213,16 +225,36 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                 width="100%"
                                 justifyContent="flex-end"
                                 alignItems={'flex-end'}
+                                mb={1}
                             >
                                 <ToggleButtonGroup
                                     value={chartBy}
                                     exclusive
                                     onChange={handleToggleChange}
                                     size={isTablet ? 'small' : 'medium'}
-                                    sx={{ ...dashboardCustomStyles.toggleGroup, marginX: isTablet ? 2 : 0 }}
+                                    sx={{
+                                        ...dashboardCustomStyles.toggleGroup,
+                                        marginX: isTablet ? 1 : 0,
+                                    }}
                                 >
-                                    <MetToggleButton value="weekly">Weekly</MetToggleButton>
-                                    <MetToggleButton value="monthly">Monthly</MetToggleButton>
+                                    <MetToggleButton
+                                        value="weekly"
+                                        sx={{
+                                            fontSize: isExtraSmall ? '10px' : 'inherit',
+                                            width: isExtraSmall ? '40%' : '100%',
+                                        }}
+                                    >
+                                        Weekly
+                                    </MetToggleButton>
+                                    <MetToggleButton
+                                        value="monthly"
+                                        sx={{
+                                            fontSize: isExtraSmall ? '10px' : 'inherit',
+                                            width: isExtraSmall ? '40%' : '100%',
+                                        }}
+                                    >
+                                        Monthly
+                                    </MetToggleButton>
                                 </ToggleButtonGroup>
                             </Stack>
                             <If condition={!isLoading}>

--- a/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
+++ b/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
@@ -204,7 +204,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                 <SecondaryButton
                                     sx={{
                                         ...dashboardCustomStyles.primaryButton,
-                                        fontSize: isExtraSmall ? '10px' : 'inherit',
+                                        fontSize: isExtraSmall ? '12px' : 'inherit',
                                         width: isExtraSmall ? '80%' : 'auto',
                                     }}
                                     onClick={clearDates}
@@ -240,7 +240,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                     <MetToggleButton
                                         value="weekly"
                                         sx={{
-                                            fontSize: isExtraSmall ? '10px' : 'inherit',
+                                            fontSize: isExtraSmall ? '12px' : 'inherit',
                                             width: isExtraSmall ? '40%' : '100%',
                                         }}
                                     >
@@ -249,7 +249,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                     <MetToggleButton
                                         value="monthly"
                                         sx={{
-                                            fontSize: isExtraSmall ? '10px' : 'inherit',
+                                            fontSize: isExtraSmall ? '12px' : 'inherit',
                                             width: isExtraSmall ? '40%' : '100%',
                                         }}
                                     >

--- a/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
+++ b/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
@@ -87,31 +87,31 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
         setChartBy(chartByValue);
     };
 
-    if (engagementIsLoading) {
-        return (
-            <>
-                <MetLabel mb={0.5}>Live Activity - Engagement</MetLabel>
-                <MetPaper sx={{ p: 2 }}>
-                    <Stack direction="column" alignItems="center" gap={1}>
-                        <Grid
-                            container
-                            alignItems="center"
-                            justifyContent="center"
-                            direction="row"
-                            width={'100%'}
-                            height={HEIGHT}
-                        >
-                            <CircularProgress color="inherit" />
-                        </Grid>
-                    </Stack>
-                </MetPaper>
-            </>
-        );
-    }
+    // if (engagementIsLoading) {
+    //     return (
+    //         <>
+    //             <MetLabel mb={0.5}>Live Activity - Engagement</MetLabel>
+    //             <MetPaper sx={{ p: 2 }}>
+    //                 <Stack direction="column" alignItems="center" gap={1}>
+    //                     <Grid
+    //                         container
+    //                         alignItems="center"
+    //                         justifyContent="center"
+    //                         direction="row"
+    //                         width={'100%'}
+    //                         height={HEIGHT}
+    //                     >
+    //                         <CircularProgress color="inherit" />
+    //                     </Grid>
+    //                 </Stack>
+    //             </MetPaper>
+    //         </>
+    //     );
+    // }
 
-    if (isError) {
-        return <ErrorBox sx={{ height: HEIGHT }} onClick={fetchData} />;
-    }
+    // if (isError) {
+    //     return <ErrorBox sx={{ height: HEIGHT }} onClick={fetchData} />;
+    // }
 
     return (
         <>
@@ -140,7 +140,13 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                             <Grid container item alignItems={'center'} justifyContent={'center'} xs={12} sx={{ mb: 1 }}>
                                 <MetLabel>Select Date Range </MetLabel>
                             </Grid>
-                            <Grid container item sx={{ mb: 1 }} direction="column" alignItems="center">
+                            <Grid
+                                container
+                                item
+                                sx={{ mb: 1, marginX: isTablet ? 2 : 0 }}
+                                direction="column"
+                                alignItems="center"
+                            >
                                 <Stack flexDirection={'column'} alignItems={'flex-start'}>
                                     <MetLabel>From: </MetLabel>
                                     <DatePicker
@@ -160,7 +166,13 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                     />
                                 </Stack>
                             </Grid>
-                            <Grid container item sx={{ mb: 1 }} direction="column" alignItems="center">
+                            <Grid
+                                container
+                                item
+                                sx={{ mb: 1, marginX: isTablet ? 2 : 0 }}
+                                direction="column"
+                                alignItems="center"
+                            >
                                 <Stack flexDirection={'column'} alignItems={'flex-start'}>
                                     <MetLabel>To: </MetLabel>
                                     <DatePicker
@@ -207,7 +219,7 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
                                     exclusive
                                     onChange={handleToggleChange}
                                     size={isTablet ? 'small' : 'medium'}
-                                    sx={dashboardCustomStyles.toggleGroup}
+                                    sx={{ ...dashboardCustomStyles.toggleGroup, marginX: isTablet ? 2 : 0 }}
                                 >
                                     <MetToggleButton value="weekly">Weekly</MetToggleButton>
                                     <MetToggleButton value="monthly">Monthly</MetToggleButton>

--- a/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
+++ b/met-web/src/components/publicDashboard/SubmissionTrend/SubmissionTrend.tsx
@@ -88,31 +88,31 @@ const SubmissionTrend = ({ engagement, engagementIsLoading }: SubmissionTrendPro
         setChartBy(chartByValue);
     };
 
-    // if (engagementIsLoading) {
-    //     return (
-    //         <>
-    //             <MetLabel mb={0.5}>Live Activity - Engagement</MetLabel>
-    //             <MetPaper sx={{ p: 2 }}>
-    //                 <Stack direction="column" alignItems="center" gap={1}>
-    //                     <Grid
-    //                         container
-    //                         alignItems="center"
-    //                         justifyContent="center"
-    //                         direction="row"
-    //                         width={'100%'}
-    //                         height={HEIGHT}
-    //                     >
-    //                         <CircularProgress color="inherit" />
-    //                     </Grid>
-    //                 </Stack>
-    //             </MetPaper>
-    //         </>
-    //     );
-    // }
+    if (engagementIsLoading) {
+        return (
+            <>
+                <MetLabel mb={0.5}>Live Activity - Engagement</MetLabel>
+                <MetPaper sx={{ p: 2 }}>
+                    <Stack direction="column" alignItems="center" gap={1}>
+                        <Grid
+                            container
+                            alignItems="center"
+                            justifyContent="center"
+                            direction="row"
+                            width={'100%'}
+                            height={HEIGHT}
+                        >
+                            <CircularProgress color="inherit" />
+                        </Grid>
+                    </Stack>
+                </MetPaper>
+            </>
+        );
+    }
 
-    // if (isError) {
-    //     return <ErrorBox sx={{ height: HEIGHT }} onClick={fetchData} />;
-    // }
+    if (isError) {
+        return <ErrorBox sx={{ height: HEIGHT }} onClick={fetchData} />;
+    }
 
     return (
         <>


### PR DESCRIPTION
-Dashboard touch ups requested for less then 300 px phone responsivenss 

-general margin for a better layout

<img width="596" alt="image" src="https://github.com/bcgov/met-public/assets/103138766/9ba1135a-db9d-40c2-bded-1b1dd0270f27">

<img width="673" alt="image" src="https://github.com/bcgov/met-public/assets/103138766/448e8899-10da-4d21-90f9-b75f3c482988">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
