### PR TITLE
Restrict export comments proponent and internal by roles

### DIFF
--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -20,7 +20,6 @@ from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
 from met_api.auth import auth
-from met_api.auth import jwt as _jwt
 from met_api.models.pagination_options import PaginationOptions
 from met_api.services.comment_service import CommentService
 from met_api.utils.roles import Role

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -23,6 +23,8 @@ from met_api.auth import auth
 from met_api.auth import jwt as _jwt
 from met_api.models.pagination_options import PaginationOptions
 from met_api.services.comment_service import CommentService
+from met_api.utils.roles import Role
+from met_api.utils.tenant_validator import require_role
 from met_api.utils.util import allowedorigins, cors_preflight
 
 
@@ -68,7 +70,7 @@ class GeneratedStaffCommentsSheet(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
-    @_jwt.requires_auth
+    @require_role([Role.EXPORT_INTERNAL_COMMENT_SHEET.value])
     def get(survey_id):
         """Export comments."""
         try:
@@ -95,7 +97,7 @@ class GeneratedProponentCommentsSheet(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
-    @_jwt.requires_auth
+    @require_role([Role.EXPORT_PROPONENT_COMMENT_SHEET.value])
     def get(survey_id):
         """Export comments."""
         try:

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -160,11 +160,6 @@ class CommentService:
     def export_comments_to_spread_sheet_staff(cls, survey_id):
         """Export comments to spread sheet."""
         engagement = SurveyModel.find_by_id(survey_id)
-        one_of_roles = (
-            MembershipType.TEAM_MEMBER.name,
-            Role.EXPORT_TO_CSV.value
-        )
-        authorization.check_auth(one_of_roles=one_of_roles, engagement_id=engagement.engagement_id)
         comments = Comment.get_comments_by_survey_id(survey_id)
         metadata_model = EngagementMetadataModel.find_by_id(engagement.engagement_id)
         project_name = metadata_model.project_metadata.get('project_name') if metadata_model else None
@@ -257,7 +252,7 @@ class CommentService:
         engagement = SurveyModel.find_by_id(survey_id)
         one_of_roles = (
             MembershipType.TEAM_MEMBER.name,
-            Role.EXPORT_TO_CSV.value
+            Role.EXPORT_ALL_TO_CSV.value
         )
         authorization.check_auth(one_of_roles=one_of_roles, engagement_id=engagement.engagement_id)
         comments = Comment.get_public_viewable_comments_by_survey_id(survey_id)

--- a/met-api/src/met_api/utils/roles.py
+++ b/met-api/src/met_api/utils/roles.py
@@ -55,8 +55,10 @@ class Role(Enum):
     VIEW_FEEDBACKS = 'view_feedbacks'
     VIEW_ALL_ENGAGEMENTS = 'view_all_engagements'  # Allows user access to all engagements including draft
     SHOW_ALL_COMMENT_STATUS = 'show_all_comment_status'  # Allows user to see all comment status
-    EXPORT_TO_CSV = 'export_to_csv'  # Allows users to export comments to csv
     EXPORT_ALL_CAC_FORM_TO_SHEET = 'export_all_cac_form_to_sheet'  # Allows users to export CAC form to csv
     EXPORT_CAC_FORM_TO_SHEET = 'export_cac_form_to_sheet'  # Allows users to export CAC form to csv
     VIEW_ALL_SURVEY_RESULTS = 'view_all_survey_results'  # Allows users to view results to all questions
     UNPUBLISH_ENGAGEMENT = 'unpublish_engagement'
+    EXPORT_ALL_TO_CSV = 'export_all_to_csv'
+    EXPORT_INTERNAL_COMMENT_SHEET = 'export_internal_comment_sheet'
+    EXPORT_PROPONENT_COMMENT_SHEET = 'export_proponent_comment_sheet'

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -330,8 +330,11 @@ class TestJwtClaims(dict, Enum):
                 'review_all_comments',
                 'view_all_engagements',
                 'toggle_user_status',
-                'export_to_csv',
+                'export_all_to_csv',
                 'update_user_group',
+                'export_proponent_comment_sheet',
+                'export_internal_comment_sheet'
+                
             ]
         }
     }
