### PR TITLE
[To Feature] DESENG-445/frontend

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,14 @@
   - Added a new endpoint to the API to retrieve filterable taxa.
   - Modified the search endpoint to allow filtering by metadata.
   - Added schemas, data validation and unit tests for the new functionality.
+  - Updated the Metadata Management UI to allow taxa to be marked as filterable.
+    - Currently, the only two filter types are `chips_any` and `chips_all`.
+    - `chips_any`: Displays as a series of toggleable buttons ("chips"), uses the `list_match_any` subquery returning engagements with any of the selected values.
+    - `chips_all`: Similar to chips_any; uses the `list_match_all` subquery to get only engagements with ALL of the selected values.
+  - If multiple filterable taxa are selected, all the taxon filters must be met for an engagement to be returned.
+  - Updated the public-facing engagement list to allow filtering by metadata taxa. This makes use of the new API endpoint to retrieve filterable taxa.
+  - Added a new filter "drawer" to the listing page to hold these and any future filter types.
+  - (Out of scope, but related to UX work for this ticket) Fixed a display issue with the public engagements page where engagements would not take up the full width of their grid cell.
 
 ## March 08, 2024
 

--- a/met-api/src/met_api/services/metadata_taxon_service.py
+++ b/met-api/src/met_api/services/metadata_taxon_service.py
@@ -46,12 +46,15 @@ class MetadataTaxonService:
                 else:
                     # Just use the preset values
                     values = taxon.preset_values
