### PR TITLE
Made slug url case insensitive , Fixed bug with wrong query join for submission

### DIFF
--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -134,13 +134,12 @@ class Comment(BaseModel):
         """Get submissions by survey id paginated."""
         null_value = None
         query = db.session.query(Submission)\
-            .join(Comment, Submission.id == Comment.submission_id)\
             .filter(and_(Submission.survey_id == survey_id,
-                         or_(Submission.reviewed_by != 'System', Submission.reviewed_by == null_value)))\
+                         or_(Submission.reviewed_by != 'System', Submission.reviewed_by == null_value)))
 
         if search_text:
             # Remove all non-digit characters from search text
-            query = query.filter(Comment.text.ilike('%' + search_text + '%'))
+            query = query.filter(Submission.comments.any(Comment.text.ilike('%' + search_text + '%')))
 
         if advanced_search_filters:
             query = cls._filter_by_advanced_filters(query, advanced_search_filters)

--- a/met-api/src/met_api/models/engagement_slug.py
+++ b/met-api/src/met_api/models/engagement_slug.py
@@ -26,7 +26,7 @@ class EngagementSlug(BaseModel):
     @classmethod
     def find_by_slug(cls, slug):
         """Return engagement slug by slug."""
-        return cls.query.filter_by(slug=slug).first()
+        return cls.query.filter(cls.slug.ilike(slug)).first()
 
     @classmethod
     def find_by_engagement_id(cls, engagement_id):

--- a/met-api/src/met_api/schemas/engagement.py
+++ b/met-api/src/met_api/schemas/engagement.py
@@ -82,9 +82,6 @@ class EngagementSchema(Schema):
         # Strip time off datetime object
         date_due = datetime(now.year, now.month, now.day)
 
-        print('--date_due-:',date_due)
-        print('-start_date -:', obj.start_date )
-        print('--end_date -:', obj.end_date)
         if obj.start_date <= date_due <= obj.end_date:
             return SubmissionStatus.Open.value
 


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*

- add the find by method for slug to behave case-insensitive..so that something like engage.eao.gov.bc.ca/my-test-eng and engage.eao.gov.bc.ca/MY-TEST-ENG works
- removed some unnecessary print statements
- Handled big with submission fetch.. the query was fetching multiple records of submissions since it was doing an inner join with comments table and there for it messed up the pagination/sort order etc.Handled it in a different way so that no join is manually done.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
