### PR TITLE
[To Main] Bugfix: Comments do not update when editing rejected comments [DESENG-527]

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## April 08, 2024
+
+- **Bugfix**: Submission of rejected comments [🎟️ DESENG-527](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-527)
+  - Fixed issue where resubmitted comments would not reappear in the queue for approval.
+  - Added unit tests to ensure the issue does not reoccur.
+
 ## April 05, 2024
 
 - **Task**: Allow for any gov.bc.ca email to receive emails in MET's dev & test environments [DESENG-533](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-533)

--- a/met-api/src/met_api/services/submission_service.py
+++ b/met-api/src/met_api/services/submission_service.py
@@ -62,7 +62,8 @@ class SubmissionService:
             MembershipType.TEAM_MEMBER.name,
             Role.REVIEW_COMMENTS.value
         )
-        authorization.check_auth(one_of_roles=one_of_roles, engagement_id=engagement.id)
+        authorization.check_auth(
+            one_of_roles=one_of_roles, engagement_id=engagement.id)
 
     @classmethod
     def get_by_token(cls, token):
@@ -101,7 +102,8 @@ class SubmissionService:
             EngagementSettingsModel.find_by_id(engagement_id)
         if engagement_settings:
             if engagement_settings.send_report:
-                SubmissionService._send_submission_response_email(participant_id, engagement_id)
+                SubmissionService._send_submission_response_email(
+                    participant_id, engagement_id)
         return submission_result
 
     @classmethod
@@ -127,6 +129,7 @@ class SubmissionService:
         comments_result = [Comment.update(submission.id, comment, db.session)
                            for comment in data.get('comments', [])]
         SubmissionModel.update(SubmissionSchema().dump(submission), db.session)
+        db.session.commit()
         return comments_result
 
     @staticmethod
@@ -350,7 +353,8 @@ class SubmissionService:
         templates = current_app.config.get('EMAIL_TEMPLATES')
         if engagement.status_id == EngagementStatus.Closed.value:
             template_id = templates['CLOSED_ENGAGEMENT_REJECTED']['ID']
-            template = Template.get_template('email_rejected_comment_closed.html')
+            template = Template.get_template(
+                'email_rejected_comment_closed.html')
             subject = templates['CLOSED_ENGAGEMENT_REJECTED']['SUBJECT']. \
                 format(engagement_name=engagement_name)
         else:
@@ -401,7 +405,8 @@ class SubmissionService:
         participant = ParticipantModel.find_by_id(participant_id)
         templates = current_app.config['EMAIL_TEMPLATES']
         template_id = templates['SUBMISSION_RESPONSE']['ID']
