### PR TITLE
Restrict actions on inactive user

### DIFF
--- a/met-api/src/met_api/models/staff_user.py
+++ b/met-api/src/met_api/models/staff_user.py
@@ -3,7 +3,6 @@
 Manages the staff user
 """
 from __future__ import annotations
-from operator import and_
 
 from typing import Optional
 
@@ -63,11 +62,11 @@ class StaffUser(BaseModel):
         return page.items, page.total
 
     @classmethod
-    def get_by_id(cls, id, include_inactive=False) -> Optional[StaffUser]:
+    def get_by_id(cls, _id, include_inactive=False) -> Optional[StaffUser]:
         """Get a user by id."""
         query = db.session.query(StaffUser) \
-            .filter(StaffUser.id == id)
-        
+            .filter(StaffUser.id == _id)
+
         if not include_inactive:
             query = query.filter(StaffUser.status_id == UserStatus.ACTIVE.value)
         return query.first()

--- a/met-api/src/met_api/models/staff_user.py
+++ b/met-api/src/met_api/models/staff_user.py
@@ -3,6 +3,7 @@
 Manages the staff user
 """
 from __future__ import annotations
+from operator import and_
 
 from typing import Optional
 
@@ -10,6 +11,8 @@ from sqlalchemy import Column, ForeignKey, String, asc, desc, func
 from sqlalchemy.orm import column_property
 from sqlalchemy.sql import text
 from sqlalchemy.sql.operators import ilike_op
+
+from met_api.utils.enums import UserStatus
 
 from .base_model import BaseModel
 from .db import db
@@ -35,7 +38,7 @@ class StaffUser(BaseModel):
     tenant_id = db.Column(db.Integer, db.ForeignKey('tenant.id'), nullable=True)
 
     @classmethod
-    def get_all_paginated(cls, pagination_options: PaginationOptions, search_text=''):
+    def get_all_paginated(cls, pagination_options: PaginationOptions, search_text='', include_inactive=False):
         """Fetch list of users by access type."""
         query = cls.query
         query = cls._add_tenant_filter(query)
@@ -48,6 +51,9 @@ class StaffUser(BaseModel):
         if search_text:
             query = query.filter(ilike_op(StaffUser.full_name, '%' + search_text + '%'))
 
+        if not include_inactive:
+            query = query.filter(StaffUser.status_id == UserStatus.ACTIVE.value)
+
         no_pagination_options = not pagination_options.page or not pagination_options.size
         if no_pagination_options:
             items = query.all()
@@ -57,9 +63,25 @@ class StaffUser(BaseModel):
         return page.items, page.total
 
     @classmethod
-    def get_user_by_external_id(cls, _external_id) -> StaffUser:
+    def get_by_id(cls, id, include_inactive=False) -> Optional[StaffUser]:
+        """Get a user by id."""
+        query = db.session.query(StaffUser) \
+            .filter(StaffUser.id == id)
+        
+        if not include_inactive:
+            query = query.filter(StaffUser.status_id == UserStatus.ACTIVE.value)
+        return query.first()
+
+    @classmethod
+    def get_user_by_external_id(cls, _external_id, include_inactive=False) -> Optional[StaffUser]:
         """Get a user with the provided external id."""
-        return cls.query.filter(func.lower(StaffUser.external_id) == func.lower(_external_id)).first()
+        query = db.session.query(StaffUser) \
+            .filter(func.lower(StaffUser.external_id) == func.lower(_external_id))
+
+        if not include_inactive:
+            query = query.filter(StaffUser.status_id == UserStatus.ACTIVE.value)
+
+        return query.first()
 
     @classmethod
     def create_user(cls, user) -> StaffUser:

--- a/met-api/src/met_api/resources/staff_user.py
+++ b/met-api/src/met_api/resources/staff_user.py
@@ -73,6 +73,7 @@ class StaffUsers(Resource):
             pagination_options=pagination_options,
             search_text=args.get('search_text', '', str),
             include_groups=args.get('include_groups', default=False, type=lambda v: v.lower() == 'true'),
+            include_inactive=args.get('include_inactive', default=False, type=lambda v: v.lower() == 'true')
         )
         return jsonify(users), HTTPStatus.OK
 
