### PR TITLE
[To Main / DESENG-577] Being more specific with CSS selectors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,12 @@
+## April 09, 2024
+
+- **Task**: CSS Selector specificity [🎟️ DESENG-577](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-577)
+  - Replace the `!important` flag with more specific CSS selectors, specifically within dropdowns,
+    to ensure that the correct styles are applied, and that states we have not yet designed for
+    (e.g, complex focus states) are still styled appropriately and in an accessible manner.
+  - Soon, we will be doing a more in-depth revamp of dropdowns in the app to make them more
+    accessible and user-friendly. This helps work towards that goal.
+
 ## April 08, 2024
 
 - **Bugfix**: Submission of rejected comments [🎟️ DESENG-527](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-527)

--- a/met-web/src/App.scss
+++ b/met-web/src/App.scss
@@ -25,24 +25,32 @@ code {
 }
 
 /** Overriding Select Menu Dropdown color **/
-// Background white and on hover light grey
+// Background white and on hover/focus, light grey
 .MuiMenuItem-root {
-  background-color: var(--bcds-surface-background-white) !important;
-  &:hover {
-    background-color: var(--bcds-surface-secondary-hover) !important;
-  }
+  background-color: var(--bcds-surface-background-white);
+
   &.Mui-selected {
-    // from MET design library
-    background-color: var(--bcds-surface-brand-blue-20) !important;
+    background-color: var(--bcds-surface-brand-blue-20);
+    &:hover, &.Mui-focusVisible {
+      background-color: var(--bcds-surface-secondary-hover);
+    }
+  }
+
+  &.Mui-disabled, &.Mui-disabled:hover {
+    background-color: var(--bcds-surface-background-white);
+  }
+  // the focusVisible class is added when the item is focused by keyboard
+  &.Mui-focusVisible, &:hover {
+    background-color: var(--bcds-surface-secondary-hover);
   }
 }
 
 /** Overriding Met table styles **/
 // set background color of tr to white
-.MuiTable-root tbody > tr {
-  background-color: var(--bcds-surface-background-white) !important;
+.MuiTable-root tbody > tr.MuiTableRow {
+  background-color: var(--bcds-surface-background-white);
 }
 // set background color of tr on hover to light gray
-tbody.MuiTableBody-root > tr:hover {
-  background-color: var(--bcds-surface-secondary-hover) !important;
+tbody.MuiTableBody-root > tr.MuiTableRow-hover:hover {
+  background-color: var(--bcds-surface-secondary-hover);
 }


### PR DESCRIPTION
Issue #: [🎟️ DESENG-577](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-577)

- **Task**: CSS Selector specificity 
  - Replace the `!important` flag with more specific CSS selectors, specifically within dropdowns,
    to ensure that the correct styles are applied, and that states we have not yet designed for
    (e.g, complex focus states) are still styled appropriately and in an accessible manner.
  - Soon, we will be doing a more in-depth revamp of dropdowns in the app to make them more
    accessible and user-friendly. This helps work towards that goal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
