### PR TITLE
Make Engagement Tiles consistent with submission_status

### DIFF
--- a/met-web/src/components/landing/EngagementTile.tsx
+++ b/met-web/src/components/landing/EngagementTile.tsx
@@ -118,7 +118,7 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
                 </Stack>
             </CardContent>
             <CardActions>
-                <If condition={status_id === SubmissionStatus.Open}>
+                <If condition={submission_status === SubmissionStatus.Open}>
                     <Then>
                         <PrimaryButton
                             fullWidth
@@ -131,7 +131,11 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
                         </PrimaryButton>
                     </Then>
                 </If>
-                <If condition={status_id === SubmissionStatus.Closed || status_id === SubmissionStatus.Upcoming}>
+                <If
+                    condition={
+                        submission_status === SubmissionStatus.Closed || submission_status === SubmissionStatus.Upcoming
+                    }
+                >
                     <Then>
                         <SecondaryButton
                             fullWidth

--- a/met-web/src/components/landing/EngagementTile.tsx
+++ b/met-web/src/components/landing/EngagementTile.tsx
@@ -75,7 +75,7 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
         return <MetLabel>error Loading</MetLabel>;
     }
 
-    const { name, end_date, start_date, description, status_id, banner_url, submission_status } = loadedEngagement;
+    const { name, end_date, start_date, description, banner_url, submission_status } = loadedEngagement;
     const EngagementDate = `${dayjs(start_date).format(dateFormat)} to ${dayjs(end_date).format(dateFormat)}`;
     return (
         <Card


### PR DESCRIPTION
-Change boolean to check submission_status instead of status_id to match engagement tile badge


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
