### PR TITLE
Allow TM to assign engagements user is assigned to

### DIFF
--- a/met-web/src/components/userManagement/listing/AddUserModal.tsx
+++ b/met-web/src/components/userManagement/listing/AddUserModal.tsx
@@ -25,7 +25,6 @@ type AddUserForm = yup.TypeOf<typeof schema>;
 
 export const AddUserModal = () => {
     const dispatch = useAppDispatch();
-    /*const { assignedEngagements } = useAppSelector((state) => state.user);*/
     const { addUserModalOpen, setAddUserModalOpen, user, loadUserListing } = useContext(UserManagementContext);
     const [isAddingToEngagement, setIsAddingToEngagement] = useState(false);
     const [engagements, setEngagements] = useState<Engagement[]>([]);
@@ -71,11 +70,6 @@ export const AddUserModal = () => {
                 search_text: searchText,
                 has_team_access: true,
             });
-            /* Need to fix this part to exclude engagements to which the selected user has already been assigned
-            /* const filteredEngagements = response.items.filter(
-                (engagement) => !assignedEngagements.includes(engagement.id),
-            );
-            */
             setEngagements(response.items);
             setEngagementsLoading(false);
         } catch (error) {

--- a/met-web/src/components/userManagement/listing/AddUserModal.tsx
+++ b/met-web/src/components/userManagement/listing/AddUserModal.tsx
@@ -10,7 +10,7 @@ import { getEngagements } from 'services/engagementService';
 import { addTeamMemberToEngagement } from 'services/membershipService';
 import { When } from 'react-if';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { useAppDispatch, useAppSelector } from 'hooks';
+import { useAppDispatch } from 'hooks';
 import { debounce } from 'lodash';
 import { Engagement } from 'models/engagement';
 import axios, { AxiosError } from 'axios';
@@ -25,7 +25,7 @@ type AddUserForm = yup.TypeOf<typeof schema>;
 
 export const AddUserModal = () => {
     const dispatch = useAppDispatch();
-    const { assignedEngagements } = useAppSelector((state) => state.user);
+    /*const { assignedEngagements } = useAppSelector((state) => state.user);*/
     const { addUserModalOpen, setAddUserModalOpen, user, loadUserListing } = useContext(UserManagementContext);
     const [isAddingToEngagement, setIsAddingToEngagement] = useState(false);
     const [engagements, setEngagements] = useState<Engagement[]>([]);
@@ -71,10 +71,12 @@ export const AddUserModal = () => {
                 search_text: searchText,
                 has_team_access: true,
             });
-            const filteredEngagements = response.items.filter(
+            /* Need to fix this part to exclude engagements to which the selected user has already been assigned
+            /* const filteredEngagements = response.items.filter(
                 (engagement) => !assignedEngagements.includes(engagement.id),
             );
-            setEngagements(filteredEngagements);
+            */
+            setEngagements(response.items);
             setEngagementsLoading(false);
         } catch (error) {
             dispatch(


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*
- Currently TM is not able to assign an engagement to which the user is assigned to another TM/Reviewer
- This change is to fix this by temporarily removing the check for assigned engagements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
