### PR TITLE
updating Docker file base Image

### DIFF
--- a/met-web/Dockerfile
+++ b/met-web/Dockerfile
@@ -1,6 +1,6 @@
 # "build-stage", based on Node.js, to build and compile the frontend
 # pull official base image
-FROM node:14-alpine as build-stage
+FROM node:16-alpine as build-stage
 
 # set working directory
 WORKDIR /app


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*
- Updating base image to node 16 in order to fix failing image build stage 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
