### PR TITLE
Added refreshed tokens to session storage

### DIFF
--- a/met-web/src/services/userService/index.ts
+++ b/met-web/src/services/userService/index.ts
@@ -78,6 +78,16 @@ const refreshToken = (dispatch: Dispatch<Action>) => {
                 const refreshed = await KeycloakData.updateToken(3000);
                 if (refreshed) {
                     dispatch(userToken(KeycloakData.token));
+                    // Check if tokens are defined before storing them in session storage
+                    if (KeycloakData.token) {
+                        sessionStorage.setItem('accessToken', KeycloakData.token);
+                    }
+                    if (KeycloakData.idToken) {
+                        sessionStorage.setItem('idToken', KeycloakData.idToken);
+                    }
+                    if (KeycloakData.refreshToken) {
+                        sessionStorage.setItem('refreshToken', KeycloakData.refreshToken);
+                    }
                 }
             } catch (error) {
                 console.log(error);


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*

Once token is refreshed , the new refreshed token is stored in the session storage


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
