### PR TITLE
update email config to be dynamic with the tenant

### DIFF
--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -163,13 +163,15 @@ class _Config():  # pylint: disable=too-few-public-methods
             'VERIFICATION_EMAIL_TEMPLATE_ID': os.getenv('VERIFICATION_EMAIL_TEMPLATE_ID'),
             'VERIFICATION_EMAIL_SUBJECT': os.getenv('VERIFICATION_EMAIL_SUBJECT', '{engagement_name} - Survey link'),
             'SUBSCRIBE_EMAIL_TEMPLATE_ID': os.getenv('SUBSCRIBE_EMAIL_TEMPLATE_ID'),
-            'SUBSCRIBE_EMAIL_SUBJECT': os.getenv('SUBSCRIBE_EMAIL_SUBJECT', 'Confirm your Subscription to {engagement_name}'),
+            'SUBSCRIBE_EMAIL_SUBJECT': os.getenv(
+                'SUBSCRIBE_EMAIL_SUBJECT',
+                'Confirm your Subscription to {engagement_name}'),
             'REJECTED_EMAIL_TEMPLATE_ID': os.getenv('REJECTED_EMAIL_TEMPLATE_ID'),
             'REJECTED_EMAIL_SUBJECT': os.getenv('REJECTED_EMAIL_SUBJECT', '{engagement_name} - About your Comments'),
             'EMAIL_ENVIRONMENT': os.getenv('EMAIL_ENVIRONMENT', ''),
             'ACCESS_REQUEST_EMAIL_TEMPLATE_ID': os.getenv('ACCESS_REQUEST_EMAIL_TEMPLATE_ID'),
             'ACCESS_REQUEST_EMAIL_SUBJECT': os.getenv('ACCESS_REQUEST_EMAIL_SUBJECT', 'MET - New User Access Request'),
-            'ACCESS_REQUEST_EMAIL_ADDRESS': os.getenv('ACCESS_REQUEST_EMAIL_ADDRESS')            
+            'ACCESS_REQUEST_EMAIL_ADDRESS': os.getenv('ACCESS_REQUEST_EMAIL_ADDRESS')
         }
     }
 

--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -158,22 +158,6 @@ class _Config():  # pylint: disable=too-few-public-methods
     SITE_URL = os.getenv('SITE_URL')
 
     # The GC notify email variables
