### PR TITLE
Implemented floating save/preview buttons for engagement editing

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## February 16, 2024
+- **Task**Make a floating save/preview bar when editing engagements [DESENG-498](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-498)
+    - Implemented a floating behavior for the save/preview buttons during engagement editing. This feature persists across all tabs but exclusively saves data for the Engagement Content tab.
+
 ## February 15, 2024
 - **Task**Restore role assignment functionality to MET with the CSS API [DESENG-473](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-473)
     - Utilize the CSS API for efficient management of composite roles. This involves the assignment, reassignment, or removal of users from the composite roles of TEAM_MEMBER, REVIEWER, IT_ADMIN, or IT_VIEWER.

--- a/met-web/src/components/engagement/form/EngagementFormTabs/AdditionalDetails/AdditionalTabContent.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/AdditionalDetails/AdditionalTabContent.tsx
@@ -1,13 +1,16 @@
 import React, { useContext } from 'react';
-import { Divider, Grid } from '@mui/material';
-import { MetPaper, PrimaryButton } from 'components/common';
+import { Divider, Grid, Box } from '@mui/material';
+import { MetPaper, PrimaryButton, SecondaryButton } from 'components/common';
 import ConsentMessage from './ConsentMessage';
 import EngagementInformation from './EngagementInformation';
