### PR TITLE
Update document widget arrow size

### DIFF
--- a/met-web/src/components/Form/formio.scss
+++ b/met-web/src/components/Form/formio.scss
@@ -4,7 +4,7 @@
 
 @import '~formiojs/dist/formio.full.min.css';
 
-@import '~met-formio/dist/met-formio-components.css';
+// @import '~met-formio/dist/met-formio-components.css';
 
 $btn-primary-main: #ffc107;
 $btn-primary-light: #ffe082;

--- a/met-web/src/components/Form/formio.scss
+++ b/met-web/src/components/Form/formio.scss
@@ -4,7 +4,7 @@
 
 @import '~formiojs/dist/formio.full.min.css';
 
-// @import '~met-formio/dist/met-formio-components.css';
+@import '~met-formio/dist/met-formio-components.css';
 
 $btn-primary-main: #ffc107;
 $btn-primary-light: #ffe082;

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/StyledTreeItem.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/StyledTreeItem.tsx
@@ -58,7 +58,15 @@ export function StyledTreeItem(props: StyledTreeItemProps & DocumentTreeItemProp
     return (
         <StyledTreeItemRoot
             label={
-                <Box sx={{ display: 'flex', alignItems: 'center', p: 0.5, pr: 0 }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        p: 0.5,
+                        pr: 0,
+                        pl: 0,
+                    }}
+                >
                     <If condition={labelUrl}>
                         <Then>
                             <Box

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/TreeView.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/TreeView.tsx
@@ -18,8 +18,8 @@ export default function DocumentTree({ documentItem }: DocumentTreeProps) {
         <TreeView
             aria-label="documentTree"
             defaultExpanded={['3']}
-            defaultCollapseIcon={<ArrowDropDownIcon />}
-            defaultExpandIcon={<ArrowRightIcon />}
+            defaultCollapseIcon={<ArrowDropDownIcon sx={{ height: '35px', width: '35px' }} />}
+            defaultExpandIcon={<ArrowRightIcon sx={{ height: '35px', width: '35px' }} />}
             defaultEndIcon={<div style={{ width: 24 }} />}
             sx={{ flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
         >


### PR DESCRIPTION
Issue: #1830 
-Make document arrow slightly bigger

<img width="550" alt="image" src="https://github.com/bcgov/met-public/assets/103138766/c31c9daf-aa1f-4902-b934-7a943964841e">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