@@ -86,11 +87,12 @@ class StaffUser(Resource):
     @cross_origin(origins=allowedorigins())
     @require_role([Role.VIEW_USERS.value])
     def get(user_id):
-        """Return a set of users(staff only)."""
+        """Fetch a user by id."""
         args = request.args
         user = StaffUserService.get_user_by_id(
             user_id,
             include_groups=args.get('include_groups', default=False, type=lambda v: v.lower() == 'true'),
+            include_inactive=True,
         )
         return user, HTTPStatus.OK
 
@@ -110,7 +112,7 @@ class StaffUserStatus(Resource):
             if data.get('active', None) is None:
                 return {'message': 'active field is required'}, HTTPStatus.BAD_REQUEST
 
-            user = StaffUserService.toggle_user_active_status(
+            user = StaffUserMembershipService().toggle_user_active_status(
                 user_id,
                 active=data.get('active'),
             )

--- a/met-api/src/met_api/services/membership_service.py
+++ b/met-api/src/met_api/services/membership_service.py
@@ -11,7 +11,7 @@ from met_api.schemas.staff_user import StaffUserSchema
 from met_api.services import authorization
 from met_api.services.staff_user_service import KEYCLOAK_SERVICE, StaffUserService
 from met_api.utils.constants import Groups
-from met_api.utils.enums import KeycloakGroups, MembershipStatus, UserStatus
+from met_api.utils.enums import KeycloakGroups, MembershipStatus
 from met_api.utils.roles import Role
 from met_api.utils.token_info import TokenInfo
 

--- a/met-api/src/met_api/services/membership_service.py
+++ b/met-api/src/met_api/services/membership_service.py
@@ -11,7 +11,7 @@ from met_api.schemas.staff_user import StaffUserSchema
 from met_api.services import authorization
 from met_api.services.staff_user_service import KEYCLOAK_SERVICE, StaffUserService
 from met_api.utils.constants import Groups
-from met_api.utils.enums import KeycloakGroups, MembershipStatus
+from met_api.utils.enums import KeycloakGroups, MembershipStatus, UserStatus
 from met_api.utils.roles import Role
 from met_api.utils.token_info import TokenInfo
 
@@ -53,6 +53,8 @@ class MembershipService:
                 error='You cannot add yourself to an engagement.',
                 status_code=HTTPStatus.FORBIDDEN.value)
 
+        user_id = user_details.get('id')
+
         groups = user_details.get('groups')
         if KeycloakGroups.EAO_IT_ADMIN.value in groups:
             raise BusinessException(
@@ -61,7 +63,7 @@ class MembershipService:
 
         existing_membership = MembershipModel.find_by_engagement_and_user_id(
             engagement_id,
-            user_details.get('id'),
+            user_id,
             status=MembershipStatus.ACTIVE.value
         )
 

--- a/met-api/src/met_api/services/staff_user_membership_service.py
+++ b/met-api/src/met_api/services/staff_user_membership_service.py
@@ -53,7 +53,7 @@ class StaffUserMembershipService:
         if user is None:
             raise KeyError('User not found')
 
-        if not active:            
+        if not active:
             MembershipService.revoke_memberships_bulk(user.id)
 
         KEYCLOAK_SERVICE.toggle_user_enabled_status(user_id=user_external_id, enabled=active)

--- a/met-api/src/met_api/services/staff_user_service.py
+++ b/met-api/src/met_api/services/staff_user_service.py
@@ -10,7 +10,7 @@ from met_api.schemas.staff_user import StaffUserSchema
 from met_api.services.keycloak import KeycloakService
 from met_api.utils import notification
 from met_api.utils.constants import GROUP_NAME_MAPPING, Groups
-from met_api.utils.enums import KeycloakGroupName, UserStatus
+from met_api.utils.enums import KeycloakGroupName
 from met_api.utils.template import Template
 from met_api.config import get_gc_notify_config
 

--- a/met-web/src/components/userManagement/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/userManagement/listing/ActionsDropDown.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useContext } from 'react';
 import { MenuItem, Select } from '@mui/material';
-import { User, USER_GROUP } from 'models/user';
+import { User, USER_GROUP, USER_STATUS } from 'models/user';
 import { Palette } from 'styles/Theme';
 import { UserManagementContext } from './UserManagementContext';
 import { useAppSelector } from 'hooks';
