### PR TITLE
[To Feature] Updated unit test for in-app role management

### DIFF
--- a/met-api/tests/conftest.py
+++ b/met-api/tests/conftest.py
@@ -23,8 +23,9 @@ from sqlalchemy import event, text
 from met_api import create_app, setup_jwt_manager
 from met_api.auth import jwt as _jwt
 from met_api.models import db as _db
-from tests.utilities.factory_utils import factory_staff_user_model
+from tests.utilities.factory_utils import factory_staff_user_model, factory_user_group_membership_model
 from tests.utilities.factory_scenarios import TestJwtClaims, TestUserInfo
+from met_api.utils.enums import CompositeRoleId
 
 
 @pytest.fixture(scope='session')
@@ -180,6 +181,7 @@ def setup_admin_user_and_claims(jwt):
     """Set up a user with the staff admin role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
     claims['sub'] = str(user.external_id)
 
@@ -192,6 +194,7 @@ def setup_reviewer_and_claims(jwt):
     """Set up a user with the reviewer role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.REVIEWER.value)
     claims = copy.deepcopy(TestJwtClaims.reviewer_role.value)
     claims['sub'] = str(user.external_id)
 
@@ -204,6 +207,7 @@ def setup_team_member_and_claims(jwt):
     """Set up a user with the team member role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.TEAM_MEMBER.value)
     claims = copy.deepcopy(TestJwtClaims.team_member_role.value)
     claims['sub'] = str(user.external_id)
 

--- a/met-api/tests/unit/api/test_engagement_membership.py
+++ b/met-api/tests/unit/api/test_engagement_membership.py
@@ -7,37 +7,29 @@ import json
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from met_api.constants.membership_type import MembershipType
 from met_api.exceptions.business_exception import BusinessException
 from met_api.services.membership_service import MembershipService
-from met_api.utils.enums import ContentType, KeycloakCompositeRoleNames, MembershipStatus
+from met_api.utils.enums import CompositeRoleId, ContentType, MembershipStatus
 from tests.utilities.factory_utils import (
-    factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model)
+    factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model,
+    factory_user_group_membership_model)
 
 
 memberships_url = '/api/engagements/{}/members'
 
 
-def test_create_engagement_membership_team_member(mocker, client, jwt, session,
-                                                  setup_admin_user_and_claims):
+def test_create_engagement_membership_team_member(client, jwt, session, setup_admin_user_and_claims):
     """Assert that a team member engagement membership can be created."""
     user, claims = setup_admin_user_and_claims
     engagement = factory_engagement_model()
     staff_user = factory_staff_user_model()
+    factory_user_group_membership_model(str(staff_user.external_id), staff_user.tenant_id,
+                                        CompositeRoleId.TEAM_MEMBER.value)
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     mock_add_user_to_role_keycloak_response = MagicMock()
     mock_add_user_to_role_keycloak_response.status_code = HTTPStatus.NO_CONTENT
-    mock_add_user_to_role_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.assign_composite_role_to_user',
-        return_value=mock_add_user_to_role_keycloak_response
-    )
-    mock_get_users_roles_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.get_users_roles',
-        return_value={staff_user.external_id: [KeycloakCompositeRoleNames.TEAM_MEMBER.value]}
-    )
 
     data = {'user_id': staff_user.external_id}
 
@@ -52,8 +44,6 @@ def test_create_engagement_membership_team_member(mocker, client, jwt, session,
     assert rv.json.get('user_id') == staff_user.id
     assert rv.json.get('type') == MembershipType.TEAM_MEMBER
     assert rv.json.get('status') == MembershipStatus.ACTIVE.value
-    mock_add_user_to_role_keycloak.assert_called()
-    mock_get_users_roles_keycloak.assert_called()
 
     with patch.object(MembershipService, 'create_membership',
                       side_effect=BusinessException('Test error', status_code=HTTPStatus.INTERNAL_SERVER_ERROR)):
@@ -66,24 +56,17 @@ def test_create_engagement_membership_team_member(mocker, client, jwt, session,
     assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
-def test_create_engagement_membership_reviewer(mocker, client, jwt, session,
-                                               setup_admin_user_and_claims):
+def test_create_engagement_membership_reviewer(client, jwt, session, setup_admin_user_and_claims):
     """Assert that a reviewer engagement membership can be created."""
     user, claims = setup_admin_user_and_claims
     engagement = factory_engagement_model()
     staff_user = factory_staff_user_model()
+    factory_user_group_membership_model(str(staff_user.external_id), staff_user.tenant_id,
+                                        CompositeRoleId.REVIEWER.value)
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     mock_add_user_to_role_keycloak_response = MagicMock()
     mock_add_user_to_role_keycloak_response.status_code = HTTPStatus.NO_CONTENT
-    mock_add_user_to_group_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.assign_composite_role_to_user',
-        return_value=mock_add_user_to_role_keycloak_response
-    )
-    mock_get_users_roles_keycloak = mocker.patch(
-        'met_api.services.keycloak.KeycloakService.get_users_roles',
-        return_value={staff_user.external_id: [KeycloakCompositeRoleNames.REVIEWER.value]}
-    )
 
     data = {'user_id': staff_user.external_id}
 
@@ -98,8 +81,6 @@ def test_create_engagement_membership_reviewer(mocker, client, jwt, session,
     assert rv.json.get('user_id') == staff_user.id
     assert rv.json.get('type') == MembershipType.REVIEWER
     assert rv.json.get('status') == MembershipStatus.ACTIVE.value
-    mock_add_user_to_group_keycloak.assert_called()
-    mock_get_users_roles_keycloak.assert_called()
 
 
 def test_create_engagement_membership_unauthorized(client, jwt, session,
@@ -266,27 +247,17 @@ def test_get_membership(client, jwt, session,
     assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
-@pytest.mark.parametrize('side_effect, expected_status', [
-    (ValueError('Test error'), HTTPStatus.BAD_REQUEST),
-])
-def test_get_all_engagements_by_user(mocker, client, jwt, session, side_effect, expected_status,
-                                     setup_admin_user_and_claims):
+def test_get_all_engagements_by_user(client, jwt, session, setup_admin_user_and_claims):
     """Test that all engagements can be fetched for a member."""
     user, claims = setup_admin_user_and_claims
     engagement = factory_engagement_model()
     staff_user = factory_staff_user_model()
+    factory_user_group_membership_model(str(staff_user.external_id), staff_user.tenant_id,
+                                        CompositeRoleId.TEAM_MEMBER.value)
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     mock_add_user_to_role_keycloak_response = MagicMock()
     mock_add_user_to_role_keycloak_response.status_code = HTTPStatus.NO_CONTENT
-    mocker.patch(
-        'met_api.services.keycloak.KeycloakService.assign_composite_role_to_user',
-        return_value=mock_add_user_to_role_keycloak_response
-    )
-    mocker.patch(
-        'met_api.services.keycloak.KeycloakService.get_users_roles',
-        return_value={staff_user.external_id: [KeycloakCompositeRoleNames.TEAM_MEMBER.value]}
-    )
 
     data = {'user_id': staff_user.external_id}
 

--- a/met-api/tests/unit/api/test_user_membership.py
+++ b/met-api/tests/unit/api/test_user_membership.py
@@ -17,50 +17,17 @@
 Test-Suite to ensure that the user membership endpoints are working as expected.
 """
 from http import HTTPStatus
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from met_api.exceptions.business_exception import BusinessException
 from met_api.models.membership import Membership as MembershipModel
 from met_api.services.staff_user_membership_service import StaffUserMembershipService
