### PR TITLE
Persist engagement banner after save is pressed

### DIFF
--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementForm.tsx
@@ -22,6 +22,7 @@ const EngagementForm = () => {
         isSaving,
         savedEngagement,
         handleAddBannerImage,
+        fetchEngagement,
     } = useContext(ActionContext);
 
     const {
@@ -162,15 +163,14 @@ const EngagementForm = () => {
             return;
         }
 
-        const engagement = await handleUpdateEngagementRequest({
+        await handleUpdateEngagementRequest({
             ...engagementFormData,
             rich_description: richDescription,
             rich_content: richContent,
             status_block: surveyBlockList,
         });
 
-        navigate(`/engagements/${engagement.id}/form`);
-
+        fetchEngagement();
         return savedEngagement;
     };
 


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/1433

*Description of changes:*
- fetch engagement after update it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