@@ -350,7 +353,8 @@ class TestJwtClaims(dict, Enum):
                 'staff',
                 'view_engagement',
                 'view_users',
-                'clone_survey'
+                'clone_survey',
+                'export_proponent_comment_sheet'
             ]
         }
     }

--- a/met-web/src/components/comments/admin/textListing/index.tsx
+++ b/met-web/src/components/comments/admin/textListing/index.tsx
@@ -30,6 +30,9 @@ import { getStaffCommentSheet, getProponentCommentSheet } from 'services/comment
 import { downloadFile } from 'utils';
 import { getSurvey } from 'services/surveyService';
 import { Survey, createDefaultSurvey } from 'models/survey';
+import { PermissionsGate } from 'components/permissionsGate';
+import { HTTP_STATUS_CODES } from 'constants/httpResponseCodes';
+import axios, { AxiosError } from 'axios';
 
 const CommentTextListing = () => {
     const { roles, userDetail, assignedEngagements } = useAppSelector((state) => state.user);
@@ -68,28 +71,62 @@ const CommentTextListing = () => {
     const [exportToCSVOpen, setExportToCSVOpen] = useState(false);
     const [isExporting, setIsExporting] = useState(false);
     const [survey, setSurvey] = useState<Survey>(createDefaultSurvey());
+
     const handleExportStaffComments = async () => {
-        setIsExporting(true);
-        const response = await getStaffCommentSheet({ survey_id: survey.id });
-        downloadFile(response, `INTERNAL ONLY - ${survey.engagement?.name || ''} - ${formatToUTC(Date())}.csv`);
-        setIsExporting(false);
-        handleExportToCSVClose(); // Close the menu after export
+        try {
+            setIsExporting(true);
+            const response = await getStaffCommentSheet({ survey_id: survey.id });
+            downloadFile(response, `INTERNAL ONLY - ${survey.engagement?.name || ''} - ${formatToUTC(Date())}.csv`);
+            setIsExporting(false);
+            handleExportToCSVClose(); // Close the menu after export
+        } catch (error) {
+            setIsExporting(false);
+            dispatch(
+                openNotification({
+                    severity: 'error',
+                    text: 'Error occurred while exporting comments. Please try again later.',
+                }),
+            );
+        }
     };
+
     const handleExportProponentComments = async () => {
-        setIsExporting(true);
-        const response = await getProponentCommentSheet({ survey_id: survey.id });
-        downloadFile(response, `PUBLIC - ${survey.engagement?.name || ''} - ${formatToUTC(Date())}.csv`);
-        setIsExporting(false);
-        handleExportToCSVClose(); // Close the menu after export
+        try {
+            setIsExporting(true);
+            const response = await getProponentCommentSheet({ survey_id: survey.id });
+            downloadFile(response, `PUBLIC - ${survey.engagement?.name || ''} - ${formatToUTC(Date())}.csv`);
+            setIsExporting(false);
+            handleExportToCSVClose(); // Close the menu after export
+        } catch (error) {
+            setIsExporting(false);
+            if (axios.isAxiosError(error) && error.response?.status === HTTP_STATUS_CODES.FORBIDDEN) {
+                dispatch(
+                    openNotification({
+                        severity: 'error',
+                        text: 'You do not have permission to export this data.',
+                    }),
+                );
+            } else {
+                dispatch(
+                    openNotification({
+                        severity: 'error',
+                        text: 'Error occurred while exporting comments. Please try again later.',
+                    }),
+                );
+            }
+        }
     };
+
     const handleExportToCSVOpen = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);
         setExportToCSVOpen(!exportToCSVOpen);
     };
+
     const handleExportToCSVClose = () => {
         setAnchorEl(null);
         setExportToCSVOpen(false);
     };
