### PR TITLE
Updating Github actions to use EAO as default Environment

### DIFF
--- a/.github/workflows/analytics-api-cd.yml
+++ b/.github/workflows/analytics-api-cd.yml
@@ -13,6 +13,10 @@ on:
         description: "Environment (dev/test/prod)"
         required: true
         default: "dev"
+      project_type:
+        description: "Project Type (EAO/GDX)"
+        required: false
+        default: "EAO" # Default value is EAO   
 
 defaults:
   run:
@@ -22,6 +26,13 @@ defaults:
 env:
   APP_NAME: "analytics-api"
   TAG_NAME: "${{github.event.inputs.environment || 'dev' }}" # If the environment type is manually selected, use the input value; otherwise, use 'dev' as default
+  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
+
+  OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:
   analytics-api-cd:
@@ -37,12 +48,12 @@ jobs:
       - name: Login Openshift
         shell: bash
         run: |
-          oc login --server=${{secrets.OPENSHIFT_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT_SA_TOKEN}}
+          oc login --server=${{env.OPENSHIFT_LOGIN_REGISTRY}} --token=${{env.OPENSHIFT_SA_TOKEN}}
 
       - name: Login Docker
         run: |
-          echo "${{ secrets.OPENSHIFT_SA_TOKEN }}" | 
-          docker login ${{ secrets.OPENSHIFT_IMAGE_REGISTRY }} -u ${{ secrets.OPENSHIFT_SA_NAME}} --password-stdin
+          echo "${{ env.OPENSHIFT_SA_TOKEN }}" | 
+          docker login ${{ env.OPENSHIFT_IMAGE_REGISTRY }} -u ${{ env.OPENSHIFT_SA_NAME}} --password-stdin
 
       - name: Build image
         run: |
@@ -50,7 +61,7 @@ jobs:
 
       - name: Push image
         run: |
-          IMAGE_ID=${{ secrets.OPENSHIFT_IMAGE_REGISTRY }}/"${{ secrets.OPENSHIFT_REPOSITORY}}-tools"/$APP_NAME
+          IMAGE_ID=${{ env.OPENSHIFT_IMAGE_REGISTRY }}/"${{ env.OPENSHIFT_REPOSITORY}}-tools"/$APP_NAME
           docker tag image $IMAGE_ID:latest
           docker push $IMAGE_ID:latest
           docker image tag $IMAGE_ID:latest $IMAGE_ID:$TAG_NAME
@@ -59,4 +70,4 @@ jobs:
       - name: Rollout
         shell: bash
         run: |
-          oc rollout status dc/${{ env.APP_NAME }} -n ${{ secrets.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w
+          oc rollout status dc/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w

--- a/.github/workflows/analytics-api-cd.yml
+++ b/.github/workflows/analytics-api-cd.yml
@@ -29,9 +29,9 @@ env:
   PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN || secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY || secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
   OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:

--- a/.github/workflows/met-api-cd.yml
+++ b/.github/workflows/met-api-cd.yml
@@ -16,7 +16,7 @@ on:
       project_type:
         description: "Project Type (EAO/GDX)"
         required: false
-        default: "GDX" # Default value is GDX     
+        default: "EAO" # Default value is EAO     
 
 defaults:
   run:
@@ -26,14 +26,14 @@ defaults:
 env:
   APP_NAME: "met-api"
   TAG_NAME: "${{ github.event.inputs.environment || 'dev' }}" # If the environment type is manually selected, use the input value; otherwise, use 'dev' as default
-  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'GDX' }}" # If the project type is manually selected, use the input value; otherwise, use 'GDX' as default
+  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
   
   # Set OpenShift related variables based on PROJECT_TYPE
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ (github.event.inputs.project_type == 'EAO') && secrets.OPENSHIFT_SA_TOKEN_EAO || secrets.OPENSHIFT_SA_TOKEN }}
-  OPENSHIFT_SA_NAME: ${{ (github.event.inputs.project_type == 'EAO') && secrets.OPENSHIFT_SA_NAME_EAO || secrets.OPENSHIFT_SA_NAME }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ (github.event.inputs.project_type == 'EAO') && secrets.OPENSHIFT_IMAGE_REGISTRY_EAO || secrets.OPENSHIFT_IMAGE_REGISTRY }}
-  OPENSHIFT_REPOSITORY: ${{ (github.event.inputs.project_type == 'EAO') && secrets.OPENSHIFT_REPOSITORY_EAO || secrets.OPENSHIFT_REPOSITORY }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
   
   
 jobs:

--- a/.github/workflows/met-api-cd.yml
+++ b/.github/workflows/met-api-cd.yml
@@ -30,9 +30,9 @@ env:
   
   # Set OpenShift related variables based on PROJECT_TYPE
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN || secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY || secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
   OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
   
   

--- a/.github/workflows/met-cron-cd.yml
+++ b/.github/workflows/met-cron-cd.yml
@@ -17,7 +17,7 @@ on:
       project_type:
         description: "Project Type (EAO/GDX)"
         required: false
-        default: "GDX" # Default value is GDX         
+        default: "EAO" # Default value is EAO         
 
 defaults:
   run:
@@ -27,13 +27,13 @@ defaults:
 env:
   APP_NAME: "met-cron"
   TAG_NAME: "${{github.event.inputs.environment || 'dev' }}" # If the environment type is manually selected, use the input value; otherwise, use 'dev' as default
-  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'GDX' }}" # If the project type is manually selected, use the input value; otherwise, use 'GDX' as default
+  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_SA_TOKEN_EAO || secrets.OPENSHIFT_SA_TOKEN }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_SA_NAME_EAO || secrets.OPENSHIFT_SA_NAME }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_IMAGE_REGISTRY_EAO || secrets.OPENSHIFT_IMAGE_REGISTRY }}
-  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_REPOSITORY_EAO || secrets.OPENSHIFT_REPOSITORY }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 
 jobs:

--- a/.github/workflows/met-cron-cd.yml
+++ b/.github/workflows/met-cron-cd.yml
@@ -30,9 +30,9 @@ env:
   PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN || secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY || secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
   OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 

--- a/.github/workflows/met-etl-cd.yml
+++ b/.github/workflows/met-etl-cd.yml
@@ -17,7 +17,7 @@ on:
       project_type:
         description: "Project Type (EAO/GDX)"
         required: false
-        default: "GDX" # Default value is GDX    
+        default: "EAO" # Default value is EAO    
 
 defaults:
   run:
@@ -29,13 +29,13 @@ env:
   DEPLOYMENT_NAME: "dagster-dagster-user-deployments-k8s-example-user-code-1"
   TAG_NAME: "dev"
   
-  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'GDX' }}" # If the project type is manually selected, use the input value; otherwise, use 'GDX' as default
+  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_SA_TOKEN_EAO || secrets.OPENSHIFT_SA_TOKEN }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_SA_NAME_EAO || secrets.OPENSHIFT_SA_NAME }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_IMAGE_REGISTRY_EAO || secrets.OPENSHIFT_IMAGE_REGISTRY }}
-  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_REPOSITORY_EAO || secrets.OPENSHIFT_REPOSITORY }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:
   met-cron-cd:

--- a/.github/workflows/met-etl-cd.yml
+++ b/.github/workflows/met-etl-cd.yml
@@ -32,9 +32,9 @@ env:
   PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN || secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY || secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
   OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:

--- a/.github/workflows/met-web-cd.yml
+++ b/.github/workflows/met-web-cd.yml
@@ -30,9 +30,9 @@ env:
   PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN || secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY || secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
   OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:

--- a/.github/workflows/met-web-cd.yml
+++ b/.github/workflows/met-web-cd.yml
@@ -16,7 +16,7 @@ on:
       project_type:
         description: "Project Type (EAO/GDX)"
         required: false
-        default: "GDX" # Default value is GDX    
+        default: "EAO" # Default value is EAO    
 
 defaults:
   run:
@@ -27,13 +27,13 @@ env:
   APP_NAME: "met-web"
   TAG_NAME: "${{ github.event.inputs.environment || 'dev' }}" # If the environment type is manually selected, use the input value; otherwise, use 'dev' as default
   
-  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'GDX' }}" # If the project type is manually selected, use the input value; otherwise, use 'GDX' as default
+  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_SA_TOKEN_EAO || secrets.OPENSHIFT_SA_TOKEN }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_SA_NAME_EAO || secrets.OPENSHIFT_SA_NAME }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_IMAGE_REGISTRY_EAO || secrets.OPENSHIFT_IMAGE_REGISTRY }}
-  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'EAO' && secrets.OPENSHIFT_REPOSITORY_EAO || secrets.OPENSHIFT_REPOSITORY }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:
   met-web-cd:

--- a/.github/workflows/notify-api-cd.yml
+++ b/.github/workflows/notify-api-cd.yml
@@ -30,9 +30,9 @@ env:
   PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
 
   OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
-  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
-  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
-  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN || secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY || secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
   OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:

--- a/.github/workflows/notify-api-cd.yml
+++ b/.github/workflows/notify-api-cd.yml
@@ -13,6 +13,10 @@ on:
         description: "Environment (dev/test/prod)"
         required: true
         default: "dev"
+      project_type:
+        description: "Project Type (EAO/GDX)"
+        required: false
+        default: "EAO" # Default value is EAO  
 
 defaults:
   run:
@@ -22,6 +26,14 @@ defaults:
 env:
   APP_NAME: "notify-api"
   TAG_NAME: "${{ github.event.inputs.environment || 'dev' }}" # If the environment type is manually selected, use the input value; otherwise, use 'dev' as default
+
+  PROJECT_TYPE: "${{ github.event.inputs.project_type || 'EAO' }}" # If the project type is manually selected, use the input value; otherwise, use 'EAO' as default
+
+  OPENSHIFT_LOGIN_REGISTRY: ${{ secrets.OPENSHIFT_LOGIN_REGISTRY }}
+  OPENSHIFT_SA_TOKEN: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_TOKEN ||  secrets.OPENSHIFT_SA_TOKEN_EAO }}
+  OPENSHIFT_SA_NAME: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_SA_NAME || secrets.OPENSHIFT_SA_NAME secrets.OPENSHIFT_SA_NAME_EAO }}
+  OPENSHIFT_IMAGE_REGISTRY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_IMAGE_REGISTRY ||  secrets.OPENSHIFT_IMAGE_REGISTRY_EAO }}
+  OPENSHIFT_REPOSITORY: ${{ github.event.inputs.project_type == 'GDX' && secrets.OPENSHIFT_REPOSITORY || secrets.OPENSHIFT_REPOSITORY_EAO }}
 
 jobs:
   notify-api-cd:
@@ -37,12 +49,12 @@ jobs:
       - name: Login Openshift
         shell: bash
         run: |
-          oc login --server=${{secrets.OPENSHIFT_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT_SA_TOKEN}}
+          oc login --server=${{env.OPENSHIFT_LOGIN_REGISTRY}} --token=${{env.OPENSHIFT_SA_TOKEN}}
 
       - name: Login Docker
         run: |
-          echo "${{ secrets.OPENSHIFT_SA_TOKEN }}" | 
-          docker login ${{ secrets.OPENSHIFT_IMAGE_REGISTRY }} -u ${{ secrets.OPENSHIFT_SA_NAME}} --password-stdin
+          echo "${{ env.OPENSHIFT_SA_TOKEN }}" | 
+          docker login ${{ env.OPENSHIFT_IMAGE_REGISTRY }} -u ${{ env.OPENSHIFT_SA_NAME}} --password-stdin
 
       - name: Build image
         run: |
@@ -50,7 +62,7 @@ jobs:
 
       - name: Push image
         run: |
-          IMAGE_ID=${{ secrets.OPENSHIFT_IMAGE_REGISTRY }}/"${{ secrets.OPENSHIFT_REPOSITORY}}-tools"/$APP_NAME
+          IMAGE_ID=${{ env.OPENSHIFT_IMAGE_REGISTRY }}/"${{ env.OPENSHIFT_REPOSITORY}}-tools"/$APP_NAME
           docker tag image $IMAGE_ID:latest
           docker push $IMAGE_ID:latest
           docker image tag $IMAGE_ID:latest $IMAGE_ID:$TAG_NAME
@@ -59,4 +71,4 @@ jobs:
       - name: Rollout
         shell: bash
         run: |
-          oc rollout status dc/${{ env.APP_NAME }} -n ${{ secrets.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w
+          oc rollout status dc/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*
- Workflow should now push/deploy images to the EAO environment by default
- Users will have to manually run actions if they wish to deploy to GDX 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