-    # Email address verification
-    VERIFICATION_EMAIL_TEMPLATE_ID = os.getenv('VERIFICATION_EMAIL_TEMPLATE_ID')
-    VERIFICATION_EMAIL_SUBJECT = os.getenv('VERIFICATION_EMAIL_SUBJECT', '{engagement_name} - Survey link')
-    # Email address verification
-    SUBSCRIBE_EMAIL_TEMPLATE_ID = os.getenv('SUBSCRIBE_EMAIL_TEMPLATE_ID')
-    SUBSCRIBE_EMAIL_SUBJECT = os.getenv('SUBSCRIBE_EMAIL_SUBJECT', 'Confirm your Subscription to {engagement_name}')
-    # Rejected comments
-    REJECTED_EMAIL_TEMPLATE_ID = os.getenv('REJECTED_EMAIL_TEMPLATE_ID')
-    REJECTED_EMAIL_SUBJECT = os.getenv('REJECTED_EMAIL_SUBJECT', '{engagement_name} - About your Comments')
-    # Environment from which email is sent
-    EMAIL_ENVIRONMENT = os.getenv('EMAIL_ENVIRONMENT', '')
-    # New User Registration
-    ACCESS_REQUEST_EMAIL_TEMPLATE_ID = os.getenv('ACCESS_REQUEST_EMAIL_TEMPLATE_ID')
-    ACCESS_REQUEST_EMAIL_SUBJECT = os.getenv('ACCESS_REQUEST_EMAIL_SUBJECT', 'MET - New User Access Request')
-    ACCESS_REQUEST_EMAIL_ADDRESS = os.getenv('ACCESS_REQUEST_EMAIL_ADDRESS')
-
     GC_NOTIFY_CONFIG = {
         'DEFAULT': {
             'VERIFICATION_EMAIL_TEMPLATE_ID': os.getenv('VERIFICATION_EMAIL_TEMPLATE_ID'),

--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -70,6 +70,29 @@ def get_s3_config(key: str):
     return config_value
 
 
+def get_gc_notify_config(key: str):
+    """Return the gc notify configuration object based on the tenant short name.
+
+    :raise: KeyError: if an unknown configuration is requested
+    """
+    tenant_short_name = g.get('tenant_name', None)
+    if not tenant_short_name:
+        return _Config.GC_NOTIFY_CONFIG['DEFAULT'][key]
+
+    tenant_short_name = tenant_short_name.upper()
+
+    if tenant_short_name in _Config.GC_NOTIFY_CONFIG:
+        return _Config.GC_NOTIFY_CONFIG[tenant_short_name][key]
+
+    config_key = f'{tenant_short_name}_{key}'
+    config_value = os.getenv(config_key)
+
+    if not config_value:
+        return _Config.GC_NOTIFY_CONFIG['DEFAULT'][key]
+
+    return config_value
+
+
 class _Config():  # pylint: disable=too-few-public-methods
     """Base class configuration that should set reasonable defaults for all the other configurations."""
 
@@ -98,13 +121,6 @@ class _Config():  # pylint: disable=too-few-public-methods
     JWT_OIDC_AUDIENCE = os.getenv('JWT_OIDC_AUDIENCE', 'account')
     JWT_OIDC_CACHING_ENABLED = os.getenv('JWT_OIDC_CACHING_ENABLED', 'True')
     JWT_OIDC_JWKS_CACHE_TIMEOUT = 300
-
-    S3_BUCKET = os.getenv('S3_BUCKET')
-    S3_ACCESS_KEY_ID = os.getenv('S3_ACCESS_KEY_ID')
-    S3_SECRET_ACCESS_KEY = os.getenv('S3_SECRET_ACCESS_KEY')
-    S3_HOST = os.getenv('S3_HOST')
-    S3_REGION = os.getenv('S3_REGION')
-    S3_SERVICE = os.getenv('S3_SERVICE')
 
     S3_CONFIG = {
         'DEFAULT': {
@@ -157,6 +173,21 @@ class _Config():  # pylint: disable=too-few-public-methods
     ACCESS_REQUEST_EMAIL_TEMPLATE_ID = os.getenv('ACCESS_REQUEST_EMAIL_TEMPLATE_ID')
     ACCESS_REQUEST_EMAIL_SUBJECT = os.getenv('ACCESS_REQUEST_EMAIL_SUBJECT', 'MET - New User Access Request')
     ACCESS_REQUEST_EMAIL_ADDRESS = os.getenv('ACCESS_REQUEST_EMAIL_ADDRESS')
+
+    GC_NOTIFY_CONFIG = {
+        'DEFAULT': {
+            'VERIFICATION_EMAIL_TEMPLATE_ID': os.getenv('VERIFICATION_EMAIL_TEMPLATE_ID'),
+            'VERIFICATION_EMAIL_SUBJECT': os.getenv('VERIFICATION_EMAIL_SUBJECT', '{engagement_name} - Survey link'),
+            'SUBSCRIBE_EMAIL_TEMPLATE_ID': os.getenv('SUBSCRIBE_EMAIL_TEMPLATE_ID'),
+            'SUBSCRIBE_EMAIL_SUBJECT': os.getenv('SUBSCRIBE_EMAIL_SUBJECT', 'Confirm your Subscription to {engagement_name}'),
+            'REJECTED_EMAIL_TEMPLATE_ID': os.getenv('REJECTED_EMAIL_TEMPLATE_ID'),
+            'REJECTED_EMAIL_SUBJECT': os.getenv('REJECTED_EMAIL_SUBJECT', '{engagement_name} - About your Comments'),
+            'EMAIL_ENVIRONMENT': os.getenv('EMAIL_ENVIRONMENT', ''),
+            'ACCESS_REQUEST_EMAIL_TEMPLATE_ID': os.getenv('ACCESS_REQUEST_EMAIL_TEMPLATE_ID'),
+            'ACCESS_REQUEST_EMAIL_SUBJECT': os.getenv('ACCESS_REQUEST_EMAIL_SUBJECT', 'MET - New User Access Request'),
+            'ACCESS_REQUEST_EMAIL_ADDRESS': os.getenv('ACCESS_REQUEST_EMAIL_ADDRESS')            
+        }
+    }
 
     NOTIFICATIONS_EMAIL_ENDPOINT = os.getenv('NOTIFICATIONS_EMAIL_ENDPOINT')
     # CDOGS

--- a/met-api/src/met_api/services/email_verification_service.py
+++ b/met-api/src/met_api/services/email_verification_service.py
@@ -16,6 +16,7 @@ from met_api.schemas.email_verification import EmailVerificationSchema
 from met_api.services.participant_service import ParticipantService
 from met_api.utils import notification
 from met_api.utils.template import Template
+from met_api.config import get_gc_notify_config
 
 
 class EmailVerificationService:
@@ -133,10 +134,9 @@ class EmailVerificationService:
         engagement: EngagementModel = EngagementModel.find_by_id(
             survey.engagement_id)
         engagement_name = engagement.name
-        template_id = current_app.config.get(
-            'SUBSCRIBE_EMAIL_TEMPLATE_ID', None)
+        template_id = get_gc_notify_config('SUBSCRIBE_EMAIL_TEMPLATE_ID')
         template = Template.get_template('subscribe_email.html')
-        subject_template = current_app.config.get('SUBSCRIBE_EMAIL_SUBJECT')
+        subject_template = get_gc_notify_config('SUBSCRIBE_EMAIL_SUBJECT')
         confirm_path = current_app.config.get('SUBSCRIBE_PATH'). \
             format(engagement_id=engagement.id, token=token)
         unsubscribe_path = current_app.config.get('UNSUBSCRIBE_PATH'). \
@@ -145,8 +145,7 @@ class EmailVerificationService:
             engagement.tenant_id, confirm_path)
         unsubscribe_url = notification.get_tenant_site_url(
             engagement.tenant_id, unsubscribe_path)
-        email_environment = current_app.config.get(
-            'EMAIL_ENVIRONMENT', '')
+        email_environment = get_gc_notify_config('EMAIL_ENVIRONMENT')
         tenant_name = EmailVerificationService._get_tenant_name(
             engagement.tenant_id)
         args = {
@@ -172,12 +171,10 @@ class EmailVerificationService:
         engagement: EngagementModel = EngagementModel.find_by_id(
             survey.engagement_id)
         engagement_name = engagement.name
-        template_id = current_app.config.get(
-            'VERIFICATION_EMAIL_TEMPLATE_ID', None)
-        email_environment = current_app.config.get(
-            'EMAIL_ENVIRONMENT', '')
+        template_id = get_gc_notify_config('VERIFICATION_EMAIL_TEMPLATE_ID')
+        email_environment = get_gc_notify_config('EMAIL_ENVIRONMENT')
         template = Template.get_template('email_verification.html')
-        subject_template = current_app.config.get('VERIFICATION_EMAIL_SUBJECT')
+        subject_template = get_gc_notify_config('VERIFICATION_EMAIL_SUBJECT')
         survey_path = current_app.config.get('SURVEY_PATH'). \
             format(survey_id=survey.id, token=token)
         engagement_path = EmailVerificationService._get_engagement_path(

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -24,6 +24,7 @@ from met_api.utils.roles import Role
 from met_api.utils.template import Template
 from met_api.utils.token_info import TokenInfo
 from met_api.models import Tenant as TenantModel
+from met_api.config import get_gc_notify_config
 
 
 class EngagementService:
@@ -286,8 +287,7 @@ class EngagementService:
         engagement_url = notification.get_tenant_site_url(engagement.tenant_id, dashboard_path)
         subject = current_app.config.get('ENGAGEMENT_CLOSEOUT_EMAIL_SUBJECT'). \
             format(engagement_name=engagement.name)
-        email_environment = current_app.config.get(
-            'EMAIL_ENVIRONMENT', '')
+        email_environment = get_gc_notify_config('EMAIL_ENVIRONMENT')
         tenant_name = EngagementService._get_tenant_name(
             engagement.tenant_id)
         args = {

--- a/met-api/src/met_api/services/staff_user_service.py
+++ b/met-api/src/met_api/services/staff_user_service.py
@@ -13,6 +13,7 @@ from met_api.utils import notification
 from met_api.utils.constants import GROUP_NAME_MAPPING, Groups
 from met_api.utils.enums import KeycloakGroupName, UserStatus
 from met_api.utils.template import Template
+from met_api.config import get_gc_notify_config
 
 
 KEYCLOAK_SERVICE = KeycloakService()
@@ -56,11 +57,11 @@ class StaffUserService:
     @staticmethod
     def _send_access_request_email(user: StaffUserModel) -> None:
         """Send a new user email.Throws error if fails."""
-        to_email_address = current_app.config.get('ACCESS_REQUEST_EMAIL_ADDRESS', None)
+        to_email_address = get_gc_notify_config('ACCESS_REQUEST_EMAIL_ADDRESS')
         if to_email_address is None:
             return
 
-        template_id = current_app.config.get('ACCESS_REQUEST_EMAIL_TEMPLATE_ID', None)
+        template_id = get_gc_notify_config('ACCESS_REQUEST_EMAIL_TEMPLATE_ID')
         subject, body, args = StaffUserService._render_email_template(user)
         try:
             notification.send_email(subject=subject,
@@ -77,10 +78,10 @@ class StaffUserService:
     @staticmethod
     def _render_email_template(user: StaffUserModel):
         template = Template.get_template('email_access_request.html')
-        subject = current_app.config.get('ACCESS_REQUEST_EMAIL_SUBJECT')
+        subject = get_gc_notify_config('ACCESS_REQUEST_EMAIL_SUBJECT')
         grant_access_url = \
             notification.get_tenant_site_url(user.tenant_id, current_app.config.get('USER_MANAGEMENT_PATH'))
-        email_environment = current_app.config.get('EMAIL_ENVIRONMENT', '')
+        email_environment = get_gc_notify_config('EMAIL_ENVIRONMENT')
         args = {
             'first_name': user.first_name,
             'last_name': user.last_name,

--- a/met-api/src/met_api/services/submission_service.py
+++ b/met-api/src/met_api/services/submission_service.py
@@ -29,6 +29,7 @@ from met_api.services.survey_service import SurveyService
 from met_api.utils import notification
 from met_api.utils.roles import Role
 from met_api.utils.template import Template
+from met_api.config import get_gc_notify_config
 
 
 class SubmissionService:
@@ -309,9 +310,7 @@ class SubmissionService:
         """Send an verification email.Throws error if fails."""
         participant_id = submission.participant_id
         participant = ParticipantModel.find_by_id(participant_id)
-
-        template_id = current_app.config.get(
-            'REJECTED_EMAIL_TEMPLATE_ID', None)
+        template_id = get_gc_notify_config('REJECTED_EMAIL_TEMPLATE_ID')
         subject, body, args = SubmissionService._render_email_template(
             staff_review_details, submission, review_note, token)
         try:
@@ -344,10 +343,9 @@ class SubmissionService:
                    submission_id=submission.id, token=token)
         submission_url = notification.get_tenant_site_url(
             engagement.tenant_id, submission_path)
-        subject = current_app.config.get('REJECTED_EMAIL_SUBJECT'). \
+        subject = get_gc_notify_config('REJECTED_EMAIL_SUBJECT'). \
             format(engagement_name=engagement_name)
-        email_environment = current_app.config.get(
-            'EMAIL_ENVIRONMENT', '')
+        email_environment = get_gc_notify_config('EMAIL_ENVIRONMENT')
         args = {
             'engagement_name': engagement_name,
             'survey_name': survey_name,


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2017

*Description of changes:*
- Add a get gc notify config method
- Structure gc notify configs to have default and ability to have tenant name as key


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
