### PR TITLE
Pull projectId from query params and redirect to login

### DIFF
--- a/met-web/src/components/engagement/form/ActionContext.tsx
+++ b/met-web/src/components/engagement/form/ActionContext.tsx
@@ -71,7 +71,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
     const [savedEngagement, setSavedEngagement] = useState<Engagement>(createDefaultEngagement());
     const [engagementMetadata, setEngagementMetadata] = useState<EngagementMetadata>({
         ...createDefaultEngagementMetadata(),
-        project_id: projectId || '',
+        project_id: projectId ?? '',
     });
     const [bannerImage, setBannerImage] = useState<File | null>();
     const [savedBannerImageFileName, setSavedBannerImageFileName] = useState('');

--- a/met-web/src/components/engagement/form/ActionContext.tsx
+++ b/met-web/src/components/engagement/form/ActionContext.tsx
@@ -5,7 +5,7 @@ import {
     getEngagementMetadata,
     patchEngagementMetadata,
 } from '../../../services/engagementMetadataService';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { EngagementContext, EngagementForm, EngagementFormUpdate, EngagementParams } from './types';
 import {
     createDefaultEngagement,
@@ -55,6 +55,10 @@ export const ActionContext = createContext<EngagementContext>({
 
 export const ActionProvider = ({ children }: { children: JSX.Element }) => {
     const { engagementId } = useParams<EngagementParams>();
+    // get projectId from query params
+    const { search } = useLocation();
+    const searchParams = new URLSearchParams(search);
+    const projectId = searchParams.get('projectId');
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
 
@@ -65,7 +69,10 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
     const [loadingAuthorization, setLoadingAuthorization] = useState(true);
 
     const [savedEngagement, setSavedEngagement] = useState<Engagement>(createDefaultEngagement());
-    const [engagementMetadata, setEngagementMetadata] = useState<EngagementMetadata>(createDefaultEngagementMetadata());
+    const [engagementMetadata, setEngagementMetadata] = useState<EngagementMetadata>({
+        ...createDefaultEngagementMetadata(),
+        project_id: projectId || '',
+    });
     const [bannerImage, setBannerImage] = useState<File | null>();
     const [savedBannerImageFileName, setSavedBannerImageFileName] = useState('');
     const isCreate = window.location.pathname.includes(CREATE);
@@ -105,8 +112,8 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
         }
 
         try {
-            const engagement = await getEngagementMetadata(Number(engagementId));
-            setEngagementMetadata(engagement);
+            const engagementMetaData = await getEngagementMetadata(Number(engagementId));
+            setEngagementMetadata(engagementMetaData);
         } catch (err) {
             console.log(err);
             dispatch(openNotification({ severity: 'error', text: 'Error Fetching Engagement Metadata' }));

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
@@ -160,6 +160,10 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
     const [richContent, setRichContent] = useState(savedEngagement?.rich_content || '');
     const [engagementFormError, setEngagementFormError] = useState<EngagementFormError>(initialFormError);
 
+    useEffect(() => {
+        console.log('engagementFormData', engagementFormData.project_id);
+    }, [engagementFormData]);
+
     // Survey block
     const [surveyBlockText, setSurveyBlockText] = useState<{ [key in SubmissionStatusTypes]: string }>({
         Upcoming:

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
@@ -160,10 +160,6 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
     const [richContent, setRichContent] = useState(savedEngagement?.rich_content || '');
     const [engagementFormError, setEngagementFormError] = useState<EngagementFormError>(initialFormError);
 
-    useEffect(() => {
-        console.log('engagementFormData', engagementFormData.project_id);
-    }, [engagementFormData]);
-
     // Survey block
     const [surveyBlockText, setSurveyBlockText] = useState<{ [key in SubmissionStatusTypes]: string }>({
         Upcoming:

--- a/met-web/src/routes/RedirectLogin.tsx
+++ b/met-web/src/routes/RedirectLogin.tsx
@@ -1,0 +1,12 @@
+import React, { useEffect } from 'react';
+import { MidScreenLoader } from 'components/common';
+import UserService from 'services/userService';
+
+export const RedirectLogin = () => {
+    const fullUrl = window.location.href;
+
+    useEffect(() => {
+        UserService.doLogin(fullUrl);
+    }, []);
+    return <MidScreenLoader />;
+};

--- a/met-web/src/routes/UnauthenticatedRoutes.tsx
+++ b/met-web/src/routes/UnauthenticatedRoutes.tsx
@@ -10,6 +10,7 @@ import Landing from 'components/landing';
 import ManageSubscription from '../components/engagement/view/widgets/Subscribe/ManageSubscription';
 import { FormCAC } from 'components/FormCAC';
 import ScrollToTop from 'components/scrollToTop';
+import { RedirectLogin } from './RedirectLogin';
 const UnauthenticatedRoutes = () => {
     return (
         <>
@@ -30,6 +31,7 @@ const UnauthenticatedRoutes = () => {
                 <Route path="/:slug/edit/:token" element={<EditSurvey />} />
                 <Route path="/surveys/submit/:surveyId/:token" element={<SurveySubmit />} />
                 <Route path="/engagements/:engagementId/cacform/:widgetId" element={<FormCAC />} />
+                <Route path="/engagements/create/form" element={<RedirectLogin />} />
                 <Route path="*" element={<NotFound />} />
                 <Route path="/not-found" element={<NotFound />} />
             </Routes>

--- a/met-web/src/services/userService/index.ts
+++ b/met-web/src/services/userService/index.ts
@@ -85,7 +85,7 @@ const userLogout = () => {
     doLogout();
 };
 
-const doLogin = () => KeycloakData.login({ redirectUri: getBaseUrl() });
+const doLogin = (redirectUri?: string) => KeycloakData.login({ redirectUri: redirectUri || getBaseUrl() });
 
 const doLogout = async () => KeycloakData.logout({ redirectUri: getBaseUrl() });
 const getToken = () => KeycloakData.token;

--- a/met-web/src/services/userService/index.ts
+++ b/met-web/src/services/userService/index.ts
@@ -85,7 +85,7 @@ const userLogout = () => {
     doLogout();
 };
 
-const doLogin = (redirectUri?: string) => KeycloakData.login({ redirectUri: redirectUri || getBaseUrl() });
+const doLogin = (redirectUri?: string) => KeycloakData.login({ redirectUri: redirectUri ?? getBaseUrl() });
 
 const doLogout = async () => KeycloakData.logout({ redirectUri: getBaseUrl() });
 const getToken = () => KeycloakData.token;

--- a/met-web/tests/unit/components/comment/CommentListing.test.tsx
+++ b/met-web/tests/unit/components/comment/CommentListing.test.tsx
@@ -43,7 +43,7 @@ jest.mock('@mui/material', () => ({
     },
 }));
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('components/common', () => ({
     ...jest.requireActual('components/common'),

--- a/met-web/tests/unit/components/engagement/EngagementFormUserTab.test.tsx
+++ b/met-web/tests/unit/components/engagement/EngagementFormUserTab.test.tsx
@@ -73,9 +73,17 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
+
 describe('Engagement form page tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     jest.spyOn(teamMemberService, 'getTeamMembers').mockReturnValue(Promise.resolve([mockTeamMember1]));
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     jest.spyOn(engagementService, 'getEngagement').mockReturnValue(Promise.resolve(draftEngagement));

--- a/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
@@ -45,6 +45,15 @@ jest.mock('components/map', () => () => {
     return <Box></Box>;
 });
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: 'test project id' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
+
 jest.mock('apiManager/apiSlices/widgets', () => ({
     ...jest.requireActual('apiManager/apiSlices/widgets'),
     useCreateWidgetMutation: () => [jest.fn(() => Promise.resolve())],
@@ -61,7 +70,6 @@ Object.defineProperty(window, 'location', {
 
 describe('Engagement form page tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const openNotificationMock = jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     const getEngagementMetadataMock = jest

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
@@ -67,6 +67,15 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
+
 // Mocking window.location.pathname in Jest
 Object.defineProperty(window, 'location', {
     value: {
@@ -76,7 +85,6 @@ Object.defineProperty(window, 'location', {
 
 describe('Engagement form page tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const openNotificationModalMock = jest
         .spyOn(notificationModalSlice, 'openNotificationModal')
         .mockImplementation(jest.fn());

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.Two.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.Two.test.tsx
@@ -64,6 +64,15 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
+
 // Mocking window.location.pathname in Jest
 Object.defineProperty(window, 'location', {
     value: {
@@ -73,7 +82,6 @@ Object.defineProperty(window, 'location', {
 
 describe('Engagement form page tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const openNotificationModalMock = jest
         .spyOn(notificationModalSlice, 'openNotificationModal')
         .mockImplementation(jest.fn());

--- a/met-web/tests/unit/components/widgets/DocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/DocumentWidget.test.tsx
@@ -12,7 +12,12 @@ import * as notificationSlice from 'services/notificationService/notificationSli
 import * as engagementMetadataService from 'services/engagementMetadataService';
 import * as membershipService from 'services/membershipService';
 import * as engagementSettingService from 'services/engagementSettingService';
-import { createDefaultEngagement, createDefaultEngagementSettings, Engagement, EngagementSettings } from 'models/engagement';
+import {
+    createDefaultEngagement,
+    createDefaultEngagementSettings,
+    Engagement,
+    EngagementSettings,
+} from 'models/engagement';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { Widget, WidgetType } from 'models/widget';
 import { DocumentItem } from 'models/document';
@@ -39,9 +44,8 @@ const engagement: Engagement = {
 };
 
 const mockEngagementSettings: EngagementSettings = {
-    ...createDefaultEngagementSettings()
-}
-
+    ...createDefaultEngagementSettings(),
+};
 
 const mockFile: DocumentItem = {
     id: 1,
@@ -65,7 +69,16 @@ const documentWidget: Widget = {
     items: [],
 };
 
-jest.mock('axios')
+jest.mock('axios');
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -97,16 +110,14 @@ jest.mock('components/map', () => () => {
 
 describe('Document widget in engagement page tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     jest.spyOn(notificationSlice, 'openNotification').mockImplementation(jest.fn());
     jest.spyOn(engagementService, 'getEngagement').mockReturnValue(Promise.resolve(engagement));
     jest.spyOn(documentService, 'fetchDocuments').mockReturnValue(Promise.resolve([mockFolder]));
-    jest.spyOn(engagementMetadataService, 'getEngagementMetadata')
-        .mockReturnValue(Promise.resolve(engagementMetadata));
-    jest.spyOn(membershipService, 'getTeamMembers')
-        .mockReturnValue(Promise.resolve([]));
-    jest.spyOn(engagementSettingService, 'getEngagementSettings')
-        .mockReturnValue(Promise.resolve(mockEngagementSettings));
+    jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
+    jest.spyOn(membershipService, 'getTeamMembers').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
+        Promise.resolve(mockEngagementSettings),
+    );
     const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([]));
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
 

--- a/met-web/tests/unit/components/widgets/EventsWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/EventsWidget.test.tsx
@@ -21,10 +21,10 @@ jest.mock('components/map', () => () => {
 });
 
 const mockEngagementSettings: EngagementSettings = {
-    ...createDefaultEngagementSettings()
-}
+    ...createDefaultEngagementSettings(),
+};
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -34,6 +34,15 @@ jest.mock('react-redux', () => ({
             assignedEngagements: [draftEngagement.id],
         };
     }),
+}));
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
 }));
 
 jest.mock('@reduxjs/toolkit/query/react', () => ({
@@ -79,18 +88,16 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 
 describe('Event Widget tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     const getEngagementMock = jest
         .spyOn(engagementService, 'getEngagement')
         .mockReturnValue(Promise.resolve(draftEngagement));
     const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([eventWidget]));
-    jest.spyOn(engagementMetadataService, 'getEngagementMetadata')
-        .mockReturnValue(Promise.resolve(engagementMetadata));
-    jest.spyOn(membershipService, 'getTeamMembers')
-        .mockReturnValue(Promise.resolve([]));
-    jest.spyOn(engagementSettingService, 'getEngagementSettings')
-        .mockReturnValue(Promise.resolve(mockEngagementSettings));
+    jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
+    jest.spyOn(membershipService, 'getTeamMembers').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
+        Promise.resolve(mockEngagementSettings),
+    );
 
     beforeEach(() => {
         setupEnv();

--- a/met-web/tests/unit/components/widgets/MapWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/MapWidget.test.tsx
@@ -17,14 +17,14 @@ import { USER_ROLES } from 'services/userService/constants';
 import { EngagementSettings, createDefaultEngagementSettings } from 'models/engagement';
 
 const mockEngagementSettings: EngagementSettings = {
-    ...createDefaultEngagementSettings()
-}
+    ...createDefaultEngagementSettings(),
+};
 
 jest.mock('components/map', () => () => {
     return <div></div>;
 });
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -77,21 +77,28 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));
 
-jest.spyOn(engagementMetadataService, 'getEngagementMetadata')
-    .mockReturnValue(Promise.resolve(engagementMetadata));
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
+
+jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
 
 describe('Map Widget tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     const getEngagementMock = jest
         .spyOn(engagementService, 'getEngagement')
         .mockReturnValue(Promise.resolve(draftEngagement));
     const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([mapWidget]));
-    jest.spyOn(membershipService, 'getTeamMembers')
-        .mockReturnValue(Promise.resolve([]));
-    jest.spyOn(engagementSettingService, 'getEngagementSettings')
-        .mockReturnValue(Promise.resolve(mockEngagementSettings));
+    jest.spyOn(membershipService, 'getTeamMembers').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
+        Promise.resolve(mockEngagementSettings),
+    );
 
     beforeEach(() => {
         setupEnv();

--- a/met-web/tests/unit/components/widgets/PhasesWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/PhasesWidget.test.tsx
@@ -23,7 +23,7 @@ const survey: Survey = {
     engagement_id: 1,
 };
 
-jest.mock('axios')
+jest.mock('axios');
 
 const surveys = [survey];
 
@@ -43,8 +43,17 @@ const phasesWidget: Widget = {
 };
 
 const mockEngagementSettings: EngagementSettings = {
-    ...createDefaultEngagementSettings()
-}
+    ...createDefaultEngagementSettings(),
+};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -83,18 +92,16 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
 
 describe('Phases widget tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     const getEngagementMock = jest
         .spyOn(engagementService, 'getEngagement')
         .mockReturnValue(Promise.resolve(draftEngagement));
     const getWidgetsMock = jest.spyOn(widgetService, 'getWidgets').mockReturnValue(Promise.resolve([phasesWidget]));
-    jest.spyOn(engagementMetadataService, 'getEngagementMetadata')
-        .mockReturnValue(Promise.resolve(engagementMetadata));
-    jest.spyOn(membershipService, 'getTeamMembers')
-        .mockReturnValue(Promise.resolve([]));
-    jest.spyOn(engagementSettingService, 'getEngagementSettings')
-        .mockReturnValue(Promise.resolve(mockEngagementSettings));
+    jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
+    jest.spyOn(membershipService, 'getTeamMembers').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
+        Promise.resolve(mockEngagementSettings),
+    );
 
     beforeEach(() => {
         setupEnv();

--- a/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
@@ -55,14 +55,23 @@ const whoIsListeningWidget: Widget = {
 };
 
 const mockEngagementSettings: EngagementSettings = {
-    ...createDefaultEngagementSettings()
-}
+    ...createDefaultEngagementSettings(),
+};
 
-jest.mock('axios')
+jest.mock('axios');
 
 jest.mock('components/map', () => () => {
     return <div></div>;
 });
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ search: '' })),
+    useParams: jest.fn(() => {
+        return { projectId: '' };
+    }),
+    useNavigate: () => jest.fn(),
+}));
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -129,18 +138,15 @@ jest.mock('apiManager/apiSlices/widgets', () => ({
     useDeleteWidgetMutation: () => [jest.fn(() => Promise.resolve())],
     useSortWidgetsMutation: () => [jest.fn(() => Promise.resolve())],
 }));
-jest.spyOn(engagementMetadataService, 'getEngagementMetadata')
-    .mockReturnValue(Promise.resolve(engagementMetadata));
+jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
 
 describe('Who is Listening widget  tests', () => {
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => jest.fn());
-    jest.spyOn(reactRouter, 'useNavigate').mockImplementation(() => jest.fn());
-    jest.spyOn(engagementMetadataService, 'getEngagementMetadata')
-        .mockReturnValue(Promise.resolve(engagementMetadata));
-    jest.spyOn(membershipService, 'getTeamMembers')
-        .mockReturnValue(Promise.resolve([]));
-    jest.spyOn(engagementSettingService, 'getEngagementSettings')
-        .mockReturnValue(Promise.resolve(mockEngagementSettings));
+    jest.spyOn(engagementMetadataService, 'getEngagementMetadata').mockReturnValue(Promise.resolve(engagementMetadata));
+    jest.spyOn(membershipService, 'getTeamMembers').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(engagementSettingService, 'getEngagementSettings').mockReturnValue(
+        Promise.resolve(mockEngagementSettings),
+    );
     const useParamsMock = jest.spyOn(reactRouter, 'useParams');
     const getEngagementMock = jest
         .spyOn(engagementService, 'getEngagement')


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2184

*Description of changes:*
- Pull project Id from query params to project metadata in engagement create
- If loggedout redirect to login and redirect back when visiting engagement create


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