-from met_api.utils.enums import ContentType, KeycloakCompositeRoleNames, MembershipStatus, UserStatus
+from met_api.utils.enums import ContentType, MembershipStatus, UserStatus
 from tests.utilities.factory_utils import (  # noqa: E501
-    factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model)
-
-
-KEYCLOAK_SERVICE_MODULE = 'met_api.services.keycloak.KeycloakService'
-
-
-def mock_keycloak_methods(mocker, mock_role_names):
-    """Mock the KeycloakService.assign_composite_role_to_user method."""
-    mock_response = MagicMock()
-    mock_response.status_code = HTTPStatus.NO_CONTENT
-
-    mock_assign_composite_role_to_user_keycloak = mocker.patch(
-        f'{KEYCLOAK_SERVICE_MODULE}.assign_composite_role_to_user', return_value=mock_response
-    )
-
-    mock_get_user_roles_keycloak = mocker.patch(
-        f'{KEYCLOAK_SERVICE_MODULE}.get_user_roles',
-        return_value=[{'name': role_name} for role_name in mock_role_names],
-    )
-
-    # mock_add_attribute_to_user = mocker.patch(
-    #     f'{KEYCLOAK_SERVICE_MODULE}.add_attribute_to_user',
-    #     return_value=mock_response
-    # )
-
-    mock_remove_user_from_role_keycloak = mocker.patch(
-        f'{KEYCLOAK_SERVICE_MODULE}.remove_composite_role_from_user', return_value=mock_response
-    )
-
-    return (
-        mock_assign_composite_role_to_user_keycloak,
-        mock_get_user_roles_keycloak,
-        # mock_add_attribute_to_user,
-        mock_remove_user_from_role_keycloak,
-    )
+    factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model,
+    factory_user_group_membership_model)
 
 
 @pytest.mark.parametrize(
@@ -74,19 +41,9 @@ def test_reassign_user_reviewer_team_member(mocker, client, jwt, session, setup_
     """Assert that returns bad request if bad request body."""
     user = factory_staff_user_model()
     eng = factory_engagement_model()
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     current_membership = factory_membership_model(user_id=user.id, engagement_id=eng.id)  # noqa: E501
     assert current_membership.status == MembershipStatus.ACTIVE.value
-    mock_response = MagicMock()
-    mock_response.status_code = HTTPStatus.NO_CONTENT
-
-    (mock_assign_composite_role_to_user_keycloak, mock_get_user_roles_keycloak, mock_remove_user_from_role_keycloak) = (
-        mock_keycloak_methods(mocker, [KeycloakCompositeRoleNames.REVIEWER.value])
-    )
-
-    mock_get_users_roles_keycloak = mocker.patch(
-        f'{KEYCLOAK_SERVICE_MODULE}.get_users_roles',
-        return_value={user.external_id: [KeycloakCompositeRoleNames.REVIEWER.value]},
-    )
 
     assert user.status_id == UserStatus.ACTIVE.value
     _, claims = setup_admin_user_and_claims
@@ -97,10 +54,6 @@ def test_reassign_user_reviewer_team_member(mocker, client, jwt, session, setup_
     )
 
     assert rv.status_code == HTTPStatus.OK
-    mock_assign_composite_role_to_user_keycloak.assert_called()
-    mock_get_user_roles_keycloak.assert_called()
-    mock_remove_user_from_role_keycloak.assert_called()
-    mock_get_users_roles_keycloak.assert_called()
 
     memberships = MembershipModel.find_by_user_id(user.id)
     assert len(memberships) == 1

--- a/met-api/tests/unit/services/test_comment.py
+++ b/met-api/tests/unit/services/test_comment.py
@@ -20,12 +20,13 @@ from met_api.services.comment_service import CommentService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestSubmissionInfo
 from tests.utilities.factory_utils import (
     factory_comment_model, factory_membership_model, factory_participant_model, factory_staff_user_model,
-    factory_submission_model, factory_survey_and_eng_model, patch_token_info)
+    factory_submission_model, factory_survey_and_eng_model, patch_token_info, set_global_tenant)
 
 
 def test_get_comments(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that comments can be fetched."""
     patch_token_info(TestJwtClaims.public_user_role, monkeypatch)
+    set_global_tenant()
     user_details = factory_staff_user_model(external_id=TestJwtClaims.public_user_role['sub'])
     participant = factory_participant_model()
     survey, eng = factory_survey_and_eng_model()

--- a/met-api/tests/unit/services/test_engagement.py
+++ b/met-api/tests/unit/services/test_engagement.py
@@ -22,7 +22,9 @@ from faker import Faker
 from met_api.services import authorization
 from met_api.services.engagement_service import EngagementService
 from tests.utilities.factory_scenarios import TestEngagementInfo, TestJwtClaims
-from tests.utilities.factory_utils import factory_engagement_model, factory_staff_user_model, patch_token_info
+from tests.utilities.factory_utils import (
+    factory_engagement_model, factory_staff_user_model, factory_user_group_membership_model, patch_token_info,
+    set_global_tenant)
 
 fake = Faker()
 date_format = '%Y-%m-%d'
@@ -31,7 +33,9 @@ date_format = '%Y-%m-%d'
 def test_create_engagement(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     engagement_data = TestEngagementInfo.engagement1
     saved_engagament = EngagementService().create_engagement(engagement_data)
     # fetch the engagement with id and assert
@@ -46,7 +50,9 @@ def test_create_engagement(session, monkeypatch):  # pylint:disable=unused-argum
 def test_create_engagement_with_survey_block(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     engagement_data = TestEngagementInfo.engagement2
     saved_engagament = EngagementService().create_engagement(engagement_data)
     # fetch the engagement with id and assert

--- a/met-api/tests/unit/services/test_engagement_content_translation_service.py
+++ b/met-api/tests/unit/services/test_engagement_content_translation_service.py
@@ -4,7 +4,7 @@ from met_api.services.engagement_content_translation_service import EngagementCo
 from tests.utilities.factory_scenarios import TestEngagementContentTranslationInfo, TestJwtClaims
 from tests.utilities.factory_utils import (
     engagement_content_model_with_language, factory_engagement_content_translation_model, factory_staff_user_model,
-    patch_token_info)
+    factory_user_group_membership_model, patch_token_info, set_global_tenant)
 
 
 def test_get_engagement_content_translation_by_id(session):
@@ -48,7 +48,9 @@ def test_create_engagement_content_translation_without_prepopulate(session, monk
     """Assert that an engagement content translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     engagement_content, language = engagement_content_model_with_language()
     data = {
         **TestEngagementContentTranslationInfo.translation_info1.value,
@@ -65,7 +67,9 @@ def test_create_engagement_content_translation_with_prepopulate(session, monkeyp
     """Assert that an engagement content translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     engagement_content, language = engagement_content_model_with_language()
     data = {
         **TestEngagementContentTranslationInfo.translation_info1.value,
@@ -82,7 +86,9 @@ def test_update_engagement_content_translation_with_authorization(session, monke
     """Assert that an engagement content translation can be updated with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     engagement_content, language = engagement_content_model_with_language()
     translation = factory_engagement_content_translation_model(
         {
@@ -104,7 +110,9 @@ def test_delete_engagement_content_translation_with_authorization(session, monke
     """Assert that an engagement content translation can be deleted with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     engagement_content, language = engagement_content_model_with_language()
     translation = factory_engagement_content_translation_model(
         {

--- a/met-api/tests/unit/services/test_event_item_translation_service.py
+++ b/met-api/tests/unit/services/test_event_item_translation_service.py
@@ -2,7 +2,8 @@
 from met_api.services.event_item_translation_service import EventItemTranslationService
 from tests.utilities.factory_scenarios import TestEventItemTranslationInfo, TestJwtClaims
 from tests.utilities.factory_utils import (
-    event_item_model_with_language, factory_event_item_translation_model, factory_staff_user_model, patch_token_info)
+    event_item_model_with_language, factory_event_item_translation_model, factory_staff_user_model,
+    factory_user_group_membership_model, patch_token_info, set_global_tenant)
 
 
 def test_get_event_item_translation_by_id(session):
@@ -49,7 +50,9 @@ def test_create_event_item_translation_with_authorization(
     """Assert that an event item translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     event_item, event, language = event_item_model_with_language()
     data = {
         ** TestEventItemTranslationInfo.event_item_info1.value,
@@ -73,7 +76,9 @@ def test_create_event_item_translation_with_authorization_pre_populate(
     """Assert that an event item translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     event_item, event, language = event_item_model_with_language()
     data = {
         ** TestEventItemTranslationInfo.event_item_info1.value,
@@ -97,7 +102,9 @@ def test_update_event_item_translation_with_authorization(
     """Assert that an event item translation can be updated with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     event_item, event, language = event_item_model_with_language()
     translation = factory_event_item_translation_model(
         {
@@ -124,7 +131,9 @@ def test_delete_event_item_translation_with_authorization(
     """Assert that an event item translation can be deleted with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     event_item, event, language = event_item_model_with_language()
     translation = factory_event_item_translation_model(
         {

--- a/met-api/tests/unit/services/test_poll_answer_translation_service.py
+++ b/met-api/tests/unit/services/test_poll_answer_translation_service.py
@@ -6,8 +6,8 @@ Test suite to ensure that the PollAnswerTranslationService routines are working 
 from met_api.services.poll_answer_translation_service import PollAnswerTranslationService
 from tests.utilities.factory_scenarios import TestJwtClaims
 from tests.utilities.factory_utils import (
-    factory_poll_answer_translation_model, factory_staff_user_model, patch_token_info,
-    poll_answer_model_with_poll_enagement)
+    factory_poll_answer_translation_model, factory_staff_user_model, factory_user_group_membership_model,
+    patch_token_info, poll_answer_model_with_poll_enagement, set_global_tenant)
 
 
 def test_get_poll_answer_translation_by_id(session):
@@ -54,7 +54,9 @@ def test_create_poll_answer_translation_with_authorization(
     """Assert that a poll answer translation can be created with proper authorization."""
     # Mock the authorization check or provide necessary setup
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     answer, poll, language = poll_answer_model_with_poll_enagement()
     data = {
         'poll_answer_id': answer.id,
@@ -77,7 +79,9 @@ def test_create_poll_answer_translation_with_authorization_with_prepopulate(
     """Assert that a poll answer translation can be created with proper authorization."""
     # Mock the authorization check or provide necessary setup
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     answer, poll, language = poll_answer_model_with_poll_enagement()
 
     data = {
@@ -101,7 +105,9 @@ def test_update_poll_answer_translation_with_authorization(
     """Assert that a poll answer translation can be updated with proper authorization."""
     # Mock the authorization check or provide necessary setup
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     answer, poll, language = poll_answer_model_with_poll_enagement()
     translation = factory_poll_answer_translation_model(
         {
@@ -127,7 +133,9 @@ def test_delete_poll_answer_translation_with_authorization(
     """Assert that a poll answer translation can be deleted with proper authorization."""
     # Mock the authorization check or provide necessary setup
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     answer, poll, language = poll_answer_model_with_poll_enagement()
     translation = factory_poll_answer_translation_model(
         {

--- a/met-api/tests/unit/services/test_subscribe_item_translation_service.py
+++ b/met-api/tests/unit/services/test_subscribe_item_translation_service.py
@@ -3,8 +3,8 @@
 from met_api.services.subscribe_item_translation_service import SubscribeItemTranslationService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestSubscribeItemTranslationInfo
 from tests.utilities.factory_utils import (
-    factory_staff_user_model, factory_subscribe_item_translation_model, patch_token_info,
-    subscribe_item_model_with_language)
+    factory_staff_user_model, factory_subscribe_item_translation_model, factory_user_group_membership_model,
+    patch_token_info, set_global_tenant, subscribe_item_model_with_language)
 
 
 def test_get_subscribe_item_translation_by_id(session):
@@ -51,7 +51,9 @@ def test_create_subscribe_item_translation_with_authorization(
     """Assert that a subscribe item translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     subscribe_item, widget_subscribe, language = subscribe_item_model_with_language()
     data = {
         **TestSubscribeItemTranslationInfo.translate_info1.value,
@@ -75,7 +77,9 @@ def test_create_subscribe_item_translation_with_authorization_with_prepopulate(
     """Assert that a subscribe item translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     subscribe_item, widget_subscribe, language = subscribe_item_model_with_language()
     data = {
         'subscribe_item_id': subscribe_item.id,
@@ -97,7 +101,9 @@ def test_update_subscribe_item_translation_with_authorization(
     """Assert that a subscribe item translation can be updated with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     subscribe_item, widget_subscribe, language = subscribe_item_model_with_language()
     translation = factory_subscribe_item_translation_model(
         {
@@ -124,7 +130,9 @@ def test_delete_subscribe_item_translation_with_authorization(
     """Assert that a subscribe item translation can be deleted with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     subscribe_item, widget_subscribe, language = subscribe_item_model_with_language()
     translation = factory_subscribe_item_translation_model(
         {

--- a/met-api/tests/unit/services/test_survey.py
+++ b/met-api/tests/unit/services/test_survey.py
@@ -18,7 +18,8 @@ Test suite to ensure that the Survey service routines are working as expected.
 
 from met_api.services.survey_service import SurveyService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestSurveyInfo
-from tests.utilities.factory_utils import factory_staff_user_model, patch_token_info
+from tests.utilities.factory_utils import (
+    factory_staff_user_model, factory_user_group_membership_model, patch_token_info, set_global_tenant)
 
 
 def test_create_survey(session, monkeypatch,):  # pylint:disable=unused-argument
@@ -28,7 +29,9 @@ def test_create_survey(session, monkeypatch,):  # pylint:disable=unused-argument
         'display': TestSurveyInfo.survey1.get('form_json').get('display'),
     }
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     saved_survey = SurveyService().create(survey_data)
     # fetch the survey with id and assert
     fetched_survey = SurveyService().get(saved_survey.id)

--- a/met-api/tests/unit/services/test_survey_translation_service.py
+++ b/met-api/tests/unit/services/test_survey_translation_service.py
@@ -7,7 +7,8 @@ from met_api.services.survey_translation_service import SurveyTranslationService
 from tests.utilities.factory_scenarios import TestJwtClaims
 from tests.utilities.factory_utils import (
     factory_language_model, factory_staff_user_model, factory_survey_and_eng_model,
-    factory_survey_translation_and_engagement_model, patch_token_info)
+    factory_survey_translation_and_engagement_model, factory_user_group_membership_model, patch_token_info,
+    set_global_tenant)
 
 
 def test_get_survey_translation_by_id(session):
@@ -27,7 +28,9 @@ def test_create_survey_translation(session, monkeypatch):
     """Assert that a survey translation can be created."""
     # Setup language and survey
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     language = factory_language_model()
     session.add(language)
     session.commit()
@@ -65,7 +68,9 @@ def test_create_survey_translation(session, monkeypatch):
 def test_update_survey_translation(session, monkeypatch):
     """Assert that a survey translation can be updated."""
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
 
     translation, _, _ = factory_survey_translation_and_engagement_model()
 
@@ -80,7 +85,9 @@ def test_update_survey_translation(session, monkeypatch):
 def test_delete_survey_translation(session, monkeypatch):
     """Assert that a survey translation can be deleted."""
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     translation, _, _ = factory_survey_translation_and_engagement_model()
     session.add(translation)
     session.commit()

--- a/met-api/tests/unit/services/test_timeline_event_translation_service.py
+++ b/met-api/tests/unit/services/test_timeline_event_translation_service.py
@@ -3,8 +3,8 @@
 from met_api.services.timeline_event_translation_service import TimelineEventTranslationService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestTimelineEventTranslationInfo
 from tests.utilities.factory_utils import (
-    factory_staff_user_model, factory_timeline_event_translation_model, patch_token_info,
-    timeline_event_model_with_language)
+    factory_staff_user_model, factory_timeline_event_translation_model, factory_user_group_membership_model,
+    patch_token_info, set_global_tenant, timeline_event_model_with_language)
 
 
 def test_get_timeline_event_translation_by_id(session):
@@ -51,7 +51,9 @@ def test_create_timeline_event_translation_with_authorization(
     """Assert that a subscribe item translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     timeline_event, widget_timeline, language = timeline_event_model_with_language()
     data = {
         **TestTimelineEventTranslationInfo.timeline_event_info1.value,
@@ -75,7 +77,9 @@ def test_create_timeline_event_translation_with_authorization_with_prepopulate(
     """Assert that a subscribe item translation can be created with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     timeline_event, widget_timeline, language = timeline_event_model_with_language()
     data = {
         'timeline_event_id': timeline_event.id,
@@ -97,7 +101,9 @@ def test_update_timeline_event_translation_with_authorization(
     """Assert that a subscribe item translation can be updated with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     timeline_event, widget_timeline, language = timeline_event_model_with_language()
     translation = factory_timeline_event_translation_model(
         {
@@ -124,7 +130,9 @@ def test_delete_timeline_event_translation_with_authorization(
     """Assert that a subscribe item translation can be deleted with proper authorization."""
     # Mock authorization
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     timeline_event, widget_timeline, language = timeline_event_model_with_language()
     translation = factory_timeline_event_translation_model(
         {

--- a/met-api/tests/unit/services/test_widget.py
+++ b/met-api/tests/unit/services/test_widget.py
@@ -23,8 +23,8 @@ from met_api.schemas.widget_item import WidgetItemSchema
 from met_api.services.widget_service import WidgetService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestUserInfo, TestWidgetInfo, TestWidgetItemInfo
 from tests.utilities.factory_utils import (
-    factory_engagement_model, factory_staff_user_model, factory_widget_item_model, factory_widget_model,
-    patch_token_info)
+    factory_engagement_model, factory_staff_user_model, factory_user_group_membership_model, factory_widget_item_model,
+    factory_widget_model, patch_token_info, set_global_tenant)
 
 
 fake = Faker()
@@ -40,7 +40,9 @@ def test_create_widget(session, monkeypatch):  # pylint:disable=unused-argument
         'widget_type_id': WidgetType.WHO_IS_LISTENING.value
     }
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
-    factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    set_global_tenant()
+    user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
+    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
     widget_record = WidgetService().create_widget(widget_to_create, engagement.id)
 
     # Assert that was created

--- a/met-api/tests/utilities/factory_scenarios.py
+++ b/met-api/tests/utilities/factory_scenarios.py
@@ -402,7 +402,6 @@ class TestJwtClaims(dict, Enum):
             'create_admin_user',
             'edit_members',
             'toggle_user_status',
-            'export_to_csv',
             'update_user_group',
             'create_tenant'
         ]
@@ -418,33 +417,7 @@ class TestJwtClaims(dict, Enum):
         'tenant_id': 1,
         'email': 'staff@gov.bc.ca',
         'identity_provider': LoginSource.IDIR.value,
-        'client_roles': [
-            'staff',
-            'view_engagement',
-            'create_engagement',
-            'edit_engagement',
-            'create_survey',
-            'view_users',
-            'view_private_engagements',
-            'create_admin_user',
-            'view_all_surveys',
-            'view_surveys',
-            'edit_all_surveys',
-            'edit_survey',
-            'view_unapproved_comments',
-            'clone_survey',
-            'edit_members',
-            'review_comments',
-            'review_all_comments',
-            'view_all_engagements',
-            'toggle_user_status',
-            'export_all_to_csv',
-            'update_user_group',
-            'export_proponent_comment_sheet',
-            'export_internal_comment_sheet',
-            'export_cac_form_to_sheet',
-            'view_members'
-        ]
+        'client_roles': []
     }
     team_member_role = {
         'iss': CONFIG.JWT_OIDC_TEST_ISSUER,
@@ -456,13 +429,7 @@ class TestJwtClaims(dict, Enum):
         'email': 'staff@gov.bc.ca',
         'identity_provider': LoginSource.IDIR.value,
         'tenant_id': 1,
-        'client_roles': [
-            'staff',
-            'view_engagement',
-            'view_users',
-            'clone_survey',
-            'export_proponent_comment_sheet'
-        ]
+        'client_roles': []
     }
 
     reviewer_role = {
@@ -475,10 +442,7 @@ class TestJwtClaims(dict, Enum):
         'email': 'staff@gov.bc.ca',
         'identity_provider': LoginSource.IDIR.value,
         'tenant_id': 1,
-        'client_roles': [
-            'staff',
-            'view_users',
-        ]
+        'client_roles': []
     }
 
 


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-574

*Description of changes:*
- Implemented functionality to fetch roles directly from the database instead of relying on role generation from the factory.
- Eliminated the Keycloak mock.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