@@ -47,7 +47,10 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
                     setUser(selectedUser);
                     setassignRoleModalOpen(true);
                 },
-                condition: hasNoRole() && roles.includes(USER_ROLES.EDIT_MEMBERS),
+                condition:
+                    hasNoRole() &&
+                    roles.includes(USER_ROLES.EDIT_MEMBERS) &&
+                    selectedUser.status_id == USER_STATUS.ACTIVE.value,
             },
             {
                 value: 2,
@@ -56,7 +59,8 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
                     setUser(selectedUser);
                     setAddUserModalOpen(true);
                 },
-                condition: !hasNoRole() && !isAdmin() && !isViewer(),
+                condition:
+                    !hasNoRole() && !isAdmin() && !isViewer() && selectedUser.status_id == USER_STATUS.ACTIVE.value,
             },
             {
                 value: 3,
@@ -65,7 +69,10 @@ export const ActionsDropDown = ({ selectedUser }: { selectedUser: User }) => {
                     setUser(selectedUser);
                     setReassignRoleModalOpen(true);
                 },
-                condition: !hasNoRole() && roles.includes(USER_ROLES.UPDATE_USER_GROUP),
+                condition:
+                    !hasNoRole() &&
+                    roles.includes(USER_ROLES.UPDATE_USER_GROUP) &&
+                    selectedUser.status_id == USER_STATUS.ACTIVE.value,
             },
         ],
         [selectedUser.id, selectedUser.main_group],

