### PR TITLE
Fix test error logs in EngagementForm tests

### DIFF
--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
@@ -197,7 +197,9 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
     };
 
     useEffect(() => {
-        loadTeamMembers();
+        if (savedEngagement.id) {
+            loadTeamMembers();
+        }
     }, []);
 
     const [settings, setSettings] = useState<EngagementSettings>(createDefaultEngagementSettings());

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
@@ -200,7 +200,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
         if (savedEngagement.id) {
             loadTeamMembers();
         }
-    }, []);
+    }, [savedEngagement]);
 
     const [settings, setSettings] = useState<EngagementSettings>(createDefaultEngagementSettings());
     const [settingsLoading, setSettingsLoading] = useState(true);

--- a/met-web/tests/unit/components/engagement/EngagementFormUserTab.test.tsx
+++ b/met-web/tests/unit/components/engagement/EngagementFormUserTab.test.tsx
@@ -6,10 +6,12 @@ import { setupEnv } from '../setEnvVars';
 import * as reactRedux from 'react-redux';
 import * as reactRouter from 'react-router';
 import * as engagementService from 'services/engagementService';
+import * as engagementMetadataService from 'services/engagementMetadataService';
+import * as engagementSettingService from 'services/engagementSettingService';
 import * as teamMemberService from 'services/membershipService';
 import * as widgetService from 'services/widgetService';
 import { Box } from '@mui/material';
-import { draftEngagement } from '../factory';
+import { draftEngagement, engagementMetadata, engagementSetting } from '../factory';
 import { createDefaultUser, USER_GROUP } from 'models/user';
 import { EngagementTeamMember, initialDefaultTeamMember } from 'models/engagementTeamMember';
 import { USER_ROLES } from 'services/userService/constants';