-                filters.append({
-                    'taxon_id': taxon.id,
-                    'name': taxon.name,
-                    'filter_type': taxon.filter_type,
-                    'values': values
-                })
+                # Don't return the filter if the user has no options; this prevents
+                # the frontend from displaying a useless filter
+                if values:
+                    filters.append({
+                        'taxon_id': taxon.id,
+                        'name': taxon.name,
+                        'filter_type': taxon.filter_type,
+                        'values': values
+                    })
         return MetadataTaxonFilterSchema(many=True).dump(filters)
 
     @staticmethod

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -17,6 +17,7 @@ const Endpoints = {
     },
     MetadataTaxa: {
         GET_BY_TENANT: `${AppConfig.apiUrl}/engagement_metadata/taxa`,
+        FILTER_BY_TENANT: `${AppConfig.apiUrl}/engagement_metadata/taxa/filters/`,
         REORDER: `${AppConfig.apiUrl}/engagement_metadata/taxa`,
         CREATE: `${AppConfig.apiUrl}/engagement_metadata/taxa`,
         GET: `${AppConfig.apiUrl}/engagement_metadata/taxon/taxon_id`,

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
@@ -383,7 +383,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
 
     const handleSaveEngagementMetadata = async () => {
         const result = await metadataFormRef.current?.submitForm();
-        if (!result) {
+        if (metadataFormRef.current && !result) {
             dispatch(
                 openNotification({
                     severity: 'error',

--- a/met-web/src/components/landing/DeletableFilterChip.tsx
+++ b/met-web/src/components/landing/DeletableFilterChip.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Chip } from '@mui/material';
+import { Close } from '@mui/icons-material';
+
+export const DeletableFilterChip = ({
+    name,
+    value,
+    onDelete,
+}: {
+    name: string;
+    value: string | number;
+    onDelete?: () => void;
+}) => {
+    return (
+        <Chip
+            label={name}
+            title={name}
+            aria-label={name + ' filter - press to delete'}
+            color="primary"
+            // replicate the delete icon on the left-hand side
+            icon={<Close fontSize="small" sx={{ opacity: 0.8, '&:hover': { opacity: 1 } }} />}
+            variant="outlined"
+            // enable deleting with backspace but hide the icon
+            deleteIcon={<span />}
+            onDelete={onDelete}
+            // make clicking anywhere on the chip also delete it (larger touch target)
+            onClick={onDelete}
+            sx={{
+                mt: '1px',
+                mr: 1,
+                mb: 2,
+                p: 1,
+                height: 48,
+                fontWeight: 'normal',
+                borderRadius: '2em',
+                maxWidth: '300px',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                fontSize: '14px',
+            }}
+        ></Chip>
+    );
+};

--- a/met-web/src/components/landing/DeletableFilterChip.tsx
+++ b/met-web/src/components/landing/DeletableFilterChip.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
 import { Chip } from '@mui/material';
 import { Close } from '@mui/icons-material';
+import { useAppTranslation } from 'hooks';
 
-export const DeletableFilterChip = ({
-    name,
-    value,
-    onDelete,
-}: {
-    name: string;
-    value: string | number;
-    onDelete?: () => void;
-}) => {
+export const DeletableFilterChip = ({ name, onDelete }: { name: string; onDelete?: () => void }) => {
+    const { t: translate } = useAppTranslation();
     return (
         <Chip
             label={name}
             title={name}
-            aria-label={name + ' filter - press to delete'}
+            aria-label={translate('landing.filters.aria.deleteFilterChip').replace('{0}', name)}
             color="primary"
             // replicate the delete icon on the left-hand side
             icon={<Close fontSize="small" sx={{ opacity: 0.8, '&:hover': { opacity: 1 } }} />}

--- a/met-web/src/components/landing/FilterBlock.tsx
+++ b/met-web/src/components/landing/FilterBlock.tsx
@@ -1,6 +1,4 @@
-// FilterBlock.js
-import React, { useEffect, useRef, useState } from 'react';
-import { useContext } from 'react';
+import React, { useEffect, useRef, useState, useContext } from 'react';
 import { LandingContext } from './LandingContext';
 import {
     Button,
@@ -15,11 +13,10 @@ import {
     useTheme,
 } from '@mui/material';
 import { DeletableFilterChip } from './DeletableFilterChip';
-import { Close, Check, HighlightOff, Tune } from '@mui/icons-material';
+import { Close, Check, HighlightOff, Tune, Search } from '@mui/icons-material';
 import { MetadataFilter } from 'components/metadataManagement/types';
 import { MetLabel } from 'components/common';
 import { debounce } from 'lodash';
-import { Search } from '@mui/icons-material';
 import { EngagementDisplayStatus } from 'constants/engagementStatus';
 
 const FilterBlock = () => {

--- a/met-web/src/components/landing/FilterBlock.tsx
+++ b/met-web/src/components/landing/FilterBlock.tsx
@@ -1,0 +1,304 @@
+// FilterBlock.js
+import React, { useEffect, useRef, useState } from 'react';
+import { useContext } from 'react';
+import { LandingContext } from './LandingContext';
+import {
+    Button,
+    Select,
+    MenuItem,
+    ListItemIcon,
+    ListItemText,
+    Grid,
+    TextField,
+    IconButton,
+    Stack,
+    useTheme,
+} from '@mui/material';
+import { DeletableFilterChip } from './DeletableFilterChip';
+import { Close, Check, HighlightOff, Tune } from '@mui/icons-material';
+import { MetadataFilter } from 'components/metadataManagement/types';
+import { MetLabel } from 'components/common';
+import { debounce } from 'lodash';
+import { Search } from '@mui/icons-material';
+import { EngagementDisplayStatus } from 'constants/engagementStatus';
+
+const FilterBlock = () => {
+    const { searchFilters, setSearchFilters, setPage, clearFilters, page, setDrawerOpened } =
+        useContext(LandingContext);
+    const selectedValue = searchFilters.status.length === 0 ? -1 : searchFilters.status[0];
+
+    const tileBlockRef = useRef<HTMLDivElement>(null);
+    const [didMount, setDidMount] = useState(false);
+
+    const selectableStatuses: number[] = [
+        EngagementDisplayStatus.Open,
+        EngagementDisplayStatus.Upcoming,
+        EngagementDisplayStatus.Closed,
+    ];
+
+    const theme = useTheme();
+
+    const debounceSetSearchFilters = useRef(
+        debounce((searchText: string) => {
+            setSearchFilters({
+                ...searchFilters,
+                name: searchText,
+            });
+        }, 300),
+    ).current;
+
+    useEffect(() => {
+        setDidMount(true);
+        return () => setDidMount(false);
+    }, []);
+
+    useEffect(() => {
+        if (didMount) {
+            const yOffset = tileBlockRef?.current?.offsetTop;
+            window.scrollTo({ top: yOffset || 0, behavior: 'smooth' });
+        }
+    }, [page]);
+
+    const [searchText, setSearchText] = useState('');
+
+    const handleDeleteFilterChip = (taxonId: number, value: string) => {
+        const newMetadataFilters = searchFilters.metadata
+            .map((filter: MetadataFilter) => {
+                if (filter.taxon_id === taxonId) {
+                    // Remove the value
+                    const newValues = filter.values.filter((v) => v !== value);
+                    return { ...filter, values: newValues };
+                }
+                return filter;
+            })
+            .filter((filter) => filter.values.length > 0); // Remove any filters with no values left
+
+        setSearchFilters({ ...searchFilters, metadata: newMetadataFilters });
+        setPage(1);
+    };
+
+    return (
+        <Grid container item xs={10} justifyContent="flex-start" alignItems="flex-start" rowSpacing={3}>
+            <Grid
+                container
+                item
+                xs={12}
+                justifyContent="flex-start"
+                alignItems="self-end"
+                columnSpacing={2}
+                rowSpacing={4}
+                marginTop="2em"
+                ref={tileBlockRef}
+            >
+                <Grid item xl={6} lg={8} md={10} sm={8} xs={12}>
+                    <MetLabel>Search Engagements</MetLabel>
+                    <TextField
+                        fullWidth
+                        placeholder="Engagement Title"
+                        value={searchText}
+                        onChange={(event) => {
+                            setSearchText(event.target.value);
+                            debounceSetSearchFilters(event.target.value);
+                        }}
+                        InputProps={{
+                            sx: { height: 48 },
+                            startAdornment: (
+                                <Search
+                                    sx={{
+                                        color: theme.palette.primary.main,
+                                        mr: 0.5,
+                                    }}
+                                />
+                            ),
+                            endAdornment: searchText ? (
+                                <IconButton
+                                    aria-label="clear search"
+                                    title="Clear search"
+                                    sx={{ color: '#9F9D9C' }}
+                                    onClick={() => {
+                                        setSearchFilters({
+                                            ...searchFilters,
+                                            name: '',
+                                        });
+                                        setSearchText('');
+                                    }}
+                                >
+                                    <HighlightOff />
+                                </IconButton>
+                            ) : undefined,
+                        }}
+                    />
+                </Grid>
+                <Grid
+                    item
+                    xs={12}
+                    sm={3}
+                    md={2}
+                    lg={2}
+                    xl={1}
+                    container
+                    justifyContent="flex-start"
+                    alignItems="flex-start"
+                >
+                    <Button
+                        fullWidth
+                        variant="contained"
+                        color="primary"
+                        startIcon={<Tune />}
+                        onClick={() => setDrawerOpened(true)}
+                        sx={{ height: 48 }}
+                    >
+                        Filter
+                    </Button>
+                </Grid>
+            </Grid>
+            <Grid item xs={12} container justifyContent="flex-start" alignItems="flex-start">
+                <Stack
+                    direction="row"
+                    sx={{ mb: 2 }}
+                    flexWrap="wrap"
+                    justifyContent="flex-start"
+                    alignItems="flex-start"
+                >
+                    <Select
+                        value={selectedValue}
+                        id="status-filter"
+                        onChange={(event) => {
+                            const selectedValue = Number(event.target.value);
+                            if (selectedValue === -1) {
+                                // Reset status filter to an empty array for "All Engagements"
+                                setSearchFilters({
+                                    ...searchFilters,
+                                    status: [],
+                                });
+                            } else {
+                                // Add selected status to the filter array
+                                setSearchFilters({
+                                    ...searchFilters,
+                                    status: [selectedValue],
+                                });
+                            }
+                            setPage(1);
+                        }}
+                        renderValue={(value) => {
+                            // for rendering the selected value
+                            if (Number(value) === -1) return 'All Engagements';
+                            return EngagementDisplayStatus[Number(value)] + ' Engagements';
+                        }}
+                        displayEmpty
+                        inputProps={{
+                            'aria-label': 'Select engagement status filter',
+                            style: { padding: 0 },
+                        }}
+                        sx={{
+                            mr: 1,
+                            mb: 1.5,
+                            p: 1,
+                            height: 48,
+                            borderRadius: '2em',
+                            backgroundColor: theme.palette.primary.main,
+                            color: 'white',
+                            borderColor: 'transparent',
+                            boxShadow: 3,
+                            // the arrow icon
+                            '& svg': {
+                                color: 'white',
+                            },
+                        }}
+                        MenuProps={{
+                            anchorOrigin: {
+                                vertical: 'bottom',
+                                horizontal: 'left',
+                            },
+                            transformOrigin: {
+                                vertical: 'top',
+                                horizontal: 'left',
+                            },
+                            sx: {
+                                backgroundColor: 'transparent',
+                                borderRadius: '8px',
+                                boxShadow: 3,
+                                mt: 1,
+                                ml: -1,
+                                '& .MuiPaper-root': {
+                                    borderRadius: '8px',
+                                    boxShadow: 3,
+                                    overflow: 'hidden',
+                                    border: '1px solid var(--Border-Light, #D9D9D9);',
+                                },
+                                '& ul': {
+                                    p: 0,
+                                    '& li': {
+                                        fontSize: '16px',
+                                        height: 48,
+                                        '&:hover': {
+                                            backgroundColor: 'var(--surface-color-secondary-hover, #ECEAE8)',
+                                        },
+                                        '&.Mui-selected': {
+                                            backgroundColor: 'var(--surface-color-brand-blue-20, #D8EAFD);',
+                                        },
+                                        '& span': {
+                                            color: 'var(--Type-Primary, #292929);',
+                                        },
+                                        '&.Mui-selected span': {
+                                            fontWeight: 'bold',
+                                            color: theme.palette.primary.main,
+                                        },
+                                        '&:not(:first-of-type)': {
+                                            borderTop: '1px solid var(--Border-Light, #D9D9D9);',
+                                        },
+                                    },
+                                },
+                            },
+                        }}
+                    >
+                        {selectableStatuses.map((status) => (
+                            <MenuItem key={status} value={status}>
+                                {selectedValue === status && (
+                                    <ListItemIcon>
+                                        <Check fontSize="small" />
+                                    </ListItemIcon>
+                                )}
+                                <ListItemText primary={EngagementDisplayStatus[status] + ' Engagements'} />
+                            </MenuItem>
+                        ))}
+                        <MenuItem value={-1}>
+                            {selectedValue === -1 && (
+                                <ListItemIcon>
+                                    <Check fontSize="small" />
+                                </ListItemIcon>
+                            )}
+                            <ListItemText primary="All Engagements" />
+                        </MenuItem>
+                    </Select>
+                    {searchFilters.metadata.map((filter) =>
+                        filter.values.map((value) => (
+                            <DeletableFilterChip
+                                key={`${filter.taxon_id}-${value}`}
+                                name={value}
+                                onDelete={() => handleDeleteFilterChip(filter.taxon_id, value)}
+                                value={value}
+                            />
+                        )),
+                    )}
+                    <Button
+                        variant="text"
+                        onClick={clearFilters}
+                        sx={{
+                            fontWeight: 'normal',
+                            height: 48,
+                            fontSize: '15px',
+                            borderRadius: '2em',
+                            p: 2,
+                        }}
+                        endIcon={<Close />}
+                    >
+                        Clear Filters
+                    </Button>
+                </Stack>
+            </Grid>
+        </Grid>
+    );
+};
+
+export default FilterBlock;

--- a/met-web/src/components/landing/FilterBlock.tsx
+++ b/met-web/src/components/landing/FilterBlock.tsx
@@ -183,13 +183,13 @@ const FilterBlock = () => {
                         }}
                         renderValue={(value) => {
                             // for rendering the selected value
-                            return selectableStatuses.get(value) || '';
+                            return selectableStatuses.get(value) ?? '';
                         }}
                         displayEmpty
                         inputProps={{
                             'aria-label': translate('landing.filters.aria.statusFilter').replace(
                                 '{0}',
-                                selectableStatuses.get(selectedValue) || '',
+                                selectableStatuses.get(selectedValue) ?? '',
                             ),
                             style: { padding: 0 },
                         }}

--- a/met-web/src/components/landing/FilterBlock.tsx
+++ b/met-web/src/components/landing/FilterBlock.tsx
@@ -18,6 +18,7 @@ import { MetadataFilter } from 'components/metadataManagement/types';
 import { MetLabel } from 'components/common';
 import { debounce } from 'lodash';
 import { EngagementDisplayStatus } from 'constants/engagementStatus';
+import { useAppTranslation } from 'hooks';
 
 const FilterBlock = () => {
     const { searchFilters, setSearchFilters, setPage, clearFilters, page, setDrawerOpened } =
@@ -27,13 +28,15 @@ const FilterBlock = () => {
     const tileBlockRef = useRef<HTMLDivElement>(null);
     const [didMount, setDidMount] = useState(false);
 
-    const selectableStatuses: number[] = [
-        EngagementDisplayStatus.Open,
-        EngagementDisplayStatus.Upcoming,
-        EngagementDisplayStatus.Closed,
-    ];
-
     const theme = useTheme();
+    const { t: translate } = useAppTranslation();
+
+    const selectableStatuses: Map<number, string> = new Map([
+        [EngagementDisplayStatus.Open, translate('landing.filters.status.open')],
+        [EngagementDisplayStatus.Upcoming, translate('landing.filters.status.upcoming')],
+        [EngagementDisplayStatus.Closed, translate('landing.filters.status.closed')],
+        [-1, translate('landing.filters.status.all')],
+    ]);
 
     const debounceSetSearchFilters = useRef(
         debounce((searchText: string) => {
@@ -88,10 +91,10 @@ const FilterBlock = () => {
                 ref={tileBlockRef}
             >
                 <Grid item xl={6} lg={8} md={10} sm={8} xs={12}>
-                    <MetLabel>Search Engagements</MetLabel>
+                    <MetLabel>{translate('landing.filters.search')}</MetLabel>
                     <TextField
                         fullWidth
-                        placeholder="Engagement Title"
+                        placeholder={translate('landing.filters.searchPlaceholder')}
                         value={searchText}
                         onChange={(event) => {
                             setSearchText(event.target.value);
@@ -139,13 +142,14 @@ const FilterBlock = () => {
                 >
                     <Button
                         fullWidth
+                        aria-label={translate('landing.filters.aria.openDrawer')}
                         variant="contained"
                         color="primary"
                         startIcon={<Tune />}
                         onClick={() => setDrawerOpened(true)}
                         sx={{ height: 48 }}
                     >
-                        Filter
+                        {translate('landing.filters.drawer.openButton')}
                     </Button>
                 </Grid>
             </Grid>
@@ -179,12 +183,14 @@ const FilterBlock = () => {
                         }}
                         renderValue={(value) => {
                             // for rendering the selected value
-                            if (Number(value) === -1) return 'All Engagements';
-                            return EngagementDisplayStatus[Number(value)] + ' Engagements';
+                            return selectableStatuses.get(value) || '';
                         }}
                         displayEmpty
                         inputProps={{
-                            'aria-label': 'Select engagement status filter',
+                            'aria-label': translate('landing.filters.aria.statusFilter').replace(
+                                '{0}',
+                                selectableStatuses.get(selectedValue) || '',
+                            ),
                             style: { padding: 0 },
                         }}
                         sx={{
@@ -221,7 +227,7 @@ const FilterBlock = () => {
                                     borderRadius: '8px',
                                     boxShadow: 3,
                                     overflow: 'hidden',
-                                    border: '1px solid var(--Border-Light, #D9D9D9);',
+                                    border: '1px solid #D9D9D9;',
                                 },
                                 '& ul': {
                                     p: 0,
@@ -229,44 +235,36 @@ const FilterBlock = () => {
                                         fontSize: '16px',
                                         height: 48,
                                         '&:hover': {
-                                            backgroundColor: 'var(--surface-color-secondary-hover, #ECEAE8)',
+                                            backgroundColor: '#ECEAE8',
                                         },
                                         '&.Mui-selected': {
-                                            backgroundColor: 'var(--surface-color-brand-blue-20, #D8EAFD);',
+                                            backgroundColor: '#D8EAFD;',
                                         },
                                         '& span': {
-                                            color: 'var(--Type-Primary, #292929);',
+                                            color: '#292929;',
                                         },
                                         '&.Mui-selected span': {
                                             fontWeight: 'bold',
                                             color: theme.palette.primary.main,
                                         },
                                         '&:not(:first-of-type)': {
-                                            borderTop: '1px solid var(--Border-Light, #D9D9D9);',
+                                            borderTop: '1px solid #D9D9D9;',
                                         },
                                     },
                                 },
                             },
                         }}
                     >
-                        {selectableStatuses.map((status) => (
+                        {Array.from(selectableStatuses).map(([status, label]) => (
                             <MenuItem key={status} value={status}>
                                 {selectedValue === status && (
                                     <ListItemIcon>
                                         <Check fontSize="small" />
                                     </ListItemIcon>
                                 )}
-                                <ListItemText primary={EngagementDisplayStatus[status] + ' Engagements'} />
+                                <ListItemText primary={label} />
                             </MenuItem>
                         ))}
-                        <MenuItem value={-1}>
-                            {selectedValue === -1 && (
-                                <ListItemIcon>
-                                    <Check fontSize="small" />
-                                </ListItemIcon>
-                            )}
-                            <ListItemText primary="All Engagements" />
-                        </MenuItem>
                     </Select>
                     {searchFilters.metadata.map((filter) =>
                         filter.values.map((value) => (
@@ -274,7 +272,6 @@ const FilterBlock = () => {
                                 key={`${filter.taxon_id}-${value}`}
                                 name={value}
                                 onDelete={() => handleDeleteFilterChip(filter.taxon_id, value)}
-                                value={value}
                             />
                         )),
                     )}
@@ -290,7 +287,7 @@ const FilterBlock = () => {
                         }}
                         endIcon={<Close />}
                     >
-                        Clear Filters
+                        {translate('landing.filters.clear')}
                     </Button>
                 </Stack>
             </Grid>

--- a/met-web/src/components/landing/FilterDrawer.tsx
+++ b/met-web/src/components/landing/FilterDrawer.tsx
@@ -93,6 +93,7 @@ const FilterDrawer = () => {
                     EngagementDisplayStatus.Closed,
                 ].map((status) => (
                     <MetadataFilterChip
+                        key={status}
                         name={(EngagementDisplayStatus[status] || 'All') + ' Engagements'}
                         selected={selectedValue == status}
                         onClick={() => {

--- a/met-web/src/components/landing/FilterDrawer.tsx
+++ b/met-web/src/components/landing/FilterDrawer.tsx
@@ -1,16 +1,17 @@
-// FilterDrawer.js
 import React, { useContext, useMemo } from 'react';
 import { LandingContext } from './LandingContext';
 import { SwipeableDrawer, IconButton, Typography, Stack, Button, Grid, useTheme, useMediaQuery } from '@mui/material';
 import { Close } from '@mui/icons-material';
 import { MetadataFilterChip } from './MetadataFilterChip';
 import { EngagementDisplayStatus } from 'constants/engagementStatus';
+import { useAppTranslation } from 'hooks';
 
 const FilterDrawer = () => {
     const { searchFilters, setSearchFilters, setPage, metadataFilters, clearFilters, drawerOpened, setDrawerOpened } =
         useContext(LandingContext);
 
     const theme = useTheme();
+    const { t: translate } = useAppTranslation();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
     const selectedValue = useMemo(() => {
@@ -68,7 +69,7 @@ const FilterDrawer = () => {
         >
             <IconButton
                 onClick={() => setDrawerOpened(false)}
-                title="Close filter drawer"
+                title={translate('landing.filters.aria.closeDrawer')}
                 sx={{
                     color: 'white',
                     position: 'absolute',
@@ -79,11 +80,11 @@ const FilterDrawer = () => {
                 <Close />
             </IconButton>
             <Typography mt={3} mb={6} variant="h5">
-                Filter Engagements
+                {translate('landing.filters.drawer.title')}
             </Typography>
 
             <Typography mt={3} variant="subtitle1">
-                Engagement Status
+                {translate('landing.filters.drawer.statusFilter')}
             </Typography>
             <Stack direction="row" sx={{ mb: 2, mt: 2.5 }} flexWrap="wrap">
                 {[
@@ -110,7 +111,10 @@ const FilterDrawer = () => {
             {metadataFilters.map((metadataFilter) => (
                 <>
                     <Typography mt={3} variant="subtitle1">
-                        Filter by {metadataFilter.name}
+                        {translate('landing.filters.drawer.filterHeader').replace(
+                            '{0}',
+                            metadataFilter.name ?? 'metadata',
+                        )}
                     </Typography>
                     <Stack direction="row" sx={{ mb: 2, mt: 2.5 }} flexWrap="wrap">
                         {metadataFilter.values.map((value) => (
@@ -131,6 +135,7 @@ const FilterDrawer = () => {
             <Grid item xs={12} container justifyContent="flex-start" alignItems="flex-end">
                 <Button
                     variant="contained"
+                    aria-label={translate('landing.filters.aria.applyFilters')}
                     sx={{
                         height: 48,
                         mt: 4,
@@ -144,7 +149,7 @@ const FilterDrawer = () => {
                     }}
                     onClick={() => setDrawerOpened(false)}
                 >
-                    Apply Filters
+                    {translate('landing.filters.drawer.apply')}
                 </Button>
 
                 <Button
@@ -161,7 +166,7 @@ const FilterDrawer = () => {
                     onClick={clearFilters}
                     endIcon={<Close />}
                 >
-                    Clear Filters
+                    {translate('landing.filters.clear')}
                 </Button>
             </Grid>
         </SwipeableDrawer>

--- a/met-web/src/components/landing/FilterDrawer.tsx
+++ b/met-web/src/components/landing/FilterDrawer.tsx
@@ -1,0 +1,170 @@
+// FilterDrawer.js
+import React, { useContext, useMemo } from 'react';
+import { LandingContext } from './LandingContext';
+import { SwipeableDrawer, IconButton, Typography, Stack, Button, Grid, useTheme, useMediaQuery } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { MetadataFilterChip } from './MetadataFilterChip';
+import { EngagementDisplayStatus } from 'constants/engagementStatus';
+
+const FilterDrawer = () => {
+    const { searchFilters, setSearchFilters, setPage, metadataFilters, clearFilters, drawerOpened, setDrawerOpened } =
+        useContext(LandingContext);
+
+    const theme = useTheme();
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+    const selectedValue = useMemo(() => {
+        if (searchFilters.status.length === 0) {
+            return -1;
+        }
+        return searchFilters.status[0];
+    }, [searchFilters.status]);
+
+    const handleMetadataFilterClick = (taxonId: number, value: string) => {
+        const existingFilter = searchFilters.metadata.find((filter) => filter.taxon_id === taxonId);
+        let newValues;
+        if (existingFilter) {
+            // Toggle value in or out
+            newValues = existingFilter.values.includes(value)
+                ? existingFilter.values.filter((v) => v !== value)
+                : [...existingFilter.values, value];
+        } else {
+            newValues = [value];
+        }
+        const metadataFilter = metadataFilters.find((f) => f.taxon_id === taxonId);
+        const newMetadataFilters = searchFilters.metadata.filter((filter) => filter.taxon_id !== taxonId);
+        if (newValues.length > 0 && metadataFilter) {
+            newMetadataFilters.push({
+                name: metadataFilter.name,
+                values: newValues,
+                filter_type: metadataFilter.filter_type,
+                taxon_id: taxonId,
+            });
+        }
+
+        setSearchFilters({ ...searchFilters, metadata: newMetadataFilters });
+        setPage(1);
+    };
+
+    return (
+        <SwipeableDrawer
+            aria-label="Filter Engagements"
+            anchor="left"
+            ModalProps={{
+                keepMounted: true, // Better open performance on mobile
+                sx: { zIndex: 1300 }, // Cover the floating feedback button
+            }}
+            PaperProps={{
+                sx: {
+                    width: isSmallScreen ? '100%' : '50%',
+                    background: theme.palette.primary.main,
+                    color: 'white',
+                    padding: '3em',
+                },
+            }}
+            open={drawerOpened}
+            onClose={() => setDrawerOpened(false)}
+            onOpen={() => setDrawerOpened(true)}
+        >
+            <IconButton
+                onClick={() => setDrawerOpened(false)}
+                title="Close filter drawer"
+                sx={{
+                    color: 'white',
+                    position: 'absolute',
+                    top: '1em',
+                    right: '1em',
+                }}
+            >
+                <Close />
+            </IconButton>
+            <Typography mt={3} mb={6} variant="h5">
+                Filter Engagements
+            </Typography>
+
+            <Typography mt={3} variant="subtitle1">
+                Engagement Status
+            </Typography>
+            <Stack direction="row" sx={{ mb: 2, mt: 2.5 }} flexWrap="wrap">
+                {[
+                    -1,
+                    EngagementDisplayStatus.Open,
+                    EngagementDisplayStatus.Upcoming,
+                    EngagementDisplayStatus.Closed,
+                ].map((status) => (
+                    <MetadataFilterChip
+                        name={(EngagementDisplayStatus[status] || 'All') + ' Engagements'}
+                        selected={selectedValue == status}
+                        onClick={() => {
+                            setSearchFilters({
+                                ...searchFilters,
+                                status: status == -1 ? [] : [status],
+                            });
+                            setPage(1);
+                        }}
+                    />
+                ))}
+            </Stack>
+
+            {metadataFilters.map((metadataFilter) => (
+                <>
+                    <Typography mt={3} variant="subtitle1">
+                        Filter by {metadataFilter.name}
+                    </Typography>
+                    <Stack direction="row" sx={{ mb: 2, mt: 2.5 }} flexWrap="wrap">
+                        {metadataFilter.values.map((value) => (
+                            <MetadataFilterChip
+                                key={`${metadataFilter.taxon_id}-${value}`}
+                                name={value}
+                                selected={searchFilters.metadata.some(
+                                    (filter) =>
+                                        filter.taxon_id === metadataFilter.taxon_id && filter.values.includes(value),
+                                )}
+                                onClick={() => handleMetadataFilterClick(metadataFilter.taxon_id, value)}
+                            />
+                        ))}
+                    </Stack>
+                </>
+            ))}
+
+            <Grid item xs={12} container justifyContent="flex-start" alignItems="flex-end">
+                <Button
+                    variant="contained"
+                    sx={{
+                        height: 48,
+                        mt: 4,
+                        mr: 2,
+                        width: '200px',
+                        backgroundColor: 'white',
+                        color: theme.palette.primary.main,
+                        '&:hover, &:focus': {
+                            backgroundColor: '#EDEBE9',
+                        },
+                    }}
+                    onClick={() => setDrawerOpened(false)}
+                >
+                    Apply Filters
+                </Button>
+
+                <Button
+                    variant="text"
+                    sx={{
+                        height: 48,
+                        mt: 2,
+                        width: '200px',
+                        color: 'white',
+                        '&:hover,&:focus': {
+                            backgroundColor: '#1E5189',
+                        },
+                    }}
+                    onClick={clearFilters}
+                    endIcon={<Close />}
+                >
+                    Clear Filters
+                </Button>
+            </Grid>
+        </SwipeableDrawer>
+    );
+};
+
+export default FilterDrawer;

--- a/met-web/src/components/landing/LandingComponent.tsx
+++ b/met-web/src/components/landing/LandingComponent.tsx
@@ -1,47 +1,21 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
-import { Grid, MenuItem, TextField } from '@mui/material';
+import React from 'react';
+import { Grid } from '@mui/material';
 import { Banner } from 'components/banner/Banner';
-import { MetHeader1, MetLabel, MetParagraph } from 'components/common';
+import { MetHeader1, MetParagraph } from 'components/common';
 import TileBlock from './TileBlock';
-import { debounce } from 'lodash';
-import { EngagementDisplayStatus } from 'constants/engagementStatus';
-import { LandingContext } from './LandingContext';
 import { Container } from '@mui/system';
 import LandingPageBanner from 'assets/images/LandingPageBanner.png';
 import { useAppTranslation } from 'hooks';
-
+import FilterBlock from './FilterBlock';
+import FilterDrawer from './FilterDrawer';
 const LandingComponent = () => {
-    const { searchFilters, setSearchFilters, setPage, page } = useContext(LandingContext);
-    const [didMount, setDidMount] = useState(false);
     const { t: translate } = useAppTranslation();
 
-    const debounceSetSearchFilters = useRef(
-        debounce((searchText: string) => {
-            setSearchFilters({
-                ...searchFilters,
-                name: searchText,
-            });
-        }, 300),
-    ).current;
-
-    const tileBlockRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        setDidMount(true);
-        return () => setDidMount(false);
-    }, []);
-
-    useEffect(() => {
-        if (didMount) {
-            const yOffset = tileBlockRef?.current?.offsetTop;
-            window.scrollTo({ top: yOffset || 0, behavior: 'smooth' });
-        }
-    }, [page]);
-
     return (
-        <Grid container direction="row" justifyContent={'center'} alignItems="center">
+        <Grid container direction="row" justifyContent="center" alignItems="center">
+            <FilterDrawer />
             <Grid item xs={12}>
-                <Banner height={'330px'} imageUrl={LandingPageBanner}>
+                <Banner height="330px" imageUrl={LandingPageBanner}>
                     <Grid
                         container
                         direction="row"
@@ -84,74 +58,9 @@ const LandingComponent = () => {
             </Grid>
 
             <Container maxWidth={false} sx={{ maxWidth: '1700px' }}>
-                <Grid
-                    container
-                    item
-                    xs={12}
-                    direction="row"
-                    justifyContent={'center'}
-                    alignItems="center"
-                    rowSpacing={3}
-                >
-                    <Grid
-                        container
-                        item
-                        xs={10}
-                        justifyContent={'flex-start'}
-                        alignItems="flex-start"
-                        columnSpacing={2}
-                        rowSpacing={4}
-                        marginTop={'2em'}
-                        ref={tileBlockRef}
-                    >
-                        <Grid item xs={12} sm={6} md={6} lg={6}>
-                            <MetLabel>Engagement name</MetLabel>
-                            <TextField
-                                fullWidth
-                                placeholder="Type engagement's name..."
-                                InputLabelProps={{
-                                    shrink: false,
-                                }}
-                                onChange={(event) => {
-                                    debounceSetSearchFilters(event.target.value);
-                                }}
-                            />
-                        </Grid>
-                        <Grid item xs={12} sm={6} md={6} lg={6}>
-                            <MetLabel>Status</MetLabel>
-                            <TextField
-                                id="status"
-                                name="status"
-                                variant="outlined"
-                                label=" "
-                                defaultValue=""
-                                value={searchFilters.status}
-                                fullWidth
-                                size="small"
-                                onChange={(event) => {
-                                    setSearchFilters({
-                                        ...searchFilters,
-                                        status: event.target.value ? [Number(event.target.value)] : [],
-                                    });
-                                    setPage(1);
-                                }}
-                                select
-                                InputLabelProps={{
-                                    shrink: false,
-                                }}
-                            >
-                                <MenuItem value={0} sx={{ fontStyle: 'italic', height: '2em' }}>
-                                    {''}
-                                </MenuItem>
-                                <MenuItem value={EngagementDisplayStatus.Open}>Open</MenuItem>
-                                <MenuItem value={EngagementDisplayStatus.Upcoming}>Upcoming</MenuItem>
-                                <MenuItem value={EngagementDisplayStatus.Closed}>Closed</MenuItem>
-                            </TextField>
-                        </Grid>
-                    </Grid>
-                    <Grid item xs={10} container justifyContent={'center'} alignItems="center">
-                        <TileBlock />
-                    </Grid>
+                <Grid container item xs={12} direction="row" justifyContent="center" alignItems="center" rowSpacing={3}>
+                    <FilterBlock />
+                    <TileBlock />
                 </Grid>
             </Container>
         </Grid>

--- a/met-web/src/components/landing/LandingContext.tsx
+++ b/met-web/src/components/landing/LandingContext.tsx
@@ -94,7 +94,7 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
             const loadedFilters = await getMetadataFilters();
             setMetadataFilters(loadedFilters);
         } catch (error) {
-        console.error(error)
+            console.error(error);
         }
     };
 

--- a/met-web/src/components/landing/LandingContext.tsx
+++ b/met-web/src/components/landing/LandingContext.tsx
@@ -80,7 +80,9 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
             setEngagements(loadedEngagements.items);
             setTotalEngagements(loadedEngagements.total);
             setLoadingEngagements(false);
-        } catch (error) {}
+        } catch (error) {
+            console.error(error);
+        }
     };
 
     useEffect(() => {

--- a/met-web/src/components/landing/LandingContext.tsx
+++ b/met-web/src/components/landing/LandingContext.tsx
@@ -91,7 +91,9 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
         try {
             const loadedFilters = await getMetadataFilters();
             setMetadataFilters(loadedFilters);
-        } catch (error) {}
+        } catch (error) {
+        console.error(error)
+        }
     };
 
     useEffect(() => {

--- a/met-web/src/components/landing/LandingContext.tsx
+++ b/met-web/src/components/landing/LandingContext.tsx
@@ -1,11 +1,14 @@
 import React, { createContext, useState, useEffect } from 'react';
 import { Engagement } from 'models/engagement';
 import { getEngagements } from 'services/engagementService';
+import { getMetadataFilters } from 'services/engagementMetadataService';
 import { PAGE_SIZE } from './constants';
+import { MetadataFilter } from 'components/metadataManagement/types';
 
 interface SearchFilters {
     name: string;
     status: number[];
+    metadata: MetadataFilter[];
 }
 
 export interface LandingContextProps {
@@ -16,12 +19,18 @@ export interface LandingContextProps {
     totalEngagements: number;
     page: number;
     setPage: React.Dispatch<React.SetStateAction<number>>;
+    metadataFilters: MetadataFilter[];
+    clearFilters: () => void;
+    drawerOpened: boolean;
+    setDrawerOpened: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const initialSearchFilters = {
     name: '',
     status: [],
+    metadata: [],
 };
+
 export const LandingContext = createContext<LandingContextProps>({
     engagements: [],
     loadingEngagements: false,
@@ -34,14 +43,26 @@ export const LandingContext = createContext<LandingContextProps>({
     setPage: () => {
         throw new Error('setPage unimplemented');
     },
+    metadataFilters: [],
+    clearFilters: () => {
+        throw new Error('clearFilters unimplemented');
+    },
+    drawerOpened: false,
+    setDrawerOpened: () => {
+        throw new Error('setDrawerOpened unimplemented');
+    },
 });
 
 export const LandingContextProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
     const [engagements, setEngagements] = useState<Engagement[]>([]);
     const [totalEngagements, setTotalEngagements] = useState(0);
     const [loadingEngagements, setLoadingEngagements] = useState(true);
+    // The array of filters that are available for the user to select
+    const [metadataFilters, setMetadataFilters] = useState<MetadataFilter[]>([]);
     const [searchFilters, setSearchFilters] = useState<SearchFilters>(initialSearchFilters);
     const [page, setPage] = useState(1);
+    // whether the filter drawer is covering the screen
+    const [drawerOpened, setDrawerOpened] = useState(false);
 
     const loadEngagements = async () => {
         try {
@@ -54,6 +75,7 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
                 include_banner_url: true,
                 engagement_status: status,
                 search_text: name,
+                metadata: searchFilters.metadata,
             });
             setEngagements(loadedEngagements.items);
             setTotalEngagements(loadedEngagements.total);
@@ -65,6 +87,26 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
         loadEngagements();
     }, [searchFilters, page]);
 
+    const loadFilters = async () => {
+        try {
+            const loadedFilters = await getMetadataFilters();
+            setMetadataFilters(loadedFilters);
+        } catch (error) {}
+    };
+
+    useEffect(() => {
+        loadFilters();
+    }, []);
+
+    const clearFilters = () => {
+        setSearchFilters({
+            ...searchFilters,
+            status: [],
+            metadata: [],
+        });
+        setPage(1);
+    };
+
     return (
         <LandingContext.Provider
             value={{
@@ -75,6 +117,10 @@ export const LandingContextProvider = ({ children }: { children: JSX.Element | J
                 totalEngagements,
                 page,
                 setPage,
+                metadataFilters,
+                clearFilters,
+                drawerOpened,
+                setDrawerOpened,
             }}
         >
             {children}

--- a/met-web/src/components/landing/MetadataFilterChip.tsx
+++ b/met-web/src/components/landing/MetadataFilterChip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Chip, useTheme } from '@mui/material';
 import { Check } from '@mui/icons-material';
+import { useAppTranslation } from 'hooks';
 
 export const MetadataFilterChip = ({
     name,
@@ -12,10 +13,15 @@ export const MetadataFilterChip = ({
     onClick?: () => void;
 }) => {
     const theme = useTheme();
+    const { t: translate } = useAppTranslation();
+    const selectionHint = translate(selected ? 'landing.filters.aria.selected' : 'landing.filters.aria.notSelected');
     return (
         <Chip
             size="medium"
             label={name}
+            aria-label={translate('landing.filters.aria.metadataFilterChip')
+                .replace('{0}', name)
+                .replace('{1}', selectionHint)}
             color="default"
             avatar={selected ? <Check /> : undefined}
             variant={selected ? 'filled' : 'outlined'}
@@ -26,22 +32,16 @@ export const MetadataFilterChip = ({
                 p: 1,
                 height: '48px',
                 fontWeight: selected ? 'bold' : 'normal',
-                borderColor: selected
-                    ? 'var(--surface-color-brand-blue-100, #053662)'
-                    : 'var(--surface-color-brand-blue-20, #D8EAFD)',
+                borderColor: selected ? '#053662' : '#D8EAFD',
                 borderRadius: '2em',
-                backgroundColor: selected ? 'var(--surface-color-brand-blue-20, #D8EAFD)' : 'transparent',
+                backgroundColor: selected ? '#D8EAFD' : 'transparent',
                 color: selected ? theme.palette.primary.main : 'white',
                 fontSize: '16px',
                 '&.MuiChip-clickable:hover': {
-                    backgroundColor: selected
-                        ? 'var(--surface-color-brand-blue-10, #F1F8FE)'
-                        : 'var(--surface-color-brand-blue-90, #1E5189)',
+                    backgroundColor: selected ? '#F1F8FE' : '#1E5189',
                 },
                 '&:focus': {
-                    backgroundColor: selected
-                        ? 'var(--surface-color-brand-blue-10, #F1F8FE)'
-                        : 'var(--surface-color-brand-blue-90, #1E5189)',
+                    backgroundColor: selected ? '#F1F8FE' : '#1E5189',
                 },
             }}
         />

--- a/met-web/src/components/landing/MetadataFilterChip.tsx
+++ b/met-web/src/components/landing/MetadataFilterChip.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Chip, useTheme } from '@mui/material';
+import { Check } from '@mui/icons-material';
+
+export const MetadataFilterChip = ({
+    name,
+    selected,
+    onClick,
+}: {
+    name: string;
+    selected?: boolean;
+    onClick?: () => void;
+}) => {
+    const theme = useTheme();
+    return (
+        <Chip
+            size="medium"
+            label={name}
+            color="default"
+            avatar={selected ? <Check /> : undefined}
+            variant={selected ? 'filled' : 'outlined'}
+            onClick={onClick}
+            sx={{
+                mr: 1,
+                mb: 2,
+                p: 1,
+                height: '48px',
+                fontWeight: selected ? 'bold' : 'normal',
+                borderColor: selected
+                    ? 'var(--surface-color-brand-blue-100, #053662)'
+                    : 'var(--surface-color-brand-blue-20, #D8EAFD)',
+                borderRadius: '2em',
+                backgroundColor: selected ? 'var(--surface-color-brand-blue-20, #D8EAFD)' : 'transparent',
+                color: selected ? theme.palette.primary.main : 'white',
+                fontSize: '16px',
+                '&.MuiChip-clickable:hover': {
+                    backgroundColor: selected
+                        ? 'var(--surface-color-brand-blue-10, #F1F8FE)'
+                        : 'var(--surface-color-brand-blue-90, #1E5189)',
+                },
+                '&:focus': {
+                    backgroundColor: selected
+                        ? 'var(--surface-color-brand-blue-10, #F1F8FE)'
+                        : 'var(--surface-color-brand-blue-90, #1E5189)',
+                },
+            }}
+        />
+    );
+};

--- a/met-web/src/components/landing/TileBlock.tsx
+++ b/met-web/src/components/landing/TileBlock.tsx
@@ -18,6 +18,8 @@ const TileBlock = () => {
                 justifyContent="flex-start"
                 columnSpacing={2}
                 rowSpacing={4}
+                item
+                xs={10}
             >
                 <RepeatedGrid times={4} item xs={12} sm={6} md={4} lg={3}>
                     <TileSkeleton />
@@ -33,6 +35,8 @@ const TileBlock = () => {
             alignItems="flex-start"
             columnSpacing={2}
             rowSpacing={4}
+            item
+            xs={10}
         >
             {engagements.map((engagement) => {
                 return (
@@ -47,7 +51,7 @@ const TileBlock = () => {
                         justifyContent={{ xs: 'center', sm: 'flex-start' }}
                         alignItems={{ xs: 'center', sm: 'flex-start' }}
                     >
-                        <Grid item>
+                        <Grid item xs={12}>
                             <EngagementTile passedEngagement={engagement} engagementId={engagement.id} />
                         </Grid>
                     </Grid>

--- a/met-web/src/components/metadataManagement/MetadataFilterTypes.tsx
+++ b/met-web/src/components/metadataManagement/MetadataFilterTypes.tsx
@@ -1,6 +1,5 @@
 import { EditAttributes, EditAttributesOutlined } from '@mui/icons-material';
 import { MetadataFilterType } from './types';
-import React from 'react';
 
 export const MetadataFilterTypes: { [key: string]: MetadataFilterType } = {
     chips_any: {

--- a/met-web/src/components/metadataManagement/MetadataFilterTypes.tsx
+++ b/met-web/src/components/metadataManagement/MetadataFilterTypes.tsx
@@ -1,0 +1,20 @@
+import { EditAttributes, EditAttributesOutlined } from '@mui/icons-material';
+import { MetadataFilterType } from './types';
+import React from 'react';
+
+export const MetadataFilterTypes: { [key: string]: MetadataFilterType } = {
+    chips_any: {
+        name: 'Chips (Match Any Selected)',
+        code: 'chips_any',
+        details:
+            'Users can click chips to filter by metadata. At least one of the selected values must be present on the engagement for it to be shown.',
+        icon: EditAttributesOutlined,
+    },
+    chips_all: {
+        name: 'Chips (Match All Selected)',
+        code: 'chips_all',
+        details:
+            'Users can click chips to filter by metadata. All the selected values must be present on the engagement for it to be shown.',
+        icon: EditAttributes,
+    },
+};

--- a/met-web/src/components/metadataManagement/TaxonCard.tsx
+++ b/met-web/src/components/metadataManagement/TaxonCard.tsx
@@ -13,12 +13,22 @@ import {
     Divider,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { ExpandMore, DragIndicator, FormatQuote, EditAttributes, InsertDriveFile, FileCopy } from '@mui/icons-material';
+import {
+    ExpandMore,
+    DragIndicator,
+    FormatQuote,
+    EditAttributes,
+    InsertDriveFile,
+    FileCopy,
+    FilterAlt,
+    FilterAltOff,
+} from '@mui/icons-material';
 import React from 'react';
 import { MetHeader4 } from 'components/common';
 import { TaxonTypes } from './TaxonTypes';
 import { TaxonCardProps } from './types';
 import { Draggable, DraggableProvided } from '@hello-pangea/dnd';
+import { MetadataFilterTypes } from './MetadataFilterTypes';
 
 const DetailsRow = ({ name, icon, children }: { name: string; icon: React.ReactNode; children: React.ReactNode }) => {
     const theme = useTheme();
@@ -224,6 +234,25 @@ export const TaxonCard: React.FC<TaxonCardProps> = ({ taxon, isExpanded, onExpan
                                             : 'Unlimited values per engagement.'}
                                     </Typography>
                                 </DetailsRow>
+
+                                {/* Filter Type */}
+                                {Boolean(taxonType.supportedFilters) && (
+                                    <DetailsRow
+                                        name="Filter Type"
+                                        icon={taxon.filter_type ? <FilterAlt /> : <FilterAltOff />}
+                                    >
+                                        <Typography variant="body1" pl={1}>
+                                            {taxon.filter_type
+                                                ? MetadataFilterTypes[taxon.filter_type].name
+                                                : 'Engagements are not filtered by this field.'}
+                                        </Typography>
+                                        {taxon.filter_type && (
+                                            <Typography variant="body1" pl={1}>
+                                                {MetadataFilterTypes[taxon.filter_type].details}
+                                            </Typography>
+                                        )}
+                                    </DetailsRow>
+                                )}
                             </Grid>
                         </Collapse>
                     </Grid>

--- a/met-web/src/components/metadataManagement/TaxonEditForm.tsx
+++ b/met-web/src/components/metadataManagement/TaxonEditForm.tsx
@@ -29,6 +29,15 @@ import { useForm, SubmitHandler, Controller, FormProvider } from 'react-hook-for
 import { MetHeader3, MetLabel } from 'components/common';
 import { openNotification } from 'services/notificationService/notificationSlice';
 
+const HelpTooltip = ({ children }: { children: string | string[] }) => {
+    if (Array.isArray(children)) children = children.join(' ');
+    return (
+        <Tooltip title={children}>
+            <HelpOutline tabIndex={0} color="primary" aria-label={children} />
+        </Tooltip>
+    );
+};
+
 const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
     const { setSelectedTaxonId, updateMetadataTaxon, removeMetadataTaxon } = useContext(ActionContext);
     const dispatch = useAppDispatch();
@@ -74,15 +83,6 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
     const isFreeform = watch('freeform');
     const isValidFilter = watch('filter_type') !== 'none';
     const presetValues = watch('preset_values');
-
-    const HelpTooltip = ({ children }: { children: string | string[] }) => {
-        if (Array.isArray(children)) children = children.join(' ');
-        return (
-            <Tooltip title={children}>
-                <HelpOutline tabIndex={0} color="primary" aria-label={children} />
-            </Tooltip>
-        );
-    };
 
     const schema = yup.object().shape({
         name: yup.string().required('Name is required').max(64, 'Name is too long! Limit: 64 characters.'),
@@ -354,7 +354,7 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                             <HelpTooltip>
                                 Selecting a filter style allows the public to use this taxon to narrow down which
                                 engagements they want to see. "No filtering" means it will not be publicly shown. For
-                                details on the selected filter, expand and read the blue highlighted {taxon.name || ''}{' '}
+                                details on the selected filter, expand and read the blue highlighted {taxon.name ?? ''}{' '}
                                 card.`
                             </HelpTooltip>
                         </Grid>
@@ -466,7 +466,7 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                             </Then>
                             <Else>
                                 <Tooltip title="Unable to save due to form errors" id="save-button-tooltip">
-                                    <span tabIndex={0}>
+                                    <span>
                                         {/* Span is used to allow disabled elements in a tooltip */}
                                         <Button
                                             variant="contained"

--- a/met-web/src/components/metadataManagement/TaxonEditForm.tsx
+++ b/met-web/src/components/metadataManagement/TaxonEditForm.tsx
@@ -6,15 +6,16 @@ import {
     FormGroup,
     Select,
     Grid,
-    InputLabel,
     Button,
     MenuItem,
     Tooltip,
     Avatar,
     Collapse,
     Box,
+    useMediaQuery,
+    Theme,
 } from '@mui/material';
-import { Save, Check, Edit, Close, Delete, Error, VerifiedUser, ShieldMoon, Queue, AddBox } from '@mui/icons-material';
+import { Save, Check, Edit, Close, Delete, Error, FilterAltOff, HelpOutline } from '@mui/icons-material';
 import * as yup from 'yup';
 import React, { useContext, useEffect } from 'react';
 import { MetadataTaxon } from 'models/engagement';
@@ -25,12 +26,13 @@ import { TaxonTypes } from './TaxonTypes';
 import { TaxonType } from './types';
 import PresetValuesEditor from './presetFieldsEditor/PresetValuesEditor';
 import { useForm, SubmitHandler, Controller, FormProvider } from 'react-hook-form';
-import { MetHeader3 } from 'components/common';
+import { MetHeader3, MetLabel } from 'components/common';
 import { openNotification } from 'services/notificationService/notificationSlice';
 
 const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
     const { setSelectedTaxonId, updateMetadataTaxon, removeMetadataTaxon } = useContext(ActionContext);
     const dispatch = useAppDispatch();
+    const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
     const methods = useForm<MetadataTaxon>({
         defaultValues: {
             name: taxon.name,
@@ -39,6 +41,8 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
             one_per_engagement: taxon.one_per_engagement,
             data_type: taxon.data_type,
             preset_values: taxon.preset_values,
+            filter_type: taxon.filter_type,
+            include_freeform: taxon.include_freeform,
         },
     });
     const {
@@ -58,6 +62,8 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
             one_per_engagement: taxon.one_per_engagement ?? false,
             data_type: taxon.data_type ?? 'text',
             preset_values: taxon.preset_values ?? [],
+            filter_type: taxon.filter_type ?? 'none',
+            include_freeform: taxon.include_freeform ?? false,
         });
     }, [taxon, reset]);
 
@@ -66,8 +72,17 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
     const taxonType = TaxonTypes[dataType as keyof typeof TaxonTypes];
     // Watch freeform to update label
     const isFreeform = watch('freeform');
-    const isMulti = !watch('one_per_engagement');
+    const isValidFilter = watch('filter_type') !== 'none';
     const presetValues = watch('preset_values');
+
+    const HelpTooltip = ({ children }: { children: string | string[] }) => {
+        if (Array.isArray(children)) children = children.join(' ');
+        return (
+            <Tooltip title={children}>
+                <HelpOutline tabIndex={0} color="primary" aria-label={children} />
+            </Tooltip>
+        );
+    };
 
     const schema = yup.object().shape({
         name: yup.string().required('Name is required').max(64, 'Name is too long! Limit: 64 characters.'),
@@ -76,7 +91,7 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
         one_per_engagement: taxonType.supportsMulti ? yup.boolean() : yup.boolean().oneOf([true]),
         data_type: yup.string().required('Type is required'),
         preset_values: yup.mixed().when('data_type', {
-            is: (value: string) => TaxonTypes[value as keyof typeof TaxonTypes].supportsPresetValues,
+            is: (value: string) => taxonType.supportsPresetValues,
             then: yup.mixed().when('freeform', {
                 is: false,
                 then: yup
@@ -86,6 +101,21 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                 otherwise: yup.array().of(taxonType.yupValidator ?? yup.mixed()),
             }),
             otherwise: yup.mixed().strip(),
+        }),
+        filter_type: yup.string().when('data_type', {
+            is: (value: string) => (taxonType.supportedFilters ?? []).length > 0,
+            then: yup
+                .string()
+                .oneOf(['none', ...(taxonType.supportedFilters ?? []).map((filter) => filter.code)])
+                .nullable(),
+            otherwise: yup.string().strip(),
+        }),
+        include_freeform: yup.boolean().when('filter_type', {
+            is: (value: string) => {
+                return taxonType.allowFreeformInFilter;
+            },
+            then: yup.boolean().optional(),
+            otherwise: yup.boolean().strip(),
         }),
     });
 
@@ -101,6 +131,7 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
             // Catch clause variable type annotation must be 'any' or 'unknown' if specified
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: yup.ValidationError | any) {
+            console.error(error);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             formErrors = error.inner.reduce((errors: { [key: string]: string }, innerError: any) => {
                 errors[innerError.path] = innerError.message;
@@ -117,7 +148,11 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
 
         if (Object.keys(formErrors).length) {
             dispatch(
-                openNotification({ text: 'Please correct the highlighted errors before saving.', severity: 'error' }),
+                // openNotification({ text: 'Please correct the highlighted errors before saving.', severity: 'error' }),
+                openNotification({
+                    severity: 'info',
+                    text: 'This state is never used and I had to make a custom function to open it',
+                }),
             );
             return false;
         }
@@ -130,8 +165,10 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
             one_per_engagement: data.one_per_engagement || !TaxonTypes[data.data_type ?? 'text'].supportsMulti,
             data_type: data.data_type,
             preset_values: TaxonTypes[data.data_type ?? 'text'].supportsPresetValues ? data.preset_values : [],
+            filter_type: data.filter_type === 'none' ? null : data.filter_type,
+            include_freeform: data.include_freeform,
         };
-
+        console.log(updatedTaxon);
         updateMetadataTaxon(updatedTaxon);
     };
 
@@ -158,9 +195,11 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                 <Grid container spacing={2} direction="column" sx={{ width: '100%', maxWidth: '40em' }}>
                     <Grid item container direction="row">
                         <Grid item xs={6} container alignItems="center">
-                            <Avatar sx={{ backgroundColor: 'primary.main', marginRight: '0.5em' }}>
-                                <Edit />
-                            </Avatar>
+                            {!isSmallScreen && (
+                                <Avatar sx={{ backgroundColor: 'primary.main', marginRight: '0.5em' }}>
+                                    <Edit />
+                                </Avatar>
+                            )}
                             <MetHeader3>Edit taxon</MetHeader3>
                         </Grid>
                         <Grid item xs={6} alignItems="center" textAlign="right">
@@ -175,12 +214,13 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                         </Grid>
                     </Grid>
                     <Grid item>
+                        <MetLabel>Taxon Name</MetLabel>
                         <Controller
                             name="name"
                             control={control}
                             render={({ field }) => (
                                 <TextField
-                                    label="Taxon Name"
+                                    placeholder="Enter taxon name"
                                     error={!!methods.formState.errors.name}
                                     helperText={methods.formState.errors.name?.message}
                                     value={field.value}
@@ -190,6 +230,7 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                         />
                     </Grid>
                     <Grid item>
+                        <MetLabel>Taxon Description</MetLabel>
                         <Controller
                             name="description"
                             control={control}
@@ -199,7 +240,7 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                                     multiline
                                     minRows={2}
                                     maxRows={8}
-                                    label="Taxon Description"
+                                    placeholder="[Optional] Enter a description"
                                     value={field.value}
                                     onChange={field.onChange}
                                     error={!!fieldState?.error}
@@ -209,13 +250,19 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                         />
                     </Grid>
                     <Grid item>
+                        <Grid item container justifyContent="flex-start" alignItems="left">
+                            <MetLabel marginRight={1}>Data Type</MetLabel>
+                            <HelpTooltip>
+                                The type of data that this taxon will store. Affects the availability of some other
+                                options.
+                            </HelpTooltip>
+                        </Grid>
                         <FormControl fullWidth>
-                            <InputLabel id="taxonType">Type</InputLabel>
                             <Controller
                                 name="data_type"
                                 control={control}
                                 render={({ field }) => (
-                                    <Select label="Type" value={field.value} onChange={field.onChange}>
+                                    <Select value={field.value} onChange={field.onChange}>
                                         {Object.entries(TaxonTypes).map(([key, type]: [string, TaxonType]) => (
                                             <MenuItem key={key} value={key}>
                                                 <Grid container spacing={1} alignItems="center">
@@ -231,57 +278,153 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                             />
                         </FormControl>
                     </Grid>
-                    <Grid item>
-                        <Collapse in={taxonType.supportsPresetValues} timeout="auto" unmountOnExit>
-                            <PresetValuesEditor control={methods.control} name="preset_values" />
-                        </Collapse>
+                    <Grid item component={Collapse} in={taxonType.supportsPresetValues} timeout="auto" unmountOnExit>
+                        <Grid item container justifyContent="flex-start" alignItems="left">
+                            <MetLabel marginRight={1}>Preset Values</MetLabel>
+                            <HelpTooltip>
+                                These values will be shown to staff as possible options when creating engagements.
+                                {(Boolean(taxonType.supportedFilters) || '') &&
+                                    "If filtering is enabled below, they are also publicly visible as the filter's options."}
+                            </HelpTooltip>
+                        </Grid>
+                        <PresetValuesEditor control={methods.control} name="preset_values" />
                     </Grid>
-                    <Grid item>
-                        <Collapse in={taxonType.supportsPresetValues && allowLimiting} timeout="auto" unmountOnExit>
-                            <FormControlLabel
-                                control={
-                                    <Controller
-                                        name="freeform"
-                                        control={control}
-                                        render={({ field: { onChange, value } }) => {
-                                            return (
-                                                <Switch
-                                                    checked={!value && allowLimiting}
-                                                    onChange={(e) => onChange(!e.target.checked)}
-                                                />
-                                            );
-                                        }}
-                                    />
-                                }
-                                label={
-                                    <Box display="flex" alignItems="center">
-                                        {isFreeform ? <ShieldMoon /> : <VerifiedUser />}
-                                        <Box ml={1}>Limit to preset values</Box>
+                    <Grid
+                        item
+                        component={Collapse}
+                        in={taxonType.supportsPresetValues && allowLimiting}
+                        timeout="auto"
+                        unmountOnExit
+                    >
+                        <FormControlLabel
+                            control={
+                                <Controller
+                                    name="freeform"
+                                    control={control}
+                                    render={({ field: { onChange, value } }) => {
+                                        return (
+                                            <Switch
+                                                checked={value && allowLimiting}
+                                                onChange={(e) => onChange(e.target.checked)}
+                                            />
+                                        );
+                                    }}
+                                />
+                            }
+                            label={
+                                <Box display="flex" alignItems="center">
+                                    <Box ml={1} mr={1}>
+                                        Allow custom values
                                     </Box>
-                                }
-                            />
-                        </Collapse>
+                                    <HelpTooltip>
+                                        If enabled, users can enter custom values when creating engagements. Otherwise,
+                                        only preset values can be used.
+                                    </HelpTooltip>
+                                </Box>
+                            }
+                        />
                     </Grid>
-                    <Grid item>
-                        <Collapse in={taxonType.supportsMulti} timeout="auto" unmountOnExit>
-                            <FormControlLabel
-                                control={
-                                    <Controller
-                                        name="one_per_engagement"
-                                        control={control}
-                                        render={({ field: { onChange, value } }) => (
-                                            <Switch checked={!value} onChange={(e) => onChange(!e.target.checked)} />
-                                        )}
-                                    />
-                                }
-                                label={
-                                    <Box display="flex" alignItems="center">
-                                        {isMulti ? <Queue /> : <AddBox />}
-                                        <Box ml={1}>Allow multiple values</Box>
+                    <Grid item component={Collapse} in={taxonType.supportsMulti} timeout="auto" unmountOnExit>
+                        <FormControlLabel
+                            control={
+                                <Controller
+                                    name="one_per_engagement"
+                                    control={control}
+                                    render={({ field: { onChange, value } }) => (
+                                        <Switch checked={!value} onChange={(e) => onChange(!e.target.checked)} />
+                                    )}
+                                />
+                            }
+                            label={
+                                <Box display="flex" alignItems="center">
+                                    <Box ml={1} mr={1}>
+                                        Allow multiple values
                                     </Box>
-                                }
-                            />
-                        </Collapse>
+                                    <HelpTooltip>
+                                        When enabled, users can enter multiple values for this taxon in a single
+                                        engagement. Otherwise, only one value can be entered.
+                                    </HelpTooltip>
+                                </Box>
+                            }
+                        />
+                    </Grid>
+                    <Grid item component={Collapse} in={!!taxonType.supportedFilters} timeout="auto" unmountOnExit>
+                        <Grid item container justifyContent="flex-start" alignItems="left">
+                            <MetLabel marginRight={1}>Engagement Filtering</MetLabel>
+                            <HelpTooltip>
+                                Selecting a filter style allows the public to use this taxon to narrow down which
+                                engagements they want to see. "No filtering" means it will not be publicly shown. For
+                                details on the selected filter, expand and read the blue highlighted {taxon.name || ''}{' '}
+                                card.`
+                            </HelpTooltip>
+                        </Grid>
+                        <FormControl fullWidth>
+                            <Controller
+                                name="filter_type"
+                                control={control}
+                                render={({ field: { onChange, value, ...fieldProps } }) => (
+                                    <Select
+                                        error={!!methods.formState.errors.filter_type}
+                                        value={value || 'none'} // Display "none" when value is null or undefined
+                                        onChange={onChange}
+                                        {...fieldProps}
+                                    >
+                                        <MenuItem value="none">
+                                            <Grid container alignItems="center" spacing={1}>
+                                                {!isSmallScreen && (
+                                                    <Grid item>
+                                                        <FilterAltOff />
+                                                    </Grid>
+                                                )}
+                                                <Grid item>No filtering</Grid>
+                                            </Grid>
+                                        </MenuItem>
+                                        {taxonType.supportedFilters?.map((filter) => (
+                                            <MenuItem key={filter.code} value={filter.code}>
+                                                <Grid container alignItems="center" spacing={1}>
+                                                    {!isSmallScreen && (
+                                                        <Grid item>
+                                                            <filter.icon />
+                                                        </Grid>
+                                                    )}
+                                                    <Grid item>Show as {filter.name}</Grid>
+                                                </Grid>
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                )}
+                            ></Controller>
+                        </FormControl>
+                    </Grid>
+                    <Grid
+                        item
+                        component={Collapse}
+                        in={Boolean(taxonType.allowFreeformInFilter && isFreeform && isValidFilter)}
+                        timeout="auto"
+                        unmountOnExit
+                    >
+                        <FormControlLabel
+                            control={
+                                <Controller
+                                    name="include_freeform"
+                                    control={control}
+                                    render={({ field: { onChange, value } }) => (
+                                        <Switch checked={value} onChange={(e) => onChange(e.target.checked)} />
+                                    )}
+                                />
+                            }
+                            label={
+                                <Box display="flex" alignItems="center">
+                                    <Box ml={1} mr={1}>
+                                        Include custom values as filter options
+                                    </Box>
+                                    <HelpTooltip>
+                                        If enabled, custom values entered on engagements will be available as filter
+                                        options, in addition to the preset values.
+                                    </HelpTooltip>
+                                </Box>
+                            }
+                        />
                     </Grid>
                     <Grid item container alignItems="center" justifyContent="flex-start">
                         <Tooltip title="Discard changes to taxon" id="cancel-button-tooltip">
@@ -323,16 +466,19 @@ const TaxonEditForm = ({ taxon }: { taxon: MetadataTaxon }): JSX.Element => {
                             </Then>
                             <Else>
                                 <Tooltip title="Unable to save due to form errors" id="save-button-tooltip">
-                                    <Button
-                                        variant="contained"
-                                        aria-disabled
-                                        aria-labelledby="save-button-tooltip"
-                                        aria-details="Please correct the errors before saving."
-                                        disabled
-                                        sx={{ marginLeft: '0.5em' }}
-                                    >
-                                        <Error /> Save
-                                    </Button>
+                                    <span tabIndex={0}>
+                                        {/* Span is used to allow disabled elements in a tooltip */}
+                                        <Button
+                                            variant="contained"
+                                            aria-disabled
+                                            aria-labelledby="save-button-tooltip"
+                                            aria-details="Please correct the errors before saving."
+                                            disabled
+                                            sx={{ marginLeft: '0.5em' }}
+                                        >
+                                            <Error /> Save
+                                        </Button>
+                                    </span>
                                 </Tooltip>
                             </Else>
                         </If>

--- a/met-web/src/components/metadataManagement/TaxonTypes.tsx
+++ b/met-web/src/components/metadataManagement/TaxonTypes.tsx
@@ -1,11 +1,11 @@
 import {
+    Abc,
     AlternateEmail,
     Event,
     EventNote,
     Flaky,
     Link,
     Article,
-    ChatBubbleOutline,
     PinOutlined,
     Phone,
     Schedule,
@@ -19,15 +19,18 @@ import {
     PickerTypes,
     taxonSwitch,
 } from 'components/engagement/form/EngagementFormTabs/AdditionalDetails/Metadata/TaxonInputComponents';
+import { MetadataFilterTypes } from './MetadataFilterTypes';
 
 export const TaxonTypes: { [key: string]: TaxonType } = {
     text: {
         name: 'Text',
-        icon: ChatBubbleOutline,
+        icon: Abc,
         supportsPresetValues: true,
         supportsFreeform: true,
         supportsMulti: true,
         yupValidator: yup.string(),
+        supportedFilters: [MetadataFilterTypes.chips_all, MetadataFilterTypes.chips_any],
+        allowFreeformInFilter: true,
     },
     long_text: {
         name: 'Multiline Text',
@@ -75,7 +78,7 @@ export const TaxonTypes: { [key: string]: TaxonType } = {
         icon: Event,
         supportsPresetValues: false,
         supportsFreeform: false,
-        supportsMulti: false,
+        supportsMulti: true,
         yupValidator: yup.date().typeError('This value must be a valid date.'),
         customInput: ({ ...props }: TaxonInputProps) => TaxonPicker({ ...props, pickerType: PickerTypes.DATE }),
     },

--- a/met-web/src/components/metadataManagement/presetFieldsEditor/PresetValuesEditor.tsx
+++ b/met-web/src/components/metadataManagement/presetFieldsEditor/PresetValuesEditor.tsx
@@ -1,7 +1,7 @@
 import React, { SyntheticEvent, useState } from 'react';
 import { Autocomplete, TextField, Chip, IconButton, Stack } from '@mui/material';
 import { Control, Controller, FieldError } from 'react-hook-form';
-import { ArrowCircleUp, HighlightOff } from '@mui/icons-material';
+import { AddCircleOutline, HighlightOff } from '@mui/icons-material';
 
 const PresetValuesEditor = ({
     control, // The control object (from react-hook-form)
@@ -66,7 +66,6 @@ const PresetValuesEditor = ({
                             <TextField
                                 {...params}
                                 variant="outlined"
-                                label="Preset values"
                                 placeholder="Type a new option..."
                                 error={!!errors.preset_values}
                                 helperText={errorMessage}
@@ -81,7 +80,7 @@ const PresetValuesEditor = ({
                                                         onArrayChange(null, [...value, inputValue]);
                                                     }}
                                                 >
-                                                    <ArrowCircleUp />
+                                                    <AddCircleOutline />
                                                 </IconButton>
                                             )}
                                             <IconButton

--- a/met-web/src/components/metadataManagement/types.ts
+++ b/met-web/src/components/metadataManagement/types.ts
@@ -48,12 +48,29 @@ export interface GenericInputProps {
     ) => void;
 }
 
+export interface MetadataFilterType {
+    name: string;
+    code: string;
+    details: string;
+    icon: SvgIconComponent;
+    // TODO: allow for custom input components based on the passed taxon type
+}
+
+export interface MetadataFilter {
+    taxon_id: number;
+    name?: string;
+    filter_type: string;
+    values: string[];
+}
+
 export interface TaxonType {
     name: string;
     icon: SvgIconComponent;
     supportsPresetValues: boolean;
     supportsFreeform: boolean;
     supportsMulti: boolean;
+    supportedFilters?: MetadataFilterType[];
+    allowFreeformInFilter?: boolean;
     yupValidator: yup.AnySchema;
     customInput?: (props: GenericInputProps) => JSX.Element;
     externalResource?: (value: string) => string;

--- a/met-web/src/locales/en/default.json
+++ b/met-web/src/locales/en/default.json
@@ -10,6 +10,35 @@
         "banner": {
             "header": "The Title of The Office",
             "description": "Description about the office and public engagement."
+        },
+        "filters": {
+            "drawer": {
+                "openButton": "Filter",
+                "title": "Filter Engagements",
+                "apply": "Apply Filters",
+                "statusFilter": "Engagement Status",
+                "filterHeader": "Filter by {0}"
+            },
+            "clear": "Clear Filters",
+            "search": "Search Engagements",
+            "searchPlaceholder": "Engagement Title",
+            "status": {
+                "all": "All Engagements",
+                "open": "Open Engagements",
+                "closed": "Closed Engagements",
+                "upcoming": "Upcoming Engagements"
+            },
+            "aria": {
+                "closeDrawer": "Close filter options",
+                "openDrawer": "Open more filter options",
+                "deleteFilterChip": "{0} filter - press to remove",
+                "metadataFilterChip": "{0} filter - {1}",
+                "selected": "Applied",
+                "notSelected": "Not Applied",
+                "applyFilters":"Apply Filters and close filter options",
+                "clearFilters":"Clear all filters",
+                "statusFilter": "Engagement Status Selector - {0} selected" 
+            }
         }
     },
     "comment": {

--- a/met-web/src/models/engagement.ts
+++ b/met-web/src/models/engagement.ts
@@ -40,6 +40,8 @@ export interface MetadataTaxonModify {
     data_type?: string; // The data type for the taxon, optional
     one_per_engagement?: boolean; // Whether the taxon is limited to one entry per engagement, optional
     preset_values?: string[]; // The preset values for the taxon
+    filter_type?: string | null; // The filter type for the taxon, optional
+    include_freeform?: boolean; // Whether to include freeform values in options for filtering, optional
 }
 
 export interface MetadataTaxon extends MetadataTaxonModify {

--- a/met-web/src/services/engagementMetadataService/index.ts
+++ b/met-web/src/services/engagementMetadataService/index.ts
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import { EngagementMetadata, MetadataTaxonModify, MetadataTaxon } from 'models/engagement';
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
+import { MetadataFilter } from 'components/metadataManagement/types';
 
 export const getEngagementMetadata = async (engagementId: number): Promise<EngagementMetadata[]> => {
     const url = replaceUrl(Endpoints.EngagementMetadata.GET_BY_ENG, 'engagement_id', String(engagementId));
@@ -50,6 +51,14 @@ export const getMetadataTaxa = async (): Promise<Array<MetadataTaxon>> => {
         return response.data;
     }
     throw new Error('Failed to fetch metadata taxa');
+};
+
+export const getMetadataFilters = async (): Promise<Array<MetadataFilter>> => {
+    const response = await http.GetRequest<Array<MetadataFilter>>(Endpoints.MetadataTaxa.FILTER_BY_TENANT);
+    if (response.data) {
+        return response.data;
+    }
+    throw new Error('Failed to fetch available filters');
 };
 
 export const getMetadataTaxon = async (taxonId: number): Promise<MetadataTaxon> => {

--- a/met-web/src/services/engagementService/index.ts
+++ b/met-web/src/services/engagementService/index.ts
@@ -6,6 +6,7 @@ import { PatchEngagementRequest, PostEngagementRequest, PutEngagementRequest } f
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
 import { Page } from 'services/type';
+import { MetadataFilter } from 'components/metadataManagement/types';
 
 export const fetchAll = async (dispatch: Dispatch<AnyAction>): Promise<Engagement[]> => {
     const responseData = await http.GetRequest<Engagement[]>(Endpoints.Engagement.GET_LIST);
@@ -27,6 +28,7 @@ interface GetEngagementsParams {
     published_to_date?: string;
     include_banner_url?: boolean;
     has_team_access?: boolean;
+    metadata?: MetadataFilter[];
 }
 export const getEngagements = async (params: GetEngagementsParams = {}): Promise<Page<Engagement>> => {
     const responseData = await http.GetRequest<Page<Engagement>>(Endpoints.Engagement.GET_LIST, params);

--- a/met-web/tests/unit/components/landingPage/LandingPage.test.tsx
+++ b/met-web/tests/unit/components/landingPage/LandingPage.test.tsx
@@ -89,14 +89,14 @@ describe('Landing page tests', () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByPlaceholderText('Engagement Title')).toBeInTheDocument();
-            expect(screen.getByText('Search Engagements')).toBeInTheDocument();
-            expect(screen.getByText('Filter')).toBeInTheDocument();
+            expect(screen.getByPlaceholderText('landing.filters.searchPlaceholder')).toBeInTheDocument();
+            expect(screen.getByText('landing.filters.search')).toBeInTheDocument();
+            expect(screen.getByText('landing.filters.drawer.openButton')).toBeInTheDocument();
             expect(
                 screen.getByText((content, element) => {
                     return (
                         (element as HTMLElement).classList.contains('MuiSelect-select') &&
-                        element?.textContent === 'All Engagements'
+                        element?.textContent === 'landing.filters.status.all'
                     );
                 }),
             ).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe('Landing page tests', () => {
             </LandingContext.Provider>,
         );
 
-        const searchInput = screen.getByPlaceholderText('Engagement Title');
+        const searchInput = screen.getByPlaceholderText('landing.filters.searchPlaceholder');
         fireEvent.change(searchInput, { target: { value: 'New Search' } });
 
         await waitFor(() => {
@@ -176,9 +176,8 @@ describe('Landing page tests', () => {
         const statusDropdown = allButtons.find((button) => button.id === 'status-filter') as HTMLElement;
         fireEvent.mouseDown(statusDropdown); // click event doesn't work for MUI Select
         // Wait for the dropdown to appear
-        // const openOption = await screen.findByText('Open Engagements');
         const listbox = within(getByRole(document.body, 'listbox'));
-        const openOption = listbox.getByText('Open Engagements');
+        const openOption = listbox.getByText('landing.filters.status.open');
         fireEvent.click(openOption);
 
         await waitFor(() => {
@@ -217,7 +216,7 @@ describe('Landing page tests', () => {
             </LandingContext.Provider>,
         );
 
-        const filterButton = screen.getByText('Filter');
+        const filterButton = screen.getByText('landing.filters.drawer.openButton');
         // Open the drawer...
         fireEvent.click(filterButton);
 
@@ -225,7 +224,7 @@ describe('Landing page tests', () => {
             expect(setDrawerOpenedMock).toHaveBeenCalledWith(true);
         });
 
-        const closeButton = screen.getByText('Apply Filters');
+        const closeButton = screen.getByText('landing.filters.drawer.apply');
         // Close it again >:)
         fireEvent.click(closeButton);
 

--- a/met-web/tests/unit/components/landingPage/LandingPage.test.tsx
+++ b/met-web/tests/unit/components/landingPage/LandingPage.test.tsx
@@ -189,4 +189,48 @@ describe('Landing page tests', () => {
             });
         });
     });
+
+    test('Filter drawer is opened and closed', async () => {
+        const setDrawerOpenedMock = jest.fn();
+
+        render(
+            <LandingContext.Provider
+                value={{
+                    searchFilters: {
+                        name: '',
+                        status: [],
+                        metadata: [],
+                    },
+                    metadataFilters: [],
+                    clearFilters: jest.fn(),
+                    drawerOpened: false,
+                    setDrawerOpened: setDrawerOpenedMock,
+                    setSearchFilters: jest.fn(),
+                    setPage: jest.fn(),
+                    page: 1,
+                    engagements: [],
+                    loadingEngagements: false,
+                    totalEngagements: 0,
+                }}
+            >
+                <LandingComponent />
+            </LandingContext.Provider>,
+        );
+
+        const filterButton = screen.getByText('Filter');
+        // Open the drawer...
+        fireEvent.click(filterButton);
+
+        await waitFor(() => {
+            expect(setDrawerOpenedMock).toHaveBeenCalledWith(true);
+        });
+
+        const closeButton = screen.getByText('Apply Filters');
+        // Close it again >:)
+        fireEvent.click(closeButton);
+
+        await waitFor(() => {
+            expect(setDrawerOpenedMock).toHaveBeenCalledWith(false);
+        });
+    });
 });

--- a/met-web/tests/unit/components/landingPage/LandingPage.test.tsx
+++ b/met-web/tests/unit/components/landingPage/LandingPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent, within, getByRole } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 import LandingComponent from 'components/landing/LandingComponent';
@@ -6,7 +6,6 @@ import { setupEnv } from '../setEnvVars';
 import { LandingContext } from 'components/landing/LandingContext';
 import * as reactRedux from 'react-redux';
 import { openEngagement, closedEngagement } from '../factory';
-import userEvent from '@testing-library/user-event';
 
 jest.mock('axios');
 
@@ -23,6 +22,7 @@ jest.mock('hooks', () => ({
     }),
 }));
 
+// mock enums to fix TS compiler issue when importing them
 jest.mock('constants/engagementStatus', () => ({
     EngagementDisplayStatus: {
         Draft: 1,
@@ -32,6 +32,14 @@ jest.mock('constants/engagementStatus', () => ({
         Upcoming: 5,
         Open: 6,
         Unpublished: 7,
+        // Allow backwards lookup like the enum we're mocking
+        1: 'Draft',
+        2: 'Published',
+        3: 'Closed',
+        4: 'Scheduled',
+        5: 'Upcoming',
+        6: 'Open',
+        7: 'Unpublished',
     },
     SubmissionStatus: {
         Upcoming: 1,
@@ -62,7 +70,12 @@ describe('Landing page tests', () => {
                     searchFilters: {
                         name: '',
                         status: [],
+                        metadata: [],
                     },
+                    metadataFilters: [],
+                    clearFilters: jest.fn(),
+                    drawerOpened: false,
+                    setDrawerOpened: jest.fn(),
                     setSearchFilters: jest.fn(),
                     setPage: jest.fn(),
                     page: 1,
@@ -76,9 +89,17 @@ describe('Landing page tests', () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByPlaceholderText("Type engagement's name...")).toBeInTheDocument();
-            expect(screen.getByText('Engagement name')).toBeInTheDocument();
-            expect(screen.getByText('Status')).toBeInTheDocument();
+            expect(screen.getByPlaceholderText('Engagement Title')).toBeInTheDocument();
+            expect(screen.getByText('Search Engagements')).toBeInTheDocument();
+            expect(screen.getByText('Filter')).toBeInTheDocument();
+            expect(
+                screen.getByText((content, element) => {
+                    return (
+                        (element as HTMLElement).classList.contains('MuiSelect-select') &&
+                        element?.textContent === 'All Engagements'
+                    );
+                }),
+            ).toBeInTheDocument();
             expect(screen.getByText('landing.banner.header')).toBeInTheDocument();
             expect(screen.getByText('landing.banner.description')).toBeInTheDocument();
             expect(screen.getByText(openEngagement.name)).toBeInTheDocument();
@@ -95,7 +116,12 @@ describe('Landing page tests', () => {
                     searchFilters: {
                         name: '',
                         status: [],
+                        metadata: [],
                     },
+                    metadataFilters: [],
+                    clearFilters: jest.fn(),
+                    drawerOpened: false,
+                    setDrawerOpened: jest.fn(),
                     setSearchFilters: setSearchFiltersMock,
                     setPage: jest.fn(),
                     page: 1,
@@ -108,7 +134,7 @@ describe('Landing page tests', () => {
             </LandingContext.Provider>,
         );
 
-        const searchInput = screen.getByPlaceholderText("Type engagement's name...");
+        const searchInput = screen.getByPlaceholderText('Engagement Title');
         fireEvent.change(searchInput, { target: { value: 'New Search' } });
 
         await waitFor(() => {
@@ -116,7 +142,7 @@ describe('Landing page tests', () => {
         });
     });
 
-    test('Status filter is working', async () => {
+    test('Status dropdown is working', async () => {
         const setSearchFiltersMock = jest.fn();
 
         render(
@@ -125,7 +151,12 @@ describe('Landing page tests', () => {
                     searchFilters: {
                         name: '',
                         status: [],
+                        metadata: [],
                     },
+                    metadataFilters: [],
+                    clearFilters: jest.fn(),
+                    drawerOpened: false,
+                    setDrawerOpened: jest.fn(),
                     setSearchFilters: setSearchFiltersMock,
                     setPage: jest.fn(),
                     page: 1,
@@ -142,15 +173,19 @@ describe('Landing page tests', () => {
         const allButtons = screen.getAllByRole('button');
 
         // Find the specific button with id "status"
-        const statusDropdown = allButtons.find((button) => button.id === 'status') as HTMLElement;
-        userEvent.click(statusDropdown);
-        const openItem = await screen.findByText('Open');
-        userEvent.click(openItem);
+        const statusDropdown = allButtons.find((button) => button.id === 'status-filter') as HTMLElement;
+        fireEvent.mouseDown(statusDropdown); // click event doesn't work for MUI Select
+        // Wait for the dropdown to appear
+        // const openOption = await screen.findByText('Open Engagements');
+        const listbox = within(getByRole(document.body, 'listbox'));
+        const openOption = listbox.getByText('Open Engagements');
+        fireEvent.click(openOption);
 
         await waitFor(() => {
             expect(setSearchFiltersMock).toHaveBeenCalledWith({
                 name: '',
                 status: [6], // The numeric value corresponding to 'Open'
+                metadata: [],
             });
         });
     });


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-445

  - Updated the Metadata Management UI to allow taxa to be marked as filterable.
    - Currently, the only two filter types are `chips_any` and `chips_all`.
    - `chips_any`: Displays as a series of toggleable buttons ("chips"), uses the `list_match_any` subquery returning engagements with any of the selected values.
    - `chips_all`: Similar to chips_any; uses the `list_match_all` subquery to get only engagements with ALL of the selected values.
  - If multiple filterable taxa are selected, all the taxon filters must be met for an engagement to be returned.
  - Updated the public-facing engagement list to allow filtering by metadata taxa. This makes use of the new API endpoint to retrieve filterable taxa.
  - Added a new filter "drawer" to the listing page to hold these and any future filter types.
  - (Out of scope, but related to UX work for this ticket) Fixed a display issue with the public engagements page where engagements would not take up the full width of their grid cell.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
