### PR TITLE
[To Main] DESENG-525: Resetting engagement list on reset button

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+## March 27, 2024
+
+- **Bug Fix**: MET - Engagement tab does not revert the filtered out data [DESENG-525](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-525)
+  - Resetting search filter values invoke the list to reload
+
 ## March 26, 2024
 
 - **Bug Fix**: Various bugs in the survey tab [DESENG-520](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-523)

--- a/met-web/src/components/engagement/listing/AdvancedSearch/SearchComponent.tsx
+++ b/met-web/src/components/engagement/listing/AdvancedSearch/SearchComponent.tsx
@@ -94,6 +94,14 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
             publishedFromDate: '',
             publishedToDate: '',
         });
+        // reset the search params to empty also invoke the list to reload
+        setFilterParams({
+            status_list: [],
+            created_from_date: '',
+            created_to_date: '',
+            published_from_date: '',
+            published_to_date: '',
+        });
     };
 
     return (


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-525

*Description of changes:*
Resetting search filter values invokes the list to reload

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