+
     const customStyle = {
         minWidth: '180px',
         width: '100%',
@@ -324,23 +361,28 @@ const CommentTextListing = () => {
                     <PrimaryButton component={Link} to={`/surveys/${submissions[0]?.survey_id || 0}/comments`}>
                         Return to Comments List
                     </PrimaryButton>
-                    <SecondaryButton
-                        variant="contained"
-                        onClick={handleExportToCSVOpen}
-                        aria-controls="simple-menu"
-                        aria-haspopup="true"
-                        disabled={isExporting}
-                        startIcon={
-                            <ExpandMoreIcon
-                                style={{
-                                    transition: 'transform 0.3s',
-                                    transform: exportToCSVOpen ? 'rotate(180deg)' : 'none',
-                                }}
-                            />
-                        }
+                    <PermissionsGate
+                        scopes={[USER_ROLES.EXPORT_INTERNAL_COMMENT_SHEET, USER_ROLES.EXPORT_PROPONENT_COMMENT_SHEET]}
+                        errorProps={{ disabled: true }}
                     >
-                        Export to CSV
-                    </SecondaryButton>
+                        <SecondaryButton
+                            variant="contained"
+                            onClick={handleExportToCSVOpen}
+                            aria-controls="simple-menu"
+                            aria-haspopup="true"
+                            loading={isExporting}
+                            startIcon={
+                                <ExpandMoreIcon
+                                    style={{
+                                        transition: 'transform 0.3s',
+                                        transform: exportToCSVOpen ? 'rotate(180deg)' : 'none',
+                                    }}
+                                />
+                            }
+                        >
+                            Export to CSV
+                        </SecondaryButton>
+                    </PermissionsGate>
                     <Menu
                         id="simple-menu"
                         anchorEl={anchorEl}
@@ -351,9 +393,11 @@ const CommentTextListing = () => {
                         <MenuItem onClick={handleExportProponentComments} style={customStyle}>
                             Public/Proponent
                         </MenuItem>
-                        <MenuItem onClick={handleExportStaffComments} style={customStyle}>
-                            Internal Only/Detailed
-                        </MenuItem>
+                        <PermissionsGate scopes={[USER_ROLES.EXPORT_INTERNAL_COMMENT_SHEET]}>
+                            <MenuItem onClick={handleExportStaffComments} style={customStyle}>
+                                Internal Only/Detailed
+                            </MenuItem>
+                        </PermissionsGate>
                     </Menu>
                 </Stack>
             </Grid>

--- a/met-web/src/components/common/index.tsx
+++ b/met-web/src/components/common/index.tsx
@@ -118,15 +118,31 @@ export const WidgetButton = ({ children, ...rest }: { children: React.ReactNode;
     </StyledWidgetButton>
 );
 
-export const SecondaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
-    <StyledSecondaryButton
-        {...rest}
-        variant="outlined"
-        loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
-    >
-        {children}
-    </StyledSecondaryButton>
-);
+export const SecondaryButton = ({
+    children,
+    disabled = false,
+    ...rest
+}: {
+    children: React.ReactNode;
+    [prop: string]: unknown;
+}) => {
+    if (disabled) {
+        return (
+            <PrimaryButton {...rest} disabled>
+                {children}
+            </PrimaryButton>
+        );
+    }
+    return (
+        <StyledSecondaryButton
+            {...rest}
+            variant="outlined"
+            loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
+        >
+            {children}
+        </StyledSecondaryButton>
+    );
+};
 
 export const PrimaryButton = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => (
     <StyledPrimaryButton

--- a/met-web/src/services/userService/constants.ts
+++ b/met-web/src/services/userService/constants.ts
@@ -33,8 +33,10 @@ export const USER_ROLES = {
     VIEW_FEEDBACKS: 'view_feedbacks',
     SHOW_ALL_COMMENT_STATUS: 'show_all_comment_status',
     TOGGLE_USER_STATUS: 'toggle_user_status',
-    EXPORT_TO_CSV: 'export_to_csv',
     VIEW_ALL_SURVEY_RESULTS: 'view_all_survey_results',
     EXPORT_CAC_FORM_TO_SHEET: 'export_cac_form_to_sheet',
     EXPORT_ALL_CAC_FORM_TO_SHEET: 'export_all_cac_form_to_sheet',
+    EXPORT_ALL_TO_CSV: 'export_all_to_csv',
+    EXPORT_INTERNAL_COMMENT_SHEET: 'export_internal_comment_sheet',
+    EXPORT_PROPONENT_COMMENT_SHEET: 'export_proponent_comment_sheet',
 };


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2238

*Description of changes:*
- Restrict exporting internal sheet to superuser
- Restrict exporting proponent report to assigned team members
- Make secondary button primary disabled when it is disabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