-
+import { EngagementTabsContext } from '../EngagementTabsContext';
+import { ActionContext } from '../../ActionContext';
 import { AdditionalDetailsContext } from './AdditionalDetailsContext';
 
 const AdditionalTabContent = () => {
     const { handleSaveAdditional, updatingAdditional } = useContext(AdditionalDetailsContext);
+    const { isSaving } = useContext(ActionContext);
+    const { handleSaveEngagement, handlePreviewEngagement } = useContext(EngagementTabsContext);
 
     return (
         <MetPaper elevation={1}>
@@ -33,6 +36,36 @@ const AdditionalTabContent = () => {
                         Save
                     </PrimaryButton>
                 </Grid>
+                <Box
+                    position="sticky"
+                    bottom={0}
+                    width="100%"
+                    borderTop="1px solid #ddd"
+                    padding={2}
+                    marginTop={2}
+                    marginLeft={2}
+                    zIndex={1000}
+                    boxShadow="0px 0px 5px rgba(0, 0, 0, 0.1)"
+                    sx={{ backgroundColor: 'white' }}
+                >
+                    <Grid item xs={12}>
+                        <PrimaryButton
+                            sx={{ marginRight: 1 }}
+                            data-testid="create-engagement-button"
+                            onClick={() => handleSaveEngagement()}
+                            loading={isSaving}
+                        >
+                            Save
+                        </PrimaryButton>
+                        <SecondaryButton
+                            data-testid="preview-engagement-button"
+                            onClick={() => handlePreviewEngagement()}
+                            disabled={isSaving}
+                        >
+                            {'Preview'}
+                        </SecondaryButton>
+                    </Grid>
+                </Box>
             </Grid>
         </MetPaper>
     );

--- a/met-web/src/components/engagement/form/EngagementFormTabs/Settings/EngagementSettingsForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/Settings/EngagementSettingsForm.tsx
@@ -1,13 +1,17 @@
 import React, { useContext } from 'react';
-import { Divider, Grid } from '@mui/material';
-import { MetPaper, PrimaryButton } from 'components/common';
+import { Divider, Grid, Box } from '@mui/material';
+import { MetPaper, PrimaryButton, SecondaryButton } from 'components/common';
 import InternalEngagement from './InternalEngagement';
 import SendReport from './SendReport';
 import { EngagementSettingsContext } from './EngagementSettingsContext';
 import { PublicUrls } from './PublicUrls';
+import { EngagementTabsContext } from '../EngagementTabsContext';
+import { ActionContext } from '../../ActionContext';
 
 const EngagementSettingsForm = () => {
     const { handleSaveSettings, updatingSettings } = useContext(EngagementSettingsContext);
+    const { isSaving } = useContext(ActionContext);
+    const { handleSaveEngagement, handlePreviewEngagement } = useContext(EngagementTabsContext);
 
     return (
         <MetPaper elevation={1}>
@@ -39,6 +43,36 @@ const EngagementSettingsForm = () => {
                 <Grid item xs={12}>
                     <PublicUrls />
                 </Grid>
+                <Box
+                    position="sticky"
+                    bottom={0}
+                    width="100%"
+                    borderTop="1px solid #ddd"
+                    padding={2}
+                    marginTop={2}
+                    marginLeft={2}
+                    zIndex={1000}
+                    boxShadow="0px 0px 5px rgba(0, 0, 0, 0.1)"
+                    sx={{ backgroundColor: 'white' }}
+                >
+                    <Grid item xs={12}>
+                        <PrimaryButton
+                            sx={{ marginRight: 1 }}
+                            data-testid="create-engagement-button"
+                            onClick={() => handleSaveEngagement()}
+                            loading={isSaving}
+                        >
+                            Save
+                        </PrimaryButton>
+                        <SecondaryButton
+                            data-testid="preview-engagement-button"
+                            onClick={() => handlePreviewEngagement()}
+                            disabled={isSaving}
+                        >
+                            {'Preview'}
+                        </SecondaryButton>
+                    </Grid>
+                </Box>
             </Grid>
         </MetPaper>
     );

--- a/met-web/src/components/engagement/form/EngagementFormTabs/UserManagement/EngagementUserManagement.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/UserManagement/EngagementUserManagement.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
-import { Grid } from '@mui/material';
-import { MetLabel, MetPaper, PrimaryButton, MetParagraph } from 'components/common';
+import { Grid, Box } from '@mui/material';
+import { MetLabel, MetPaper, PrimaryButton, SecondaryButton, MetParagraph } from 'components/common';
 import { ActionContext } from '../../ActionContext';
 import { EngagementTabsContext } from '../EngagementTabsContext';
 import { formatDate } from 'components/common/dateHelper';
 import TeamMemberListing from './TeamMemberListing';
 
 const EngagementUserManagement = () => {
-    const { savedEngagement } = useContext(ActionContext);
-    const { setAddTeamMemberOpen } = useContext(EngagementTabsContext);
+    const { isSaving, savedEngagement } = useContext(ActionContext);
+    const { handleSaveEngagement, handlePreviewEngagement, setAddTeamMemberOpen } = useContext(EngagementTabsContext);
 
     return (
         <MetPaper elevation={1}>
@@ -46,6 +46,35 @@ const EngagementUserManagement = () => {
                     <Grid item xs={12}>
                         <TeamMemberListing />
                     </Grid>
+                    <Box
+                        position="sticky"
+                        bottom={0}
+                        width="100%"
+                        borderTop="1px solid #ddd"
+                        padding={2}
+                        marginTop={2}
+                        zIndex={1000}
+                        boxShadow="0px 0px 5px rgba(0, 0, 0, 0.1)"
+                        sx={{ backgroundColor: 'white' }}
+                    >
+                        <Grid item xs={12}>
+                            <PrimaryButton
+                                sx={{ marginRight: 1 }}
+                                data-testid="create-engagement-button"
+                                onClick={() => handleSaveEngagement()}
+                                loading={isSaving}
+                            >
+                                Save
+                            </PrimaryButton>
+                            <SecondaryButton
+                                data-testid="preview-engagement-button"
+                                onClick={() => handlePreviewEngagement()}
+                                disabled={isSaving}
+                            >
+                                {'Preview'}
+                            </SecondaryButton>
+                        </Grid>
+                    </Box>
                 </Grid>
             </Grid>
         </MetPaper>

--- a/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
@@ -98,7 +98,7 @@ describe('Engagement form page tests', () => {
             expect(getByText('Engagement Name')).toBeInTheDocument();
             expect(container.querySelector('span.MuiSkeleton-root')).toBeNull();
         });
-        expect(screen.getByTestId('create-engagement-button')).toBeVisible();
+        expect(screen.getByTestId('save-engagement-button')).toBeVisible();
         expect(getEngagementMock).not.toHaveBeenCalled();
         expect(getEngagementMetadataMock).not.toHaveBeenCalled();
 
@@ -125,7 +125,7 @@ describe('Engagement form page tests', () => {
         useParamsMock.mockReturnValue({ engagementId: 'create' });
         const { container, getByTestId } = render(<EngagementForm />);
 
-        const createButton = getByTestId('create-engagement-button');
+        const createButton = getByTestId('save-engagement-button');
         fireEvent.click(createButton);
 
         expect(container.querySelectorAll('.Mui-error').length).toBeGreaterThan(0);

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
@@ -135,7 +135,7 @@ describe('Engagement form page tests', () => {
 
         expect(getEngagementMock).toHaveBeenCalledOnce();
         expect(getEngagementMetadataMock).toHaveBeenCalledOnce();
-        expect(screen.getByTestId('update-engagement-button')).toBeVisible();
+        expect(screen.getByTestId('save-engagement-button')).toBeVisible();
         expect(screen.getByDisplayValue('2022-09-01')).toBeInTheDocument();
         expect(screen.getByDisplayValue('2022-09-30')).toBeInTheDocument();
         expect(screen.getByText('Survey 1')).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('Engagement form page tests', () => {
         await waitFor(() => {
             expect(screen.getByDisplayValue('Test Engagement')).toBeInTheDocument();
         });
-        const updateButton = screen.getByTestId('update-engagement-button');
+        const updateButton = screen.getByTestId('save-engagement-button');
 
         const nameInput = container.querySelector('input[name="name"]');
         assert(nameInput, 'Unable to find engagement name input');


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-498

*Description of changes:*

Implemented a floating behavior for the save/preview buttons during engagement editing. This feature persists across all tabs but exclusively saves data for the Engagement Content tab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
