### PR TITLE
Only get id and name of engagement for membership

### DIFF
--- a/met-api/src/met_api/schemas/membership_engagement.py
+++ b/met-api/src/met_api/schemas/membership_engagement.py
@@ -1,12 +1,12 @@
 """Membership engagement schema class."""
 from marshmallow import fields
 
-
 from .memberships import MembershipSchema
-from .engagement import EngagementSchema
 
 
 class MembershipEngagementSchema(MembershipSchema):
     """Membership schema with engagement details."""
 
-    engagement = fields.Nested(EngagementSchema)
+    engagement = fields.Nested(
+        "EngagementSchema", only=["id", "name"]
+    )

--- a/met-api/src/met_api/schemas/membership_engagement.py
+++ b/met-api/src/met_api/schemas/membership_engagement.py
@@ -8,5 +8,5 @@ class MembershipEngagementSchema(MembershipSchema):
     """Membership schema with engagement details."""
 
     engagement = fields.Nested(
-        "EngagementSchema", only=["id", "name"]
+        'EngagementSchema', only=['id', 'name']
     )

--- a/met-web/src/components/userManagement/userDetails/AssignedEngagementsListing.tsx
+++ b/met-web/src/components/userManagement/userDetails/AssignedEngagementsListing.tsx
@@ -19,7 +19,7 @@ export const AssignedEngagementsListing = () => {
             label: 'Engagement',
             allowSort: true,
             renderCell: (row: EngagementTeamMember) => (
-                <MuiLink component={Link} to={`/engagements/${Number(row.id)}/view`}>
+                <MuiLink component={Link} to={`/engagements/${Number(row.engagement_id)}/view`}>
                     {row.engagement?.name}
                 </MuiLink>
             ),


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2049

*Description of changes:*
- update engagement link in user details table
- update membership schema to only take id and name from engagement


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
