### PR TITLE
update metadata after opened

### DIFF
--- a/met-api/src/met_api/models/engagement_metadata.py
+++ b/met-api/src/met_api/models/engagement_metadata.py
@@ -38,7 +38,10 @@ class EngagementMetadataModel(BaseModel):
             return None
         update_fields = dict(
             project_id=engagement_metadata_data.get('project_id', engagement_metadata.project_id),
-            project_metadata=engagement_metadata_data.get('project_metadata', engagement_metadata.project_metadata),
+            project_metadata= {
+                **engagement_metadata.project_metadata,
+                **engagement_metadata_data.get('project_metadata', {})
+            },
         )
         query.update(update_fields)
         db.session.commit()

--- a/met-api/src/met_api/resources/engagement.py
+++ b/met-api/src/met_api/resources/engagement.py
@@ -58,7 +58,7 @@ class Engagement(Resource):
             return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
-@cors_preflight('GET, POST, PUT, PATCH, OPTIONS')
+@cors_preflight('GET, POST, PATCH, OPTIONS')
 @API.route('/')
 class Engagements(Resource):
     """Resource for managing engagements."""
@@ -131,26 +131,6 @@ class Engagements(Resource):
             engagement_schema = EngagementSchema()
             engagement_model = EngagementService().create_engagement(requestjson)
             return engagement_schema.dump(engagement_model), HTTPStatus.OK
-        except KeyError as err:
-            return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
-        except ValueError as err:
-            return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
-        except ValidationError as err:
-            return str(err.messages), HTTPStatus.INTERNAL_SERVER_ERROR
-
-    @staticmethod
-    # @TRACER.trace()
-    @cross_origin(origins=allowedorigins())
-    @require_role([Role.EDIT_ENGAGEMENT.value])
-    def put():
-        """Update saved engagement."""
-        try:
-            requestjson = request.get_json()
-            engagment_schema = EngagementSchema().load(requestjson)
-            user_id = TokenInfo.get_id()
-            engagment_schema['updated_by'] = user_id
-            EngagementService().update_engagement(engagment_schema)
-            return engagment_schema, HTTPStatus.OK
         except KeyError as err:
             return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
         except ValueError as err:

--- a/met-api/src/met_api/services/engagement_metadata_service.py
+++ b/met-api/src/met_api/services/engagement_metadata_service.py
@@ -71,8 +71,6 @@ class EngagementMetadataService:
             engagement_id=engagement_id
         )
 
-        EngagementMetadataService.validate_engagement_for_update(engagement_id)
-
         saved_metadata = EngagementMetadataModel.find_by_id(engagement_id)
 
         if saved_metadata:
@@ -84,10 +82,3 @@ class EngagementMetadataService:
         ProjectService.update_project_info(updated_metadata.project_id, updated_metadata.engagement_id)
 
         return updated_metadata
-
-    @staticmethod
-    def validate_engagement_for_update(engagement_id: int):
-        """Validate engagement can be edited."""
-        engagement: EngagementModel = EngagementModel.find_by_id(engagement_id)
-        if engagement.status_id == SubmissionStatus.Open.value:
-            raise ValueError('Engagement is already published, cannot update metadata.')

--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -196,28 +196,6 @@ class EngagementService:
         new_status_block.save_status_blocks(status_blocks)
 
     @staticmethod
-    def validate_engagement_status_update(engagement: EngagementModel):
-        """Validate engagement not published."""
-        if engagement.status_id == SubmissionStatus.Open.value:
-            raise ValueError('Cannot update published engagement')
-
-    def update_engagement(self, request_json: dict):
-        """Update engagement."""
-        self.validate_fields(request_json)
-        engagement_id = request_json.get('id', None)
-        authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.EDIT_ENGAGEMENT.value), engagement_id=engagement_id)
-
-        saved_engagement = EngagementModel.find_by_id(engagement_id)
-        self.validate_engagement_status_update(saved_engagement)
-
-        engagement = EngagementModel.update_engagement(request_json)
-        if (status_block := request_json.get('status_block')) is not None:
-            EngagementService._save_or_update_eng_block(engagement_id, status_block)
-
-        return engagement
-
-    @staticmethod
     def _save_or_update_eng_block(engagement_id, status_block):
         for survey_block in status_block:
             # see if there is one existing for the status ;if not create one
