### PR TITLE
update formio version for met-web

### DIFF
--- a/met-web/package.json
+++ b/met-web/package.json
@@ -45,7 +45,7 @@
         "lodash": "^4.17.21",
         "mapbox-gl": "^2.13.0",
         "maplibre-gl": "^1.15.3",
-        "met-formio": "^1.0.11",
+        "met-formio": "^1.0.12",
         "mui-sx": "^1.0.0",
         "node-sass": "^7.0.3",
         "react": "^18.0.0",


### PR DESCRIPTION
Update formio version from 1.0.11 -> 1.0.12


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
