### PR TITLE
Invalidate widgets when creating widget items

### DIFF
--- a/met-web/src/apiManager/apiSlices/widgets/index.ts
+++ b/met-web/src/apiManager/apiSlices/widgets/index.ts
@@ -1,6 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { AppConfig } from 'config';
-import { Widget } from 'models/widget';
+import { Widget, WidgetItem } from 'models/widget';
 import { prepareHeaders } from 'apiManager//apiSlices/util';
 
 // Define a service using a base URL and expected endpoints
@@ -22,6 +22,17 @@ export const widgetsApi = createApi({
                 url: `widgets/engagement/${widget.engagement_id}`,
                 method: 'POST',
                 body: widget,
+            }),
+            invalidatesTags: ['Widgets'],
+        }),
+        createWidgetItems: builder.mutation<
+            WidgetItem[],
+            { widget_id: number; widget_items_data: Partial<WidgetItem>[] }
+        >({
+            query: ({ widget_id, widget_items_data }) => ({
+                url: `widgets/${widget_id}/items`,
+                method: 'POST',
+                body: widget_items_data,
             }),
             invalidatesTags: ['Widgets'],
         }),
@@ -47,5 +58,10 @@ export const widgetsApi = createApi({
 
 // Export hooks for usage in functional components, which are
 // auto-generated based on the defined endpoints
-export const { useLazyGetWidgetsQuery, useCreateWidgetMutation, useSortWidgetsMutation, useDeleteWidgetMutation } =
-    widgetsApi;
+export const {
+    useLazyGetWidgetsQuery,
+    useCreateWidgetMutation,
+    useSortWidgetsMutation,
+    useDeleteWidgetMutation,
+    useCreateWidgetItemsMutation,
+} = widgetsApi;

--- a/met-web/src/apiManager/apiSlices/widgets/index.ts
+++ b/met-web/src/apiManager/apiSlices/widgets/index.ts
@@ -69,13 +69,7 @@ export const widgetsApi = createApi({
 export const {
     useLazyGetWidgetsQuery,
     useCreateWidgetMutation,
-    useSortWidgetsMutation,
-    useDeleteWidgetMutation,
     useUpdateWidgetMutation,
-} = widgetsApi;
-export const {
-    useLazyGetWidgetsQuery,
-    useCreateWidgetMutation,
     useSortWidgetsMutation,
     useDeleteWidgetMutation,
     useCreateWidgetItemsMutation,

--- a/met-web/src/components/engagement/form/EngagementWidgets/Phases/PhasesForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Phases/PhasesForm.tsx
@@ -4,9 +4,9 @@ import { MetHeader3, MetLabel, PrimaryButton, SecondaryButton } from 'components
 import { EngagementPhases } from 'models/engagementPhases';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { postWidgetItem } from 'services/widgetService';
 import { WidgetDrawerContext } from '../WidgetDrawerContext';
 import { WidgetType } from 'models/widget';
+import { useCreateWidgetItemsMutation } from 'apiManager/apiSlices/widgets';
 
 interface ISelectOptions {
     id: EngagementPhases;
@@ -20,6 +20,8 @@ const PhasesForm = () => {
     const [isStandalone, setIsStandalone] = useState<boolean>(false);
     const [savingWidgetItems, setSavingWidgetItems] = useState(false);
     const widget = widgets.filter((widget) => widget.widget_type_id === WidgetType.Phases)[0] || null;
+
+    const [createWidgetItems] = useCreateWidgetItemsMutation();
 
     useEffect(() => {
         if (widget && widget.items.length > 0) {
@@ -66,7 +68,7 @@ const PhasesForm = () => {
         };
         try {
             setSavingWidgetItems(true);
-            await postWidgetItem(widget.id, widgetsToUpdate);
+            await createWidgetItems({ widget_id: widget.id, widget_items_data: [widgetsToUpdate] }).unwrap();
             await loadWidgets();
             dispatch(openNotification({ severity: 'success', text: 'Widget successfully added' }));
             handleWidgetDrawerOpen(false);

--- a/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningForm.tsx
@@ -4,7 +4,6 @@ import { MetLabel, PrimaryButton, SecondaryButton, MetHeader3 } from 'components
 import { Contact } from 'models/contact';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { postWidgetItems } from 'services/widgetService';
 import { WidgetDrawerContext } from '../WidgetDrawerContext';
 import { WidgetType } from 'models/widget';
 import ContactBlock from './ContactBlock';

--- a/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningForm.tsx
@@ -9,6 +9,7 @@ import { WidgetDrawerContext } from '../WidgetDrawerContext';
 import { WidgetType } from 'models/widget';
 import ContactBlock from './ContactBlock';
 import { WhoIsListeningContext } from './WhoIsListeningContext';
+import { useCreateWidgetItemsMutation } from 'apiManager/apiSlices/widgets';
 
 const WhoIsListeningForm = () => {
     const { handleWidgetDrawerOpen, widgets, loadWidgets } = useContext(WidgetDrawerContext);
@@ -17,6 +18,7 @@ const WhoIsListeningForm = () => {
     const dispatch = useAppDispatch();
     const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
     const [savingWidgetItems, setSavingWidgetItems] = useState(false);
+    const [createWidgetItems] = useCreateWidgetItemsMutation();
 
     const widget = widgets.filter((widget) => widget.widget_type_id === WidgetType.WhoIsListening)[0] || null;
     useEffect(() => {
@@ -68,7 +70,7 @@ const WhoIsListeningForm = () => {
         });
         try {
             setSavingWidgetItems(true);
-            await postWidgetItems(widget.id, widgetsToUpdate);
+            await createWidgetItems({ widget_id: widget.id, widget_items_data: widgetsToUpdate }).unwrap();
             await loadWidgets();
             dispatch(openNotification({ severity: 'success', text: 'Widgets successfully added' }));
             handleWidgetDrawerOpen(false);

--- a/met-web/src/services/widgetService/DocumentService/index.tsx
+++ b/met-web/src/services/widgetService/DocumentService/index.tsx
@@ -3,9 +3,6 @@ import { DocumentItem, DocumentType } from 'models/document';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
 
-/**
- * @deprecated The method was replaced by Redux RTK query to have caching behaviour
- */
 export const fetchDocuments = async (widget_id: number): Promise<DocumentItem[]> => {
     try {
         const url = replaceUrl(Endpoints.Documents.GET_LIST, 'widget_id', String(widget_id));

--- a/met-web/src/services/widgetService/index.tsx
+++ b/met-web/src/services/widgetService/index.tsx
@@ -36,14 +36,6 @@ interface PostWidgetItemRequest {
 /**
  * @deprecated The method was replaced by Redux RTK query to have caching behaviour
  */
-export const postWidgetItem = async (widget_id: number, data: PostWidgetItemRequest): Promise<WidgetItem> => {
-    const result = await postWidgetItems(widget_id, [data]);
-    return result[0];
-};
-
-/**
- * @deprecated The method was replaced by Redux RTK query to have caching behaviour
- */
 export const postWidgetItems = async (widget_id: number, data: PostWidgetItemRequest[]): Promise<WidgetItem[]> => {
     try {
         const url = replaceUrl(Endpoints.Widget_items.CREATE, 'widget_id', String(widget_id));

--- a/met-web/src/services/widgetService/index.tsx
+++ b/met-web/src/services/widgetService/index.tsx
@@ -13,6 +13,9 @@ interface PostWidget {
     widget_type_id: number;
     engagement_id: number;
 }
+/**
+ * @deprecated The method was replaced by Redux RTK query to have caching behaviour
+ */
 export const postWidget = async (engagement_id: number, data: PostWidget): Promise<Widget> => {
     try {
         const url = replaceUrl(Endpoints.Widgets.CREATE, 'engagement_id', String(engagement_id));
@@ -30,11 +33,17 @@ interface PostWidgetItemRequest {
     widget_id: number;
     widget_data_id: number;
 }
+/**
+ * @deprecated The method was replaced by Redux RTK query to have caching behaviour
+ */
 export const postWidgetItem = async (widget_id: number, data: PostWidgetItemRequest): Promise<WidgetItem> => {
     const result = await postWidgetItems(widget_id, [data]);
     return result[0];
 };
 
+/**
+ * @deprecated The method was replaced by Redux RTK query to have caching behaviour
+ */
 export const postWidgetItems = async (widget_id: number, data: PostWidgetItemRequest[]): Promise<WidgetItem[]> => {
     try {
         const url = replaceUrl(Endpoints.Widget_items.CREATE, 'widget_id', String(widget_id));
@@ -48,6 +57,9 @@ export const postWidgetItems = async (widget_id: number, data: PostWidgetItemReq
     }
 };
 
+/**
+ * @deprecated The method was replaced by Redux RTK query to have caching behaviour
+ */
 export const removeWidget = async (engagement_id: number, widget_id: number): Promise<Widget[]> => {
     try {
         const url = replaceAllInURL({
@@ -67,6 +79,9 @@ export const removeWidget = async (engagement_id: number, widget_id: number): Pr
     }
 };
 
+/**
+ * @deprecated The method was replaced by Redux RTK query to have caching behaviour
+ */
 export const sortWidgets = async (engagement_id: number, data: Widget[]): Promise<void> => {
     try {
         const url = replaceUrl(Endpoints.Widgets.SORT, 'engagement_id', String(engagement_id));

--- a/met-web/tests/unit/components/widgets/PhasesWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/PhasesWidget.test.tsx
@@ -55,9 +55,16 @@ jest.mock('components/map', () => () => {
 });
 
 const mockCreateWidget = jest.fn(() => Promise.resolve(phasesWidget));
+const mockCreateWidgetItems = jest.fn(() => Promise.resolve([phaseWidgetItem]));
+const mockCreateWidgetItemsTrigger = jest.fn(() => {
+    return {
+        unwrap: mockCreateWidgetItems,
+    };
+});
 jest.mock('apiManager/apiSlices/widgets', () => ({
     ...jest.requireActual('apiManager/apiSlices/widgets'),
     useCreateWidgetMutation: () => [mockCreateWidget],
+    useCreateWidgetItemsMutation: () => [mockCreateWidgetItemsTrigger],
     useDeleteWidgetMutation: () => [jest.fn(() => Promise.resolve())],
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));
@@ -75,7 +82,7 @@ describe('Phases widget tests', () => {
         setupEnv();
     });
 
-    test('Phases widget is created when option is clicked', async () => {
+    test.only('Phases widget is created when option is clicked', async () => {
         useParamsMock.mockReturnValue({ engagementId: '1' });
         getEngagementMock.mockReturnValueOnce(
             Promise.resolve({
@@ -84,9 +91,8 @@ describe('Phases widget tests', () => {
             }),
         );
         getWidgetsMock.mockReturnValueOnce(Promise.resolve([]));
-        const postWidgetItemMock = jest.spyOn(widgetService, 'postWidgetItem');
         mockCreateWidget.mockReturnValue(Promise.resolve(phasesWidget));
-        postWidgetItemMock.mockReturnValue(Promise.resolve(phaseWidgetItem));
+        mockCreateWidgetItems.mockReturnValue(Promise.resolve([phaseWidgetItem]));
         render(<EngagementForm />);
 
         await waitFor(() => {
@@ -129,9 +135,14 @@ describe('Phases widget tests', () => {
             expect(saveWidgetButton).not.toBeVisible();
         });
 
-        expect(postWidgetItemMock).toHaveBeenNthCalledWith(1, phasesWidget.id, {
+        expect(mockCreateWidgetItemsTrigger).toHaveBeenNthCalledWith(1, {
             widget_id: phasesWidget.id,
-            widget_data_id: 0,
+            widget_items_data: [
+                {
+                    widget_id: phasesWidget.id,
+                    widget_data_id: 0,
+                },
+            ],
         });
     });
 });

--- a/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
@@ -104,9 +104,16 @@ jest.mock('@hello-pangea/dnd', () => ({
 }));
 
 const mockCreateWidget = jest.fn(() => Promise.resolve(whoIsListeningWidget));
+const mockCreateWidgetItems = jest.fn(() => Promise.resolve(contactWidgetItem));
+const mockCreateWidgetItemsTrigger = jest.fn(() => {
+    return {
+        unwrap: mockCreateWidgetItems,
+    };
+});
 jest.mock('apiManager/apiSlices/widgets', () => ({
     ...jest.requireActual('apiManager/apiSlices/widgets'),
     useCreateWidgetMutation: () => [mockCreateWidget],
+    useCreateWidgetItemsMutation: () => [mockCreateWidgetItemsTrigger],
     useDeleteWidgetMutation: () => [jest.fn(() => Promise.resolve())],
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));


### PR DESCRIPTION
*Description of changes:*

- Use redux rtk for posting items
- Set redux rtk create items to invalidate widgets


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