--- a/met-web/src/components/userManagement/listing/UserManagementContext.tsx
+++ b/met-web/src/components/userManagement/listing/UserManagementContext.tsx
@@ -103,6 +103,7 @@ export const UserManagementContextProvider = ({ children }: { children: JSX.Elem
                 sort_order,
                 include_groups: true,
                 search_text: searchText,
+                include_inactive: true,
             });
             setUsers(response.items);
             setPageInfo({

--- a/met-web/src/components/userManagement/userDetails/ActionsDropDown.tsx
+++ b/met-web/src/components/userManagement/userDetails/ActionsDropDown.tsx
@@ -6,6 +6,7 @@ import { reinstateMembership, revokeMembership } from 'services/membershipServic
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { UserDetailsContext } from './UserDetailsContext';
+import { USER_STATUS } from 'models/user';
 
 interface ActionDropDownItem {
     value: number;
@@ -15,7 +16,7 @@ interface ActionDropDownItem {
 }
 export const ActionsDropDown = ({ membership }: { membership: EngagementTeamMember }) => {
     const [loading, setLoading] = React.useState(false);
-    const { getUserMemberships } = React.useContext(UserDetailsContext);
+    const { getUserMemberships, savedUser } = React.useContext(UserDetailsContext);
     const dispatch = useAppDispatch();
 
     const handleRevoke = async () => {
@@ -59,13 +60,17 @@ export const ActionsDropDown = ({ membership }: { membership: EngagementTeamMemb
                 value: 1,
                 label: 'Revoke',
                 action: () => handleRevoke(),
-                condition: membership.status !== ENGAGEMENT_MEMBERSHIP_STATUS.Revoked,
+                condition:
+                    membership.status !== ENGAGEMENT_MEMBERSHIP_STATUS.Revoked &&
+                    savedUser?.status_id === USER_STATUS.ACTIVE.value,
             },
             {
                 value: 2,
                 label: 'Reinstate',
                 action: () => handleReinstate(),
-                condition: membership.status !== ENGAGEMENT_MEMBERSHIP_STATUS.Active,
+                condition:
+                    membership.status !== ENGAGEMENT_MEMBERSHIP_STATUS.Active &&
+                    savedUser?.status_id === USER_STATUS.ACTIVE.value,
             },
         ],
         [membership.id, membership.status],

--- a/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
+++ b/met-web/src/components/userManagement/userDetails/AddToEngagement.tsx
@@ -31,6 +31,7 @@ import { Engagement } from 'models/engagement';
 import axios, { AxiosError } from 'axios';
 import { Palette } from 'styles/Theme';
 import ControlledRadioGroup from 'components/common/ControlledInputComponents/ControlledRadioGroup';
+import { HTTP_STATUS_CODES } from 'constants/httpResponseCodes';
 
 export const AddToEngagementModal = () => {
     const { savedUser, addUserModalOpen, setAddUserModalOpen, getUserMemberships, getUserDetails } =
@@ -157,7 +158,7 @@ export const AddToEngagementModal = () => {
     };
 
     const setErrors = (error: AxiosError) => {
-        if (error.response?.status !== 409) {
+        if (error.response?.status !== HTTP_STATUS_CODES.CONFLICT) {
             return;
         }
         setBackendError(error.response?.data.message || '');

--- a/met-web/src/components/userManagement/userDetails/UserDetails.tsx
+++ b/met-web/src/components/userManagement/userDetails/UserDetails.tsx
@@ -6,7 +6,7 @@ import { formatDate } from 'components/common/dateHelper';
 import AssignedEngagementsListing from './AssignedEngagementsListing';
 import UserStatusButton from './UserStatusButton';
 import UserDetailsSkeleton from './UserDetailsSkeleton';
-import { USER_GROUP } from 'models/user';
+import { USER_GROUP, USER_STATUS } from 'models/user';
 
 export const UserDetail = ({ label, value }: { label: string; value: JSX.Element }) => {
     return (
@@ -80,7 +80,10 @@ export const UserDetails = () => {
                 <Grid container justifyContent={'flex-end'} alignItems={'flex-end'} item xs={6}>
                     <PrimaryButton
                         onClick={() => setAddUserModalOpen(true)}
-                        disabled={savedUser?.main_group === USER_GROUP.VIEWER.label}
+                        disabled={
+                            savedUser?.main_group === USER_GROUP.VIEWER.label ||
+                            savedUser?.status_id === USER_STATUS.INACTIVE.value
+                        }
                     >
                         + Add to an Engagement
                     </PrimaryButton>

--- a/met-web/src/components/userManagement/userDetails/UserDetailsContext.tsx
+++ b/met-web/src/components/userManagement/userDetails/UserDetailsContext.tsx
@@ -75,6 +75,7 @@ export const UserDetailsContextProvider = ({ children }: { children: JSX.Element
     };
 
     const getUserDetails = async () => {
+        setUserLoading(true);
         const fetchedUser = await getUser({ user_id: Number(userId), include_groups: true });
         setSavedUser(fetchedUser);
         setUserLoading(false);

--- a/met-web/src/components/userManagement/userDetails/UserStatusButton.tsx
+++ b/met-web/src/components/userManagement/userDetails/UserStatusButton.tsx
@@ -10,7 +10,7 @@ import { USER_GROUP } from 'models/user';
 
 const UserStatusButton = () => {
     const { roles } = useAppSelector((state) => state.user);
-    const { savedUser } = useContext(UserDetailsContext);
+    const { savedUser, getUserDetails } = useContext(UserDetailsContext);
     const [userStatus, setUserStatus] = useState(false);
     const [togglingUserStatus, setTogglingUserStatus] = useState(false);
     const dispatch = useAppDispatch();
@@ -30,6 +30,7 @@ const UserStatusButton = () => {
             setUserStatus(active);
             setTogglingUserStatus(true);
             await toggleUserStatus(savedUser.external_id, active);
+            getUserDetails();
             dispatch(
                 openNotification({
                     severity: 'success',

--- a/met-web/src/constants/httpResponseCodes.ts
+++ b/met-web/src/constants/httpResponseCodes.ts
@@ -1,3 +1,6 @@
 export const HTTP_STATUS_CODES = {
     NOT_FOUND: 404,
+    FORBIDDEN: 403,
+    BAD_REQUEST: 400,
+    CONFLICT: 409,
 };

--- a/met-web/src/services/userService/api/index.tsx
+++ b/met-web/src/services/userService/api/index.tsx
@@ -13,6 +13,7 @@ interface GetUserListParams {
     search_text?: string;
     // If yes, user groups will be fetched as well from keycloak
     include_groups?: boolean;
+    include_inactive?: boolean;
 }
 export const getUserList = async (params: GetUserListParams = {}): Promise<Page<User>> => {
     const responseData = await http.GetRequest<Page<User>>(Endpoints.User.GET_LIST, params);


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*
- Add a default filter to filter out inactive user on fetching a single or a list of users
- Add include_inactive flag
- Make include_inactive flag true only for operations allowed on inactive user, like activate user


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
