### PR TITLE
DESENG-533: Internal email check

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,7 +1,7 @@
 ## April 05, 2024
 
 - **Task**: Allow for any gov.bc.ca email to receive emails in MET's dev & test environments [DESENG-533](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-533)
-  - Enabled dev open shift to use GC_NOTIF api key of test which allows all email.
+  - Enabled dev open shift to use GC_NOTIFY api key of test which allows all email.
   - Added new env var `SEND_EMAIL_INTERNAL_ONLY` to allow for internal emails such as govt emails only.
 
 ## April 04, 2024

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## April 05, 2024
+
+- **Task**: Allow for any gov.bc.ca email to receive emails in MET's dev & test environments [DESENG-533](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-533)
+  - Enabled dev open shift to use GC_NOTIF api key of test which allows all email.
+  - Added new env var `SEND_EMAIL_INTERNAL_ONLY` to allow for internal emails such as govt emails only.
+
 ## April 04, 2024
 
 - **Task**: Keycloak Unit Tests for New CSS API Integration [DESENG-508](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-508)

--- a/met-api/sample.env
+++ b/met-api/sample.env
@@ -147,3 +147,7 @@ EPIC_KC_CLIENT_ID=
 EPIC_MILESTONE=
 EPIC_KEYCLOAK_SERVICE_ACCOUNT_ID= 
 EPIC_KEYCLOAK_SERVICE_ACCOUNT_SECRET=
+
+# If enabled, all emails will be send only to the internal email address set in constant INTERNAL_EMAIL_DOMAIN
+# such as `@gov.bc.ca` . Mainly used for dev and test environments.
+SEND_EMAIL_INTERNAL_ONLY=false

--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -169,6 +169,10 @@ class Config:  # pylint: disable=too-few-public-methods
     # Adjust this value based on security considerations.
     CORS_MAX_AGE = os.getenv('CORS_MAX_AGE', None)  # Default: 0 seconds
 