@@ -238,12 +216,27 @@ class EngagementService:
                 new_status_block.save()
 
     @staticmethod
+    def _validate_engagement_edit_data(engagement_id: int, data: dict):
+        engagement = EngagementModel.find_by_id(engagement_id)
+        draft_status_restricted_changes = (EngagementModel.is_internal.key,)
+        engagement_has_been_opened = engagement.status_id != Status.Draft.value
+        if engagement_has_been_opened and any([field in data for field in draft_status_restricted_changes]):
+            raise ValueError('Some fields cannot be updated after the engagement has been published')
+
+    @staticmethod
     def edit_engagement(data: dict):
         """Update engagement partially."""
         survey_block = data.pop('status_block', None)
         engagement_id = data.get('id', None)
-        authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.EDIT_ENGAGEMENT.value), engagement_id=engagement_id)
+        authorization.check_auth(
+            one_of_roles=(
+                MembershipType.TEAM_MEMBER.name,
+                Role.EDIT_ENGAGEMENT.value
+            ),
+            engagement_id=engagement_id
+        )
+
+        EngagementService._validate_engagement_edit_data(engagement_id, data)
         if data:
             updated_engagement = EngagementModel.edit_engagement(data)
             if not updated_engagement:

--- a/met-api/src/met_api/services/engagement_settings_service.py
+++ b/met-api/src/met_api/services/engagement_settings_service.py
@@ -64,8 +64,6 @@ class EngagementSettingsService:
             engagement_id=engagement_id
         )
 
-        EngagementSettingsService.validate_engagement_for_update(engagement_id)
-
         saved_settings = EngagementSettingsModel.find_by_id(engagement_id)
 
         if saved_settings:
@@ -74,10 +72,3 @@ class EngagementSettingsService:
             updated_settings = EngagementSettingsService._create_settings_model(data)
 
         return updated_settings
-
-    @staticmethod
-    def validate_engagement_for_update(engagement_id: int):
-        """Validate engagement can be edited."""
-        engagement: EngagementModel = EngagementModel.find_by_id(engagement_id)
-        if engagement.status_id == SubmissionStatus.Open.value:
-            raise ValueError('Engagement is already published, cannot update settings.')

--- a/met-web/src/components/engagement/form/EngagementFormTabs/Settings/EngagementInformation.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/Settings/EngagementInformation.tsx
@@ -46,7 +46,6 @@ const EngagementInformation = () => {
                     variant="outlined"
                     fullWidth
                     onChange={handleChangeMetadata}
-                    disabled={hasBeenOpened}
                 />
             </Grid>
             <Grid item xs={12} lg={6} p={1}>
@@ -58,7 +57,6 @@ const EngagementInformation = () => {
                     variant="outlined"
                     fullWidth
                     onChange={handleChangeMetadata}
-                    disabled={hasBeenOpened}
                 />
             </Grid>
             <Grid item xs={12} lg={6} p={1}>
@@ -70,7 +68,6 @@ const EngagementInformation = () => {
                     variant="outlined"
                     fullWidth
                     onChange={handleChange}
-                    disabled={hasBeenOpened}
                 />
             </Grid>
             <Grid item xs={12} lg={6} p={1}>
@@ -85,7 +82,6 @@ const EngagementInformation = () => {
                     fullWidth
                     size="small"
                     onChange={handleChangeMetadata}
-                    disabled={hasBeenOpened}
                 >
                     <MenuItem value={''} sx={{ fontStyle: 'italic', height: '2em' }}>
                         none
@@ -108,7 +104,6 @@ const EngagementInformation = () => {
                     variant="outlined"
                     fullWidth
                     onChange={handleChangeMetadata}
-                    disabled={hasBeenOpened}
                 />
             </Grid>
         </Grid>

--- a/met-web/src/components/engagement/form/EngagementFormTabs/Settings/SendReport.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/Settings/SendReport.tsx
@@ -44,7 +44,7 @@ const SendReport = () => {
                                     }
                                     setSendReport(!sendReport);
                                 }}
-                                disabled={settingsLoading || hasBeenOpened}
+                                // disabled={settingsLoading || hasBeenOpened}
                             />
                         }
                         sx={{ fontWeight: 'bold' }}


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/2263

*Description of changes:*
- enable settings field after engagement open
- Add check for changing is_internal after open
- Remove unused PUT resource
- Fix engagement settings bug where metadata fields are cleared if one is updated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
