### PR TITLE
Prevent two tabs from opening when engagement tile is clicked

### DIFF
--- a/met-web/src/components/landing/EngagementTile.tsx
+++ b/met-web/src/components/landing/EngagementTile.tsx
@@ -123,7 +123,8 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
                     <Then>
                         <PrimaryButton
                             fullWidth
-                            onClick={() => {
+                            onClick={(event: React.MouseEvent) => {
+                                event.stopPropagation();
                                 window.open(engagementUrl, '_blank');
                             }}
                         >
@@ -133,7 +134,8 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
                     <Else>
                         <SecondaryButton
                             fullWidth
-                            onClick={() => {
+                            onClick={(event: React.MouseEvent) => {
+                                event.stopPropagation();
                                 window.open(engagementUrl, '_blank');
                             }}
                         >


### PR DESCRIPTION
-Prevent event bubbling in engagement tile


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
