### PR TITLE
Remove reinstate memberships functionality

### DIFF
--- a/met-api/src/met_api/resources/staff_user.py
+++ b/met-api/src/met_api/resources/staff_user.py
@@ -119,7 +119,7 @@ class StaffUserStatus(Resource):
             return str(err), HTTPStatus.BAD_REQUEST
 
 
-@cors_preflight('POST')
+@cors_preflight('POST, PUT')
 @API.route('/<user_id>/groups')
 class UserGroup(Resource):
     """Add user to group."""

--- a/met-api/src/met_api/services/membership_service.py
+++ b/met-api/src/met_api/services/membership_service.py
@@ -227,11 +227,7 @@ class MembershipService:
         return new_membership
 
     @staticmethod
-    def reassign_memberships(user_id: int, membership_type: int):
-        """Update memberships type."""
-        MembershipModel.revoke_memberships_bulk(user_id)
-        new_memberships = []
-        if membership_type in [MembershipType.TEAM_MEMBER.value, MembershipType.REVIEWER.value]:
-            new_memberships = MembershipModel.reinstate_memberships_bulk(user_id, membership_type)
-
-        return new_memberships
+    def revoke_memberships_bulk(user_id: int):
+        """Revoke memberships in bulk."""
+        revoked_memberships = MembershipModel.revoke_memberships_bulk(user_id)
+        return revoked_memberships

--- a/met-api/src/met_api/services/staff_user_membership_service.py
+++ b/met-api/src/met_api/services/staff_user_membership_service.py
@@ -1,26 +1,15 @@
 """Service for membership."""
 from http import HTTPStatus
 
-from met_api.constants.membership_type import MembershipType
 from met_api.exceptions.business_exception import BusinessException
 from met_api.schemas.staff_user import StaffUserSchema
-from met_api.services.staff_user_service import StaffUserService
 from met_api.services.membership_service import MembershipService
+from met_api.services.staff_user_service import StaffUserService
 from met_api.utils.constants import Groups
-from met_api.utils.enums import KeycloakGroups
 
 
 class StaffUserMembershipService:
     """Staff User Membership management service."""
-
-    @staticmethod
-    def _get_membership_type_from_group_name(group_name):
-        """Get membership type from group name."""
-        if group_name == KeycloakGroups.EAO_TEAM_MEMBER.name:
-            return MembershipType.TEAM_MEMBER
-        if group_name == KeycloakGroups.EAO_REVIEWER.name:
-            return MembershipType.REVIEWER
-        return None
 
     @classmethod
     def reassign_user(cls, user_id, group_name):
@@ -51,8 +40,6 @@ class StaffUserMembershipService:
 
         StaffUserService.remove_user_from_group(external_id, Groups.get_name_by_value(main_group))
         StaffUserService.add_user_to_group(external_id, group_name)
-        membership_type = StaffUserMembershipService._get_membership_type_from_group_name(group_name)
-        MembershipService.reassign_memberships(user_id, membership_type)
-
+        MembershipService.revoke_memberships_bulk(user_id)
         new_user = StaffUserService.get_user_by_id(user_id, include_groups=True)
         return StaffUserSchema().dump(new_user)

--- a/met-api/src/met_api/services/staff_user_service.py
+++ b/met-api/src/met_api/services/staff_user_service.py
@@ -103,7 +103,7 @@ class StaffUserService:
     @staticmethod
     def attach_groups(user_collection):
         """Attach keycloak groups to user object."""
