### PR TITLE
Feature/deseng438 - Superusers can publish engagements without attached surveys

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,30 +1,20 @@
-# Change Log
+## November 29, 2023
+- **Feature** Superusers can publish engagements without attached surveys [🎟️DESENG-438](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-438)
 
-All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
+## November 11, 2023
+- **Feature**: Started logging source url path with feedback submission. Viewable in dashboard. [🎟️DESENG-415](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-415)
+- **Bug Fix**: Removed a duplicate service class. [🎟️DESENG-429](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-429)
 
-## v1.1.0 - 2023-11-21
-
-> **Feature**: Started logging source url path with feedback submission. Viewable in dashboard. [🎟️DESENG-415](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-415)
-
-> **Bug Fix**: Removed a duplicate service class. [🎟️DESENG-429](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-429)
-
-
-## v1.0.1 - 2023-10-26
-
-> **Bug Fix**: Upgraded BC-Sans font to newest version. [🎟️DESENG-413](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-413)
-
-> **Bug Fix**: Engagements will now open in the same browser window/tab, not a new one. [🎟️DESENG-421](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-421)
-
-> **Bug Fix**: Update sample .env files - [🎟️DESENG-414](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-414)
->- Sample .env files have been updated to reflect the current state of the project.
->- *Breaking*: Keycloak URLs and resources now point to the BC Government's SSO service when using `sample.env` as a baseline
->- *Breaking*: The `met_api` module has been updated slightly to consume Pathfinder SSO's API schema.
-
+## October 26, 2023
+- **Bug Fix**: Upgraded BC-Sans font to newest version. [🎟️DESENG-413](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-413)
+- **Bug Fix**: Engagements will now open in the same browser window/tab, not a new one. [🎟️DESENG-421](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-421)
+- **Bug Fix**: Update sample .env files - [🎟️DESENG-414](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-414)
+- Sample .env files have been updated to reflect the current state of the project.
+- *Breaking*: Keycloak URLs and resources now point to the BC Government's SSO service when using `sample.env` as a baseline
+- *Breaking*: The `met_api` module has been updated slightly to consume Pathfinder SSO's API schema.
 - Changes to `DEVELOPMENT.md` to reflect the current state of the project
 - Remove one old production .env file with obsolete settings
 
-
-## v1.0.0 - 2023-10-01
-
+## October 1, 2023
 - App handoff from EAO to GDX
 - Added changelog

--- a/met-api/docker-compose.yml
+++ b/met-api/docker-compose.yml
@@ -1,27 +1,27 @@
 version: "3.9"
 
 services:
-  keycloak:
-    image: quay.io/keycloak/keycloak:12.0.2
-    ports:
-      - "8081:8081"
-    environment:
-      - KEYCLOAK_USER=admin
-      - KEYCLOAK_PASSWORD=admin
-    command: -b 0.0.0.0 -Djboss.http.port=8081 -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/tmp/keycloak/test -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "--fail",
-          "http://localhost:8081/auth/realms/demo || exit 1",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 10
-    volumes:
-      - ./setup:/tmp/keycloak/test/
+  # keycloak:
+  #   image: quay.io/keycloak/keycloak:12.0.2
+  #   ports:
+  #     - "8081:8081"
+  #   environment:
+  #     - KEYCLOAK_USER=admin
+  #     - KEYCLOAK_PASSWORD=admin
+  #   command: -b 0.0.0.0 -Djboss.http.port=8081 -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/tmp/keycloak/test -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
+  #   healthcheck:
+  #     test:
+  #       [
+  #         "CMD",
+  #         "curl",
+  #         "--fail",
+  #         "http://localhost:8081/auth/realms/demo || exit 1",
+  #       ]
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 10
+  #   volumes:
+  #     - ./setup:/tmp/keycloak/test/
   met-db:
     image: postgres
     volumes:

--- a/met-web/src/components/engagement/view/EngagementView.tsx
+++ b/met-web/src/components/engagement/view/EngagementView.tsx
@@ -92,9 +92,13 @@ export const EngagementView = () => {
                                 <Grid data-testid={'engagement-content'} item xs={12}>
                                     <EngagementContent />
                                 </Grid>
-                                <Grid item xs={12}>
-                                    <SurveyBlock startSurvey={handleStartSurvey} />
-                                </Grid>
+                                <If condition={surveyId !== ''}>
+                                    <Then>
+                                        <Grid item xs={12}>
+                                            <SurveyBlock startSurvey={handleStartSurvey} />
+                                        </Grid>
+                                    </Then>
+                                </If>
                             </Grid>
                             <Grid item data-testid={'widget-block'} xs={12} lg={4}>
                                 <WidgetBlock />
@@ -107,9 +111,13 @@ export const EngagementView = () => {
                             <Grid item data-testid={'widget-block'} xs={12}>
                                 <WidgetBlock />
                             </Grid>
-                            <Grid item xs={12}>
-                                <SurveyBlock startSurvey={handleStartSurvey} />
-                            </Grid>
+                            <If condition={surveyId !== ''}>
+                                <Then>
+                                    <Grid item xs={12}>
+                                        <SurveyBlock startSurvey={handleStartSurvey} />
+                                    </Grid>
+                                </Then>
+                            </If>
                         </Else>
                     </If>
                 </Grid>


### PR DESCRIPTION
Superusers can publish engagements without attached surveys.

I've commented out a section of the met-api docker compose that doesn't need to be run locally but have left it intact for now in case we need it for other tickets(such as DESENG-436).

I've also changed the structure of the CHANGELOG per our discussions today about deployment with a "rolling-release" system. Dates would the new headers as they do with the PMO project: https://github.com/bcgov/gdx-agreements-tracker/blob/development/CHANGELOG.md. I've chosen to omit the ticket number from the heading as we may do more than one ticket in a commit and/or add changes not encompassed by a ticket. Open to the team's feedback on how our CHANGELOG should look going forward!

Finally, I've chosen to merge into gdx-dev(the original parent of this feature branch) or now as we still need to have a discussion as developers as to how we're going to branch.