@@ -26,7 +28,7 @@ const mockTeamMember1: EngagementTeamMember = {
     },
 };
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -78,6 +80,8 @@ describe('Engagement form page tests', () => {
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     jest.spyOn(engagementService, 'getEngagement').mockReturnValue(Promise.resolve(draftEngagement));
     jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(Promise.resolve(engagementSetting));
 
     beforeEach(() => {
         setupEnv();

--- a/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
@@ -6,10 +6,11 @@ import { setupEnv } from '../../../setEnvVars';
 import * as reactRedux from 'react-redux';
 import * as reactRouter from 'react-router';
 import * as engagementService from 'services/engagementService';
-import * as engagementMetadataService from 'services/engagementMetadataService';
 import * as notificationSlice from 'services/notificationService/notificationSlice';
+import * as engagementMetadataService from 'services/engagementMetadataService';
+import * as engagementSettingService from 'services/engagementSettingService';
 import { Box } from '@mui/material';
-import { draftEngagement, engagementMetadata } from '../../../factory';
+import { draftEngagement, engagementMetadata, engagementSetting } from '../../../factory';
 import { USER_ROLES } from 'services/userService/constants';
 
 jest.mock('react-redux', () => ({
@@ -22,7 +23,7 @@ jest.mock('react-redux', () => ({
     }),
 }));
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('components/common/Dragdrop', () => ({
     ...jest.requireActual('components/common/Dragdrop'),
@@ -75,6 +76,7 @@ describe('Engagement form page tests', () => {
     const postEngagementMock = jest
         .spyOn(engagementService, 'postEngagement')
         .mockReturnValue(Promise.resolve(draftEngagement));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(Promise.resolve(engagementSetting));
 
     beforeEach(() => {
         setupEnv();

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
@@ -13,7 +13,7 @@ import * as notificationModalSlice from 'services/notificationModalService/notif
 import * as widgetService from 'services/widgetService';
 import { createDefaultSurvey, Survey } from 'models/survey';
 import { Box } from '@mui/material';
-import { draftEngagement, engagementMetadata, engagementSlugData } from '../../../factory';
+import { draftEngagement, engagementMetadata, engagementSetting, engagementSlugData } from '../../../factory';
 import { USER_ROLES } from 'services/userService/constants';
 import assert from 'assert';
 import { EngagementSettings } from 'models/engagement';
@@ -27,11 +27,6 @@ const survey: Survey = {
 };
 
 const surveys = [survey];
-
-const mockEngagementSettings: EngagementSettings = {
-    engagement_id: engagementId,
-    send_report: false,
-};
 
 jest.mock('axios');
 
@@ -89,9 +84,7 @@ describe('Engagement form page tests', () => {
     const getEngagementMetadataMock = jest
         .spyOn(engagementMetadataService, 'getEngagementMetadata')
         .mockReturnValue(Promise.resolve(engagementMetadata));
-    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
-        Promise.resolve(mockEngagementSettings),
-    );
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(Promise.resolve(engagementSetting));
     jest.spyOn(engagementMetadataService, 'patchEngagementMetadata').mockReturnValue(
         Promise.resolve(engagementMetadata),
     );

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
@@ -1,0 +1,241 @@
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import EngagementForm from '../../../../../../src/components/engagement/form';
+import { setupEnv } from '../../../setEnvVars';
+import * as reactRedux from 'react-redux';
+import * as reactRouter from 'react-router';
+import * as engagementService from 'services/engagementService';
+import * as engagementMetadataService from 'services/engagementMetadataService';
+import * as engagementSettingService from 'services/engagementSettingService';
+import * as engagementSlugService from 'services/engagementSlugService';
+import * as notificationModalSlice from 'services/notificationModalService/notificationModalSlice';
+import * as widgetService from 'services/widgetService';
+import { createDefaultSurvey, Survey } from 'models/survey';
+import { Box } from '@mui/material';
+import { draftEngagement, engagementMetadata, engagementSlugData } from '../../../factory';
+import { USER_ROLES } from 'services/userService/constants';
+import assert from 'assert';
+import { EngagementSettings } from 'models/engagement';
+
+const engagementId = 1;
+const survey: Survey = {
+    ...createDefaultSurvey(),
+    id: 1,
+    name: 'Survey 1',
+    engagement_id: engagementId,
+};
+
+const surveys = [survey];
+
+const mockEngagementSettings: EngagementSettings = {
+    engagement_id: engagementId,
+    send_report: false,
+};
+
+jest.mock('axios');
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(() => {
+        return {
+            roles: [USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS, USER_ROLES.EDIT_ENGAGEMENT, USER_ROLES.CREATE_ENGAGEMENT],
+            assignedEngagements: [draftEngagement.id],
+        };
+    }),
+}));
+
+jest.mock('components/common/Dragdrop', () => ({
+    ...jest.requireActual('components/common/Dragdrop'),
+    MetDroppable: ({ children }: { children: React.ReactNode }) => <Box>{children}</Box>,
+    MetDraggable: ({ children }: { children: React.ReactNode }) => <Box>{children}</Box>,
+}));
+
+jest.mock('@hello-pangea/dnd', () => ({
+    ...jest.requireActual('@hello-pangea/dnd'),
+    DragDropContext: ({ children }: { children: React.ReactNode }) => <Box>{children}</Box>,
+}));
+
+jest.mock('@reduxjs/toolkit/query/react', () => ({
+    ...jest.requireActual('@reduxjs/toolkit/query/react'),
+    fetchBaseQuery: jest.fn(),
+}));
+
+jest.mock('components/map', () => () => {
+    return <Box></Box>;
+});
+
+jest.mock('apiManager/apiSlices/widgets', () => ({
+    ...jest.requireActual('apiManager/apiSlices/widgets'),
+    useCreateWidgetMutation: () => [jest.fn(() => Promise.resolve())],
+    useDeleteWidgetMutation: () => [jest.fn(() => Promise.resolve())],
+    useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
+}));
+
+// Mocking window.location.pathname in Jest
+Object.defineProperty(window, 'location', {
+    value: {
+        pathname: '/engagements/1/form',
+    },
+});
+
+describe('Engagement form page tests', () => {
+    jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
+    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
+    const openNotificationModalMock = jest
+        .spyOn(notificationModalSlice, 'openNotificationModal')
+        .mockImplementation(jest.fn());
+    const useParamsMock = jest.spyOn(reactRouter, 'useParams');
+    const getEngagementMetadataMock = jest
+        .spyOn(engagementMetadataService, 'getEngagementMetadata')
+        .mockReturnValue(Promise.resolve(engagementMetadata));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
+        Promise.resolve(mockEngagementSettings),
+    );
+    jest.spyOn(engagementMetadataService, 'patchEngagementMetadata').mockReturnValue(
+        Promise.resolve(engagementMetadata),
+    );
+    const getEngagementSlugMock = jest
+        .spyOn(engagementSlugService, 'getSlugByEngagementId')
+        .mockReturnValue(Promise.resolve(engagementSlugData));
+    const getEngagementMock = jest
+        .spyOn(engagementService, 'getEngagement')
+        .mockReturnValue(Promise.resolve(draftEngagement));
+    const patchEngagementMock = jest
+        .spyOn(engagementService, 'patchEngagement')
+        .mockReturnValue(Promise.resolve(draftEngagement));
+    jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([]));
+
+    beforeEach(() => {
+        setupEnv();
+    });
+
+    test('Engagement form with saved engagement should display saved info', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        expect(getEngagementMock).toHaveBeenCalledOnce();
+        expect(getEngagementMetadataMock).toHaveBeenCalledOnce();
+        expect(screen.getByTestId('update-engagement-button')).toBeVisible();
+        expect(screen.getByDisplayValue('2022-09-01')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('2022-09-30')).toBeInTheDocument();
+        expect(screen.getByText('Survey 1')).toBeInTheDocument();
+    });
+
+    test('Save engagement button should trigger patch call', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+        const updateButton = screen.getByTestId('update-engagement-button');
+
+        const nameInput = container.querySelector('input[name="name"]');
+        assert(nameInput, 'Unable to find engagement name input');
+        fireEvent.change(nameInput, { target: { value: 'Engagement Test updated' } });
+        fireEvent.click(updateButton);
+
+        await waitFor(() => {
+            expect(patchEngagementMock).toHaveBeenCalledOnce();
+            expect(screen.getByText('Save')).toBeInTheDocument();
+        });
+    });
+
+    test('Modal with warning appears when removing survey', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        const removeSurveyButton = screen.getByTestId(`survey-widget/remove-${survey.id}`);
+
+        fireEvent.click(removeSurveyButton);
+
+        expect(openNotificationModalMock).toHaveBeenCalledOnce();
+    });
+
+    test('Cannot add more than one survey', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        getEngagementMock.mockReturnValueOnce(
+            Promise.resolve({
+                ...draftEngagement,
+                surveys: surveys,
+            }),
+        );
+        getEngagementMetadataMock.mockReturnValueOnce(
+            Promise.resolve({
+                ...engagementMetadata,
+            }),
+        );
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        expect(screen.getByText('Add Survey')).toBeDisabled();
+    });
+
+    test('Can move to settings tab', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        getEngagementMock.mockReturnValueOnce(
+            Promise.resolve({
+                ...draftEngagement,
+                surveys: surveys,
+            }),
+        );
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        const settingsTabButton = screen.getByText('Settings');
+
+        fireEvent.click(settingsTabButton);
+
+        expect(screen.getByText('Engagement Information')).toBeInTheDocument();
+        expect(screen.getByText('Internal Engagement')).toBeInTheDocument();
+        expect(screen.getByText('Send Report')).toBeInTheDocument();
+    });
+
+    test('Can move to links tab', async () => {
+        useParamsMock.mockReturnValue({ engagementId: '1' });
+        getEngagementMock.mockReturnValueOnce(
+            Promise.resolve({
+                ...draftEngagement,
+                surveys: surveys,
+            }),
+        );
+        const { container } = render(<EngagementForm />);
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
+            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
+        });
+
+        const settingsTabButton = screen.getByText('URL (links)');
+
+        fireEvent.click(settingsTabButton);
+
+        expect(screen.getByText('Public URLs (links)')).toBeInTheDocument();
+        expect(screen.getByText('Link to Public Engagement Page')).toBeInTheDocument();
+        expect(screen.getByText('Link to Public Dashboard Report')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(getEngagementSlugMock).toHaveReturned();
+            expect(screen.getAllByDisplayValue(engagementSlugData.slug, { exact: false })).toBeArrayOfSize(2);
+        });
+    });
+});

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
@@ -16,7 +16,6 @@ import { Box } from '@mui/material';
 import { draftEngagement, engagementMetadata, engagementSetting, engagementSlugData } from '../../../factory';
 import { USER_ROLES } from 'services/userService/constants';
 import assert from 'assert';
