### PR TITLE
[To Main] DESENG-541: Added save notifications for all engagement tabs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,10 @@
     (e.g, complex focus states) are still styled appropriately and in an accessible manner.
   - Soon, we will be doing a more in-depth revamp of dropdowns in the app to make them more
     accessible and user-friendly. This helps work towards that goal.
+- **Bugfix**: MET Web - No save feedback unless main content tab is selected [🎟️ DESENG-541](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-541)
+  - Implemented notifications for successful saves across all engagement tabs.
+  - Resolved issue with saving engagement summary content during engagement creation.
+  - Updated tooltip on engagement content to use MetTooltip for consistency.
 
 ## April 08, 2024
 

--- a/met-web/src/components/engagement/form/ActionContext.tsx
+++ b/met-web/src/components/engagement/form/ActionContext.tsx
@@ -218,6 +218,8 @@ export const ActionProvider = ({ children }: { children: JSX.Element }) => {
             });
 
             setEngagement(result);
+            const engagementContents = await getEngagementContent(Number(result.id));
+            setContentTabs(engagementContents);
             dispatch(openNotification({ severity: 'success', text: 'Engagement has been created' }));
             setSaving(false);
             return Promise.resolve(result);

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementContent/ContentTabs.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementContent/ContentTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Box, Button, IconButton, MenuItem, Tooltip, Menu, Skeleton, Grid, Divider } from '@mui/material';
+import { Box, Button, IconButton, MenuItem, Menu, Skeleton, Grid, Divider } from '@mui/material';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faPenToSquare, faPlus } from '@fortawesome/free-solid-svg-icons';
 import CustomTabContent from './CustomTabContent';
@@ -13,6 +13,7 @@ import { EngagementContentContext } from './EngagementContentContext';
 import { If, Then, Else } from 'react-if';
 import ContentTabModal from './ContentTabModal';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { MetTooltip } from 'components/common';
 
 export const ContentTabs: React.FC = () => {
     const { fetchEngagementContents, contentTabs, setContentTabs, savedEngagement } = useContext(ActionContext);
@@ -104,7 +105,7 @@ export const ContentTabs: React.FC = () => {
                                         label={
                                             <Box display="flex" alignItems="center">
                                                 <span>{tab.title}</span>
-                                                <Tooltip title="Edit Tab">
+                                                <MetTooltip title="Edit Tab">
                                                     <IconButton onClick={() => handleEditTab(index)} aria-label="edit">
                                                         <FontAwesomeIcon
                                                             icon={faPenToSquare as IconProp}
@@ -112,9 +113,9 @@ export const ContentTabs: React.FC = () => {
                                                             data-testid="edit-tab-details"
                                                         />
                                                     </IconButton>
-                                                </Tooltip>
+                                                </MetTooltip>
                                                 {index !== 0 && (
-                                                    <Tooltip title="Delete Tab">
+                                                    <MetTooltip title="Delete Tab">
                                                         <IconButton
                                                             onClick={() => handleDeleteTab(index)}
                                                             aria-label="delete"
@@ -124,7 +125,7 @@ export const ContentTabs: React.FC = () => {
                                                                 fontSize="small"
                                                             />
                                                         </IconButton>
-                                                    </Tooltip>
+                                                    </MetTooltip>
                                                 )}
                                             </Box>
                                         }
@@ -134,7 +135,7 @@ export const ContentTabs: React.FC = () => {
                                     aria-controls="add-tab-menu"
                                     aria-haspopup={!customTabAdded} // Only allow the dropdown if customTabAdded is false
                                     onClick={handleMenuOpen}
-                                    disabled={isAllTabTypesPresent()} // Disable the button if customTabAdded is true
+                                    disabled={isAllTabTypesPresent() || !savedEngagement.id} // Disable the button if customTabAdded is true
                                     data-testid="add-tab-menu"
                                 >
                                     <FontAwesomeIcon icon={faPlus as IconProp} fontSize="small" />

--- a/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementFormTabs/EngagementTabsContext.tsx
@@ -339,6 +339,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
                 engagement_id: savedEngagement.id,
             });
             await loadSettings();
+            dispatch(openNotification({ severity: 'success', text: 'Engagement has been saved' }));
             setSaving(false);
             return;
         } catch (error) {
@@ -376,6 +377,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
             );
             setEngagementSummaryContent(result);
             setRichContent(result.rich_content);
+            dispatch(openNotification({ severity: 'success', text: 'Engagement has been saved' }));
             setSaving(false);
             return;
         } catch (error) {
@@ -413,6 +415,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
             );
             setEngagementCustomContent(result);
             setCustomJsonContent(result.custom_json_content);
+            dispatch(openNotification({ severity: 'success', text: 'Engagement has been saved' }));
             setSaving(false);
             return;
         } catch (error) {
@@ -466,6 +469,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
                 engagement_id: savedEngagement.id,
             });
             setSavedSlug(response.slug);
+            dispatch(openNotification({ severity: 'success', text: 'Engagement has been saved' }));
             setSaving(false);
             return;
         } catch (error) {
@@ -507,6 +511,7 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
     };
 
     const handleSaveEngagementMetadata = async () => {
+        setSaving(true);
         const result = await metadataFormRef.current?.submitForm();
         if (metadataFormRef.current && !result) {
             dispatch(
@@ -516,6 +521,10 @@ export const EngagementTabsContextProvider = ({ children }: { children: React.Re
                 }),
             );
         }
+        if (metadataFormRef.current && result) {
+            dispatch(openNotification({ severity: 'success', text: 'Engagement has been saved' }));
+        }
+        setSaving(false);
         return result;
     };
 


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-541

*Description of changes:*
  - Implemented notifications for successful saves across all engagement tabs.
  - Resolved issue with saving engagement summary content during engagement creation.
  - Updated tooltip on engagement content to use MetTooltip for consistency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
