### PR TITLE
Fix link to read all comments guide and survey results question highlight

### DIFF
--- a/met-web/src/components/layout/SideNav/UserGuideNav.tsx
+++ b/met-web/src/components/layout/SideNav/UserGuideNav.tsx
@@ -19,7 +19,7 @@ const UserGuideNav = () => {
         '/surveys/1/build': `${HELP_URL}/posts/survey-builder/`,
         '/surveys/1/submit': `${HELP_URL}/posts/survey-builder/`,
         '/surveys/1/comments': `${HELP_URL}/posts/comments-listing/`,
-        '/surveys/1/comments/all': `${HELP_URL}/posts/read-all-comments-page/`,
+        '/surveys/1/comments/all': `${HELP_URL}/posts/read-all-comments/`,
         '/surveys/1/submissions/1/review': `${HELP_URL}/posts/comment-review-page/`,
         '/engagements/create/form': `${HELP_URL}/posts/create-engagement/`,
         '/engagements/1/form': `${HELP_URL}/posts/engagement-details/`,

--- a/met-web/src/components/publicDashboard/SurveyBar/index.tsx
+++ b/met-web/src/components/publicDashboard/SurveyBar/index.tsx
@@ -29,7 +29,7 @@ export const SurveyBar = ({ readComments, engagement, engagementIsLoading, dashb
     const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
     const [data, setData] = useState<SurveyResultData | null>(null);
     const [selectedData, setSelectedData] = useState(defaultData[0]);
-    const [selectedDataIndex, setSelectedDataIndex] = useState(-1);
+    const [selectedDataIndex, setSelectedDataIndex] = useState(0);
     const [isLoading, setIsLoading] = useState(true);
     const [isError, setIsError] = useState(false);
     const [chartType, setChartType] = React.useState('bar');


### PR DESCRIPTION
Issue #:

*Description of changes:*
- Fix navigation to user guide for read all comments
- Choose first question survey results by default


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