-        group_user_details: List = KEYCLOAK_SERVICE.get_users_groups(
+        group_user_details = KEYCLOAK_SERVICE.get_users_groups(
             [user.get('external_id') for user in user_collection])
 
         for user in user_collection:

--- a/met-api/src/met_api/services/staff_user_service.py
+++ b/met-api/src/met_api/services/staff_user_service.py
@@ -1,6 +1,5 @@
 """Service for user management."""
 from http import HTTPStatus
-from typing import List
 
 from flask import current_app, g
 

--- a/met-api/tests/unit/api/test_user_membership.py
+++ b/met-api/tests/unit/api/test_user_membership.py
@@ -67,7 +67,7 @@ def test_reassign_user_reviewer_team_member(mocker, client, jwt, session):
     user = factory_staff_user_model()
     eng = factory_engagement_model()
     current_membership = factory_membership_model(user_id=user.id, engagement_id=eng.id)
-    assert current_membership.status == MembershipStatus.ACTIVE.value    
+    assert current_membership.status == MembershipStatus.ACTIVE.value
     mock_response = MagicMock()
     mock_response.status_code = HTTPStatus.NO_CONTENT
 

--- a/met-api/tests/unit/api/test_user_membership.py
+++ b/met-api/tests/unit/api/test_user_membership.py
@@ -1,0 +1,108 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the user membership operations.
+
+Test-Suite to ensure that the user membership endpoints are working as expected.
+"""
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+from met_api.models.membership import Membership as MembershipModel
+from met_api.utils.enums import ContentType, KeycloakGroupName, MembershipStatus, UserStatus
+from tests.utilities.factory_scenarios import TestJwtClaims
+from tests.utilities.factory_utils import (
+    factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model)
+
+
+KEYCLOAK_SERVICE_MODULE = 'met_api.services.keycloak.KeycloakService'
+
+
+def mock_keycloak_methods(mocker, mock_group_names):
+    """Mock the KeycloakService.add_user_to_group method."""
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.NO_CONTENT
+
+    mock_add_user_to_group_keycloak = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.add_user_to_group',
+        return_value=mock_response
+    )
+
+    mock_get_user_groups_keycloak = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.get_user_groups',
+        return_value=[{'name': group_name} for group_name in mock_group_names]
+    )
+
+    mock_add_attribute_to_user = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.add_attribute_to_user',
+        return_value=mock_response
+    )
+
+    mock_remove_user_from_group_keycloak = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.remove_user_from_group',
+        return_value=mock_response
+    )
+
+    return (
+        mock_add_user_to_group_keycloak,
+        mock_get_user_groups_keycloak,
+        mock_add_attribute_to_user,
+        mock_remove_user_from_group_keycloak
+    )
+
+
+def test_reassign_user_reviewer_team_member(mocker, client, jwt, session):
+    """Assert that returns bad request if bad request body."""
+    user = factory_staff_user_model()
+    eng = factory_engagement_model()
+    current_membership = factory_membership_model(user_id=user.id, engagement_id=eng.id)
+    assert current_membership.status == MembershipStatus.ACTIVE.value    
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.NO_CONTENT
+
+    (
+        mock_add_user_to_group_keycloak,
+        mock_get_user_groups_keycloak,
+        mock_add_attribute_to_user,
+        mock_remove_user_from_group_keycloak
+    ) = mock_keycloak_methods(
+        mocker,
+        [KeycloakGroupName.EAO_REVIEWER.value]
+    )
+
+    mock_get_users_groups_keycloak = mocker.patch(
+        f'{KEYCLOAK_SERVICE_MODULE}.get_users_groups',
+        return_value={user.external_id: [KeycloakGroupName.EAO_REVIEWER.value]}
+    )
+
+    assert user.status_id == UserStatus.ACTIVE.value
+    claims = TestJwtClaims.staff_admin_role
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    rv = client.put(
+        f'/api/user/{user.id}/groups?group=EAO_TEAM_MEMBER',
+        headers=headers,
+        content_type=ContentType.JSON.value
+    )
+
+    assert rv.status_code == HTTPStatus.OK
+    mock_add_user_to_group_keycloak.assert_called()
+    mock_get_user_groups_keycloak.assert_called()
+    mock_add_attribute_to_user.assert_called()
+    mock_remove_user_from_group_keycloak.assert_called()
+    mock_get_users_groups_keycloak.assert_called()
+
+    memberships = MembershipModel.find_by_user_id(user.id)
+    assert len(memberships) == 1
+    assert memberships[0].status == MembershipStatus.REVOKED.value

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -305,6 +305,7 @@ class TestJwtClaims(dict, Enum):
                 'view_all_engagements',
                 'toggle_user_status',
                 'export_to_csv',
+                'update_user_group'
             ]
         }
     }

--- a/met-web/src/components/userManagement/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/userManagement/listing/ActionsDropDown.tsx
@@ -60,7 +60,7 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
             },
             {
                 value: 3,
-                label: 'ReassignRole',
+                label: 'Reassign Role',
                 action: () => {
                     setUser(selectedUser);
                     setReassignRoleModalOpen(true);


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/1907

*Description of changes:*
- Remove reinstate memberships logic
- Fix Reassign Role typo in drop down

We are removing reinstate membership logic above because it can create an access risk. It is better managed manually to readd users to engagements they were revoked on when their role is changed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
