### PR TITLE
Disable sorting by role for user management

### DIFF
--- a/met-web/src/components/userManagement/listing/UserManagementListing.tsx
+++ b/met-web/src/components/userManagement/listing/UserManagementListing.tsx
@@ -41,7 +41,7 @@ const UserManagementListing = () => {
             numeric: false,
             disablePadding: true,
             label: 'Role',
-            allowSort: true,
+            allowSort: false,
             renderCell: (row: User) => {
                 return row.main_group;
             },


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2110
-Disable sorting by role for user management listing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
