### PR TITLE
fixed date handling in open survey fetch

### DIFF
--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import ForeignKey, and_, asc, desc, or_
+from sqlalchemy import ForeignKey, and_, asc, desc, func, or_
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import text
 
@@ -43,11 +43,11 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
     @classmethod
     def get_open(cls, survey_id) -> Survey:
         """Get an open survey."""
-        now = datetime.now()
+        now = datetime.now().date()  # Get the current date without the timestamp
         survey: Survey = db.session.query(Survey).filter_by(id=survey_id) \
             .join(Engagement) \
             .filter_by(status_id=Status.Published.value) \
-            .filter(and_(Engagement.start_date <= now, Engagement.end_date >= now)) \
+            .filter(and_(func.date(Engagement.start_date) <= now, func.date(Engagement.end_date) >= now)) \
             .join(EngagementStatus) \
             .first()
         return survey

--- a/met-api/src/met_api/services/email_verification_service.py
+++ b/met-api/src/met_api/services/email_verification_service.py
@@ -49,7 +49,7 @@ class EmailVerificationService:
         """Create an email verification."""
         cls.validate_fields(email_verification)
         email_address: str = email_verification.get('email_address')
-        survey = SurveyModel.get_open(email_verification.get('survey_id'))
+        survey = SurveyModel.find_by_id(email_verification.get('survey_id'))
         engagement: EngagementModel = EngagementModel.find_by_id(
             survey.engagement_id)
         if engagement.is_internal and not email_address.endswith(INTERNAL_EMAIL_DOMAIN):
@@ -100,7 +100,7 @@ class EmailVerificationService:
         """Send an verification email.Throws error if fails."""
         survey_id = email_verification.get('survey_id')
         email_to = email_verification.get('email_address')
-        survey: SurveyModel = SurveyModel.get_open(survey_id)
+        survey: SurveyModel = SurveyModel.find_by_id(survey_id)
 
         if not survey:
             raise ValueError('Survey not found')


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*

- The survey get_open was wrongly factored in timestamps  since engagement start date and end dates are just days.
Fixed to remove timestamp in the date calculation.

- Get_open is not needed while fetching email validations.validations are already handled on the submit of the surveys



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