-        subject, body, args = SubmissionService._render_submission_response_email_template(engagement_id)
+        subject, body, args = SubmissionService._render_submission_response_email_template(
+            engagement_id)
         try:
             notification.send_email(subject=subject,
                                     email=ParticipantModel.decode_email(
@@ -423,7 +428,8 @@ class SubmissionService:
         template = Template.get_template('submission_response.html')
         subject = templates['SUBMISSION_RESPONSE']['SUBJECT']
         dashboard_path = SubmissionService._get_dashboard_path(engagement)
-        engagement_url = notification.get_tenant_site_url(engagement.tenant_id, dashboard_path)
+        engagement_url = notification.get_tenant_site_url(
+            engagement.tenant_id, dashboard_path)
         email_environment = templates['ENVIRONMENT']
         tenant_name = SubmissionService._get_tenant_name(
             engagement.tenant_id)
@@ -445,7 +451,8 @@ class SubmissionService:
 
     @staticmethod
     def _get_dashboard_path(engagement: EngagementModel):
-        engagement_slug = EngagementSlugModel.find_by_engagement_id(engagement.id)
+        engagement_slug = EngagementSlugModel.find_by_engagement_id(
+            engagement.id)
         paths = current_app.config['PATH_CONFIG']
         if engagement_slug:
             return paths['ENGAGEMENT']['DASHBOARD_SLUG'].format(

--- a/met-api/tests/unit/api/test_submission.py
+++ b/met-api/tests/unit/api/test_submission.py
@@ -26,9 +26,7 @@ from faker import Faker
 
 from met_api.constants.comment_status import Status
 from met_api.constants.email_verification import EmailVerificationType
-from met_api.constants.engagement_status import SubmissionStatus
 from met_api.constants.membership_type import MembershipType
-from met_api.schemas.comment import CommentSchema
 from met_api.services.submission_service import SubmissionService
 from met_api.utils.enums import ContentType
 from tests.utilities.factory_scenarios import TestJwtClaims, TestSubmissionInfo
@@ -79,7 +77,7 @@ def test_edit_rejected_submission(client, jwt, session):  # pylint:disable=unuse
     participant = factory_participant_model()
     factory_engagement_setting_model(eng.id)
     submission_request = {
-        'submission_json': {"test_question": "test answer"},
+        'submission_json': {'test_question': 'test answer'},
         'engagement_id': eng.id,
         'survey_id': survey.id,
         'participant_id': participant.id,
@@ -87,12 +85,11 @@ def test_edit_rejected_submission(client, jwt, session):  # pylint:disable=unuse
     }
     submission = factory_submission_model(
         survey.id, eng.id, participant.id, TestSubmissionInfo.rejected_submission)
-    comment: CommentSchema = CommentSchema().dump(
-        factory_comment_model(survey.id, submission.id))
     email_verification = factory_email_verification(
         survey.id, type=EmailVerificationType.RejectedComment, submission_id=submission.id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
-    rv = client.put(f'/api/submissions/public/{email_verification.verification_token}', data=json.dumps(submission_request),
+    rv = client.put(f'/api/submissions/public/{email_verification.verification_token}',
+                    data=json.dumps(submission_request),
                     headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == 200
     # roll back any pending changes to make sure the session is clean

--- a/met-api/tests/unit/services/test_submission.py
+++ b/met-api/tests/unit/services/test_submission.py
@@ -15,12 +15,10 @@
 
 Test suite to ensure that the Submission service routines are working as expected.
 """
-from re import T
 from typing import List
 from unittest.mock import patch
 
 from met_api.constants.email_verification import EmailVerificationType
-from met_api.models import staff_user
 from met_api.models.comment import Comment
 from met_api.schemas.comment import CommentSchema
 from met_api.services import authorization

--- a/met-api/tests/unit/services/test_submission.py
+++ b/met-api/tests/unit/services/test_submission.py
@@ -61,7 +61,7 @@ def test_update_submission(session):  # pylint:disable=unused-argument
     participant = factory_participant_model()
     factory_engagement_setting_model(eng.id)
     submission_request: SubmissionSchema = {
-        'submission_json': {"test_question": "test answer"},
+        'submission_json': {'test_question': 'test answer'},
         'engagement_id': eng.id,
         'survey_id': survey.id,
         'participant_id': participant.id,

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -138,7 +138,7 @@ def factory_subscription_model():
     return subscription
 
 
-def factory_email_verification(survey_id, type=None):
+def factory_email_verification(survey_id, type=None, submission_id=None):
     """Produce a EmailVerification model."""
     email_verification = EmailVerificationModel(
         verification_token=fake.uuid4(),
@@ -151,6 +151,9 @@ def factory_email_verification(survey_id, type=None):
 
     if survey_id:
         email_verification.survey_id = survey_id
+
+    if submission_id:
+        email_verification.submission_id = submission_id
 
     email_verification.save()
     return email_verification
@@ -205,7 +208,8 @@ def factory_metadata_requirements(auth: Optional[Auth] = None):
     """Create a tenant, an associated staff user, and engagement, for tests."""
     tenant = factory_tenant_model()
     tenant.short_name = fake.lexify(text='????').upper()
-    (engagement_info := TestEngagementInfo.engagement1.copy())['tenant_id'] = tenant.id
+    (engagement_info := TestEngagementInfo.engagement1.copy())[
+        'tenant_id'] = tenant.id
     engagement = factory_engagement_model(engagement_info)
     (staff_info := TestUserInfo.user_staff_1.copy())['tenant_id'] = tenant.id
     factory_staff_user_model(TestJwtClaims.staff_admin_role['sub'], staff_info)
@@ -225,7 +229,8 @@ def factory_taxon_requirements(auth: Optional[Auth] = None):
     tenant = factory_tenant_model()
     tenant.short_name = fake.lexify(text='????').upper()
     (staff_info := TestUserInfo.user_staff_1.copy())['tenant_id'] = tenant.id
-    factory_staff_user_model(TestJwtClaims.staff_admin_role.get('sub'), staff_info)
+    factory_staff_user_model(
+        TestJwtClaims.staff_admin_role.get('sub'), staff_info)
     if auth:
         headers = factory_auth_header(
             auth,
@@ -276,7 +281,8 @@ def factory_participant_model(
 ):
     """Produce a participant model."""
     participant = ParticipantModel(
-        email_address=ParticipantModel.encode_email(participant['email_address']),
+        email_address=ParticipantModel.encode_email(
+            participant['email_address']),
     )
     participant.save()
     return participant
@@ -414,7 +420,8 @@ def patch_token_info(claims, monkeypatch):
         """Return token info."""
         return claims
 
-    monkeypatch.setattr('met_api.utils.user_context._get_token_info', token_info)
+    monkeypatch.setattr(
+        'met_api.utils.user_context._get_token_info', token_info)
 
     # Add a database user that matches the token
     # factory_staff_user_model(external_id=claims.get('sub'))
@@ -474,7 +481,8 @@ def factory_poll_model(widget, poll_info: dict = TestWidgetPollInfo.poll1):
 
 def factory_poll_answer_model(poll, answer_info: dict = TestPollAnswerInfo.answer1):
     """Produce a Poll  model."""
-    answer = PollAnswerModel(answer_text=answer_info.get('answer_text'), poll_id=poll.id)
+    answer = PollAnswerModel(answer_text=answer_info.get(
+        'answer_text'), poll_id=poll.id)
     answer.save()
     return answer
 


### PR DESCRIPTION
Issue #: [🎟️ DESENG-527](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-527)
*Description of changes:*
- **Bugfix**: Submission of rejected comments [🎟️ DESENG-527](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-527)
  - Fixed issue where resubmitted comments would not reappear in the queue for approval.
  - Added unit tests to ensure the issue does not reoccur.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
