### PR TITLE
Allow empty widget title in textbox (replace with default title if user tries to save empty widget)

### DIFF
--- a/met-web/src/components/engagement/form/EngagementWidgets/WidgetTitle.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WidgetTitle.tsx
@@ -1,9 +1,8 @@
 import React, { useContext } from 'react';
-import { MetHeader3 } from 'components/common';
-import { Widget } from 'models/widget';
+import { MetHeader3, PrimaryButton } from 'components/common';
+import { Widget, WidgetTitles } from 'models/widget';
 import { CircularProgress, IconButton, Stack, TextField } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import CheckIcon from '@mui/icons-material/Check';
 import { Else, If, Then } from 'react-if';
 import { useUpdateWidgetMutation } from 'apiManager/apiSlices/widgets';
 import { useAppDispatch } from 'hooks';
@@ -24,12 +23,13 @@ export const WidgetTitle = ({ widget }: { widget: Widget }) => {
             return;
         }
         try {
+            if (title === '') setTitle(WidgetTitles[widget.widget_type_id]);
             setIsSaving(true);
             const response = await updateWidget({
                 id: widget.id,
                 engagementId: widget.engagement_id,
                 data: {
-                    title,
+                    title: title !== '' ? title : WidgetTitles[widget.widget_type_id],
                 },
             }).unwrap();
             setWidgets((prevWidgets) => {
@@ -49,10 +49,6 @@ export const WidgetTitle = ({ widget }: { widget: Widget }) => {
     };
 
     const handleTitleChange = (text: string) => {
-        if (!text) {
-            return;
-        }
-
         setTitle(text);
     };
 
@@ -78,13 +74,13 @@ export const WidgetTitle = ({ widget }: { widget: Widget }) => {
                             <CircularProgress size={20} color="info" />
                         </Then>
                         <Else>
-                            <IconButton
+                            <PrimaryButton
                                 onClick={() => {
                                     saveTitle();
                                 }}
                             >
-                                <CheckIcon color="info" />
-                            </IconButton>
+                                Save
+                            </PrimaryButton>
                         </Else>
                     </If>
                 </Stack>

--- a/met-web/src/models/widget.tsx
+++ b/met-web/src/models/widget.tsx
@@ -7,7 +7,7 @@ export interface WidgetItem {
 
 export interface Widget {
     id: number;
-    widget_type_id: number;
+    widget_type_id: WidgetType;
     engagement_id: number;
     items: WidgetItem[];
     title: string;
@@ -22,3 +22,13 @@ export enum WidgetType {
     Map = 6,
     Video = 7,
 }
+
+export const WidgetTitles: { [key in WidgetType]: string } = {
+    [WidgetType.WhoIsListening]: 'Who Is Listening',
+    [WidgetType.Document]: 'Documents',
+    [WidgetType.Phases]: 'Environmental Assesment Process',
+    [WidgetType.Subscribe]: 'Sign Up for Updates',
+    [WidgetType.Events]: 'Events',
+    [WidgetType.Map]: 'Map',
+    [WidgetType.Video]: 'Video',
+};


### PR DESCRIPTION
-Allow empty widget title

-Create default widget titles if user decides to make an empty widget name


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
