### PR TITLE
Fix for New Staff users were getting blank status

### DIFF
--- a/met-api/src/met_api/models/staff_user.py
+++ b/met-api/src/met_api/models/staff_user.py
@@ -33,7 +33,7 @@ class StaffUser(BaseModel):
     email_address = Column(db.String(100), nullable=True)
     contact_number = Column(db.String(50), nullable=True)
     external_id = Column(db.String(50), nullable=False, unique=True)
-    status_id = db.Column(db.Integer, ForeignKey('user_status.id'), nullable=False, server_default='1')
+    status_id = db.Column(db.Integer, ForeignKey('user_status.id'), nullable=False, default=1)
     tenant_id = db.Column(db.Integer, db.ForeignKey('tenant.id'), nullable=True)
 
     @classmethod


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*

Server_default was not working;probably bcoz there is no database constraint..easiser option is to work with default.so switching back to it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