+    # If enabled, Emails will be send onlt to the internal email address set in constant INTERNAL_EMAIL_DOMAIN
+    # such as `@gov.bc.ca` . Mainly used for dev and test environments.
+    SEND_EMAIL_INTERNAL_ONLY = env_truthy('SEND_EMAIL_INTERNAL_ONLY', default=False)
+
     EPIC_CONFIG = {
         'ENABLED': env_truthy('EPIC_INTEGRATION_ENABLED'),
         'JWT_OIDC_ISSUER': os.getenv('EPIC_JWT_OIDC_ISSUER'),

--- a/met-api/src/met_api/utils/notification.py
+++ b/met-api/src/met_api/utils/notification.py
@@ -4,9 +4,13 @@ import json
 import re
 
 import requests
+
+from http import HTTPStatus
 from flask import current_app
 from met_api.models.tenant import Tenant
 from met_api.services.rest_service import RestService
+from met_api.constants.email_verification import INTERNAL_EMAIL_DOMAIN
+from met_api.exceptions.business_exception import BusinessException
 
 
 def get_tenant_site_url(tenant_id, path=''):
@@ -27,6 +31,9 @@ def send_email(subject, email, html_body, args, template_id):
     """Send the email asynchronously, using the given details."""
     if not email or not is_valid_email(email):
         return
+
+    if not is_allowed_email(email):
+        raise ValueError('The email provided is not allowed in this environement.')
 
     sender = current_app.config['EMAIL_TEMPLATES']['FROM_ADDRESS']
     service_account_token = RestService.get_service_account_token()
@@ -53,3 +60,9 @@ def is_valid_email(email: str):
     if email:
         return re.match(r'[^@]+@[^@]+\.[^@]+', email) is not None
     return False
+
+
+def is_allowed_email(email: str):
+    """Return if the email is allowed or not if send_email_internal_only is enabled."""
+    send_email_internal_only = current_app.config.get('SEND_EMAIL_INTERNAL_ONLY')
+    return not send_email_internal_only or (email and email.endswith(INTERNAL_EMAIL_DOMAIN))

--- a/met-api/src/met_api/utils/notification.py
+++ b/met-api/src/met_api/utils/notification.py
@@ -31,7 +31,7 @@ def send_email(subject, email, html_body, args, template_id):
         return
 
     if not is_allowed_email(email):
-        raise ValueError('The email provided is not allowed in this environement.')
+        raise ValueError('The email provided is not allowed in this environment.')
 
     sender = current_app.config['EMAIL_TEMPLATES']['FROM_ADDRESS']
     service_account_token = RestService.get_service_account_token()

--- a/met-api/src/met_api/utils/notification.py
+++ b/met-api/src/met_api/utils/notification.py
@@ -5,12 +5,10 @@ import re
 
 import requests
 
-from http import HTTPStatus
 from flask import current_app
 from met_api.models.tenant import Tenant
 from met_api.services.rest_service import RestService
 from met_api.constants.email_verification import INTERNAL_EMAIL_DOMAIN
-from met_api.exceptions.business_exception import BusinessException
 
 
 def get_tenant_site_url(tenant_id, path=''):

--- a/met-api/tests/unit/utils/test_notification.py
+++ b/met-api/tests/unit/utils/test_notification.py
@@ -16,14 +16,31 @@
 
 Test-Suite to ensure that the Notification methods are working as expected.
 """
-
 import pytest
 
 from met_api.utils import notification
+from met_api.constants.email_verification import INTERNAL_EMAIL_DOMAIN
 
 
-@pytest.mark.parametrize('test_input_email,expected',
-                         [('helo@gw.com', True), ('helo', False), (None, False), ('', False)])
+@pytest.mark.parametrize(
+    'test_input_email,expected', [('helo@gw.com', True), ('helo', False), (None, False), ('', False)]
+)
 def test_is_valid_email(test_input_email, expected):
     """Assert that the valid email method works well.."""
     assert notification.is_valid_email(test_input_email) == expected
+
+
+@pytest.mark.parametrize(
+    'email, expected, send_email_internal_only',
+    [
+        ('test@example.com', False, True),  # External email, should be False if SEND_EMAIL_INTERNAL_ONLY is True
+        ('test' + INTERNAL_EMAIL_DOMAIN, True, True),  # Internal email, should always be True
+        ('test@example.com', True, False),  # External email, should be True if SEND_EMAIL_INTERNAL_ONLY is False
+        ('test' + INTERNAL_EMAIL_DOMAIN, True, True),  # Internal email, should always be True
+    ],
+)
+def test_is_allowed_email(app, email, expected, send_email_internal_only):
+    """Assert that the is_allowed_email method works well.."""
+    app.config['SEND_EMAIL_INTERNAL_ONLY'] = send_email_internal_only
+    with app.app_context():
+        assert notification.is_allowed_email(email) == expected

--- a/openshift/api.dc.yml
+++ b/openshift/api.dc.yml
@@ -226,6 +226,7 @@ objects:
     KEYCLOAK_REALMNAME: ${KEYCLOAK_REALMNAME}
     KEYCLOAK_BASE_URL: ${KEYCLOAK_BASE_URL}
     KEYCLOAK_ADMIN_TOKEN_URL: ${KEYCLOAK_ADMIN_TOKEN_URL}
+    SEND_EMAIL_INTERNAL_ONLY: ${SEND_EMAIL_INTERNAL_ONLY}
 - kind: Secret
   apiVersion: v1
   type: Opaque
@@ -403,6 +404,10 @@ parameters:
   - name: KEYCLOAK_ADMIN_TOKEN_URL
     description: "Keycloak url to get admin token"
     required: true
+    value: ''
+  - name: SEND_EMAIL_INTERNAL_ONLY
+    description: "Send Email only to internal email ids"
+    required: false
     value: ''
   - name: CDOGS_BASE_URL
     description: "Base url to access CDOGS"


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-533

*Description of changes:*
  - Enabled dev open shift to use GC_NOTIFY api key of test which allows all email.
  - Added new env var `SEND_EMAIL_INTERNAL_ONLY` to allow for internal emails such as govt emails only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
