### PR TITLE
Remove assign role from TM

### DIFF
--- a/met-web/src/components/userManagement/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/userManagement/listing/ActionsDropDown.tsx
@@ -27,6 +27,13 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
         return false;
     };
 
+    const isViewer = (): boolean => {
+        if (selectedUser?.main_group == USER_GROUP.VIEWER.label) {
+            return true;
+        }
+        return false;
+    };
+
     const ITEMS: ActionDropDownItem[] = useMemo(
         () => [
             {
@@ -38,7 +45,7 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
                         setassignRoleModalOpen(true);
                     }
                 },
-                condition: hasNoRole(),
+                condition: hasNoRole() && isAdmin(),
             },
             {
                 value: 2,
@@ -49,7 +56,7 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
                         setAddUserModalOpen(true);
                     }
                 },
-                condition: !hasNoRole() && !isAdmin(),
+                condition: !hasNoRole() && !isAdmin() && !isViewer(),
             },
         ],
         [selectedUser.id],

--- a/met-web/src/components/userManagement/listing/AddUserModal.tsx
+++ b/met-web/src/components/userManagement/listing/AddUserModal.tsx
@@ -69,6 +69,7 @@ export const AddUserModal = () => {
             setEngagementsLoading(true);
             const response = await getEngagements({
                 search_text: searchText,
+                has_team_access: true,
             });
             const filteredEngagements = response.items.filter(
                 (engagement) => !assignedEngagements.includes(engagement.id),

--- a/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
+++ b/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
@@ -95,6 +95,7 @@ export const AddToEngagementModal = () => {
             setEngagementsLoading(true);
             const response = await getEngagements({
                 search_text: searchText,
+                has_team_access: true,
             });
             const filteredEngagements = response.items.filter(
                 (engagement) => !assignedEngagements.includes(engagement.id),

--- a/met-web/src/services/engagementService/index.ts
+++ b/met-web/src/services/engagementService/index.ts
@@ -31,6 +31,7 @@ interface GetEngagementsParams {
     project_name?: string;
     client_name?: string;
     application_number?: string;
+    has_team_access?: boolean;
 }
 export const getEngagements = async (params: GetEngagementsParams = {}): Promise<Page<Engagement>> => {
     const responseData = await http.GetRequest<Page<Engagement>>(Endpoints.Engagement.GET_LIST, params);


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/1910

*Description of changes:*
- Removed assign role drop down for TM on user listing
- Removed assign to an engagement for Viewer on user listing
- Added check to list only assigned engagements for TM trying to assign engagement to another TM/Reviewer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