-import { EngagementSettings } from 'models/engagement';
 
 const engagementId = 1;
 const survey: Survey = {

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.Two.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.Two.test.tsx
@@ -7,15 +7,13 @@ import * as reactRedux from 'react-redux';
 import * as reactRouter from 'react-router';
 import * as engagementService from 'services/engagementService';
 import * as engagementMetadataService from 'services/engagementMetadataService';
-import * as engagementSlugService from 'services/engagementSlugService';
 import * as notificationModalSlice from 'services/notificationModalService/notificationModalSlice';
 import * as widgetService from 'services/widgetService';
 import { createDefaultSurvey, Survey } from 'models/survey';
 import { WidgetType } from 'models/widget';
 import { Box } from '@mui/material';
-import { draftEngagement, engagementMetadata, engagementSlugData } from '../../../factory';
+import { draftEngagement, engagementMetadata } from '../../../factory';
 import { USER_ROLES } from 'services/userService/constants';
-import assert from 'assert';
 
 const survey: Survey = {
     ...createDefaultSurvey(),
@@ -26,7 +24,7 @@ const survey: Survey = {
 
 const surveys = [survey];
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -79,153 +77,17 @@ describe('Engagement form page tests', () => {
         .spyOn(notificationModalSlice, 'openNotificationModal')
         .mockImplementation(jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
-    const getEngagementMetadataMock = jest
-        .spyOn(engagementMetadataService, 'getEngagementMetadata')
-        .mockReturnValue(Promise.resolve(engagementMetadata));
     jest.spyOn(engagementMetadataService, 'patchEngagementMetadata').mockReturnValue(
         Promise.resolve(engagementMetadata),
     );
-    const getEngagementSlugMock = jest
-        .spyOn(engagementSlugService, 'getSlugByEngagementId')
-        .mockReturnValue(Promise.resolve(engagementSlugData));
+    jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
     const getEngagementMock = jest
         .spyOn(engagementService, 'getEngagement')
-        .mockReturnValue(Promise.resolve(draftEngagement));
-    const patchEngagementMock = jest
-        .spyOn(engagementService, 'patchEngagement')
         .mockReturnValue(Promise.resolve(draftEngagement));
     const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([]));
 
     beforeEach(() => {
         setupEnv();
-    });
-
-    test('Engagement form with saved engagement should display saved info', async () => {
-        useParamsMock.mockReturnValue({ engagementId: '1' });
-        const { container } = render(<EngagementForm />);
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
-            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
-        });
-
-        expect(getEngagementMock).toHaveBeenCalledOnce();
-        expect(getEngagementMetadataMock).toHaveBeenCalledOnce();
-        expect(screen.getByTestId('update-engagement-button')).toBeVisible();
-        expect(screen.getByDisplayValue('2022-09-01')).toBeInTheDocument();
-        expect(screen.getByDisplayValue('2022-09-30')).toBeInTheDocument();
-        expect(screen.getByText('Survey 1')).toBeInTheDocument();
-    });
-
-    test('Save engagement button should trigger patch call', async () => {
-        useParamsMock.mockReturnValue({ engagementId: '1' });
-        const { container } = render(<EngagementForm />);
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
-            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
-        });
-        const updateButton = screen.getByTestId('update-engagement-button');
-
-        const nameInput = container.querySelector('input[name="name"]');
-        assert(nameInput, 'Unable to find engagement name input');
-        fireEvent.change(nameInput, { target: { value: 'Survey 1 Updated' } });
-        fireEvent.click(updateButton);
-
-        await waitFor(() => {
-            expect(patchEngagementMock).toHaveBeenCalledOnce();
-        });
-    });
-
-    test('Modal with warning appears when removing survey', async () => {
-        useParamsMock.mockReturnValue({ engagementId: '1' });
-        const { container } = render(<EngagementForm />);
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
-            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
-        });
-
-        const removeSurveyButton = screen.getByTestId(`survey-widget/remove-${survey.id}`);
-
-        fireEvent.click(removeSurveyButton);
-
-        expect(openNotificationModalMock).toHaveBeenCalledOnce();
-    });
-
-    test('Cannot add more than one survey', async () => {
-        useParamsMock.mockReturnValue({ engagementId: '1' });
-        getEngagementMock.mockReturnValueOnce(
-            Promise.resolve({
-                ...draftEngagement,
-                surveys: surveys,
-            }),
-        );
-        getEngagementMetadataMock.mockReturnValueOnce(
-            Promise.resolve({
-                ...engagementMetadata,
-            }),
-        );
-        const { container } = render(<EngagementForm />);
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
-            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
-        });
-
-        expect(screen.getByText('Add Survey')).toBeDisabled();
-    });
-
-    test('Can move to settings tab', async () => {
-        useParamsMock.mockReturnValue({ engagementId: '1' });
-        getEngagementMock.mockReturnValueOnce(
-            Promise.resolve({
-                ...draftEngagement,
-                surveys: surveys,
-            }),
-        );
-        const { container } = render(<EngagementForm />);
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
-            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
-        });
-
-        const settingsTabButton = screen.getByText('Settings');
-
-        fireEvent.click(settingsTabButton);
-
-        expect(screen.getByText('Engagement Information')).toBeInTheDocument();
-        expect(screen.getByText('Internal Engagement')).toBeInTheDocument();
-        expect(screen.getByText('Send Report')).toBeInTheDocument();
-    });
-
-    test('Can move to links tab', async () => {
-        useParamsMock.mockReturnValue({ engagementId: '1' });
-        getEngagementMock.mockReturnValueOnce(
-            Promise.resolve({
-                ...draftEngagement,
-                surveys: surveys,
-            }),
-        );
-        const { container } = render(<EngagementForm />);
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
-            expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
-        });
-
-        const settingsTabButton = screen.getByText('URL (links)');
-
-        fireEvent.click(settingsTabButton);
-
-        expect(screen.getByText('Public URLs (links)')).toBeInTheDocument();
-        expect(screen.getByText('Link to Public Engagement Page')).toBeInTheDocument();
-        expect(screen.getByText('Link to Public Dashboard Report')).toBeInTheDocument();
-        await waitFor(() => {
-            expect(getEngagementSlugMock).toHaveReturned();
-            expect(screen.getAllByDisplayValue(engagementSlugData.slug, { exact: false })).toBeArrayOfSize(2);
-        });
     });
 
     test('Remove survey triggers notification modal', async () => {

--- a/met-web/tests/unit/components/factory.ts
+++ b/met-web/tests/unit/components/factory.ts
@@ -3,8 +3,10 @@ import { createDefaultSurvey, Survey } from 'models/survey';
 import {
     createDefaultEngagement,
     createDefaultEngagementMetadata,
+    createDefaultEngagementSettings,
     Engagement,
     EngagementMetadata,
+    EngagementSettings,
 } from 'models/engagement';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { WidgetType, Widget, WidgetItem } from 'models/widget';
@@ -165,6 +167,11 @@ const engagementMetadata: EngagementMetadata = {
     engagement_id: 1,
 };
 
+const engagementSetting: EngagementSettings = {
+    ...createDefaultEngagementSettings(),
+    engagement_id: 1,
+};
+
 const engagementSlugData = {
     slug: 'test-engagement-slug',
 };
@@ -183,4 +190,5 @@ export {
     eventWidget,
     engagementMetadata,
     engagementSlugData,
+    engagementSetting,
 };


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2077

*Description of changes:*
- Split EngagementForm.Edit into two tests
- Add missing mocks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
