### PR TITLE
Scheduled surveys cant be viewed by unauthorized

### DIFF
--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -180,6 +180,8 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
         filter_conditions = [
             # Exclude draft engagements that the user is not assigned to
             Engagement.status_id != Status.Draft.value,
+            # Scheduled surveys are still not viewable
+            Engagement.status_id != Status.Scheduled.value,
             # Include all assigned engagements even if its draft
             Engagement.id.in_(assigned_engagements),
             # Include Un-linked surveys


### PR DESCRIPTION
*Description of changes:*

https://github.com/bcgov/met-public/issues/1899

Viewers shouldnt get access to scheduled surveys/engagements


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
