### PR TITLE
fix TM not able to assign engagement from user details

### DIFF
--- a/met-web/src/components/comments/admin/reviewListing/Submissions.tsx
+++ b/met-web/src/components/comments/admin/reviewListing/Submissions.tsx
@@ -158,7 +158,16 @@ const Submissions = () => {
                             Read All Comments
                         </PrimaryButton>
                         <PermissionsGate scopes={[USER_ROLES.EXPORT_TO_CSV]} errorProps={{ disabled: true }}>
-                            <SecondaryButton onClick={handleExportComments} loading={isExporting}>
+                            <SecondaryButton
+                                onClick={handleExportComments}
+                                loading={isExporting}
+                                sx={{
+                                    '&.Mui-disabled': {
+                                        background: '#e0e0e0',
+                                        color: '#a6a6a6',
+                                    },
+                                }}
+                            >
                                 Export to CSV
                             </SecondaryButton>
                         </PermissionsGate>

--- a/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
+++ b/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
@@ -25,7 +25,7 @@ import { addUserToGroup } from 'services/userService/api';
 import { addTeamMemberToEngagement } from 'services/membershipService';
 import { When } from 'react-if';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { useAppDispatch, useAppSelector } from 'hooks';
+import { useAppDispatch } from 'hooks';
 import { debounce } from 'lodash';
 import { Engagement } from 'models/engagement';
 import axios, { AxiosError } from 'axios';
@@ -50,7 +50,6 @@ export const AddToEngagementModal = () => {
     type AddUserForm = yup.TypeOf<typeof schema>;
 
     const dispatch = useAppDispatch();
-    const { assignedEngagements } = useAppSelector((state) => state.user);
     const [isAssigningRole, setIsAssigningRole] = useState(false);
     const [engagements, setEngagements] = useState<Engagement[]>([]);
     const [engagementsLoading, setEngagementsLoading] = useState(false);
@@ -97,10 +96,7 @@ export const AddToEngagementModal = () => {
                 search_text: searchText,
                 has_team_access: true,
             });
-            const filteredEngagements = response.items.filter(
-                (engagement) => !assignedEngagements.includes(engagement.id),
-            );
-            setEngagements(filteredEngagements);
+            setEngagements(response.items);
             setEngagementsLoading(false);
         } catch (error) {
             dispatch(


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*
- Currently TM is not able to assign an engagement to which the user is assigned to another TM/Reviewer from user details page
- This change is to fix this bug

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
