### PR TITLE
[To Main] Openshift - update buildconfig yaml

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,8 +1,14 @@
+## April 22, 2024
+
+- **Task** Openshift - Update the buildconfig for the MET-cron job runner [🎟️ DESENG-559](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-559)
+  - Versioning now uses the openshift.io namespace
+
 ## April 11, 2024
+
 - **Task** Multi-language - Create engagement content translation tables & API routes [DESENG-544](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-544)
-    - Created a new table for engagement content translations
-    - Created API routes and services for engagement content translations
-    - Created Unit tests for engagement content translations
+  - Created a new table for engagement content translations
+  - Created API routes and services for engagement content translations
+  - Created Unit tests for engagement content translations
 
 ## April 10, 2024
 

--- a/openshift/cron.bc.yml
+++ b/openshift/cron.bc.yml
@@ -1,98 +1,101 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
-    description: Build template for a MET ETL Cron job.
+    description: Build template for the MET Cron job runner.
     tags: flask
     iconClass: icon-python
   name: "${NAME}-build-template"
 objects:
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    name: "${NAME}"
-- kind: BuildConfig
-  apiVersion: v1
-  metadata:
-    name: "${NAME}"
-    labels:
-      app: "${NAME}"
-      app-group: "${APP_GROUP}"
-      template: "${NAME}-build"
-  spec:
-    source:
-      type: Git
-      git:
-        uri: "${GIT_REPO_URL}"
-        ref: "${GIT_REF}"
-      contextDir: "${SOURCE_CONTEXT_DIR}"
-    strategy:
-      type: Docker
-      dockerStrategy:
-        dockerfilePath: "${DOCKER_FILE_PATH}"
-    output:
-      to:
-        kind: ImageStreamTag
-        name: "${NAME}:${OUTPUT_IMAGE_TAG}"
-    triggers:
-    - type: ConfigChange
+  - kind: ImageStream
+    apiVersion: image.openshift.io/v1
+    metadata:
+      name: "${NAME}"
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: "${NAME}"
+      labels:
+        app: "${NAME}"
+        app-group: "${APP_GROUP}"
+        template: "${NAME}-build"
+    spec:
+      source:
+        type: Git
+        git:
+          uri: "${GIT_REPO_URL}"
+          ref: "${GIT_REF}"
+        contextDir: "${SOURCE_CONTEXT_DIR}"
+      strategy:
+        type: Docker
+        dockerStrategy:
+          dockerfilePath: "${DOCKER_FILE_PATH}"
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "${NAME}:${OUTPUT_IMAGE_TAG}"
+      triggers:
+        - type: ConfigChange
 parameters:
-- name: NAME
-  displayName: Name
-  description: The name assigned to all of the objects defined in this template.  You
-    should keep this as default unless your know what your doing.
-  required: true
-  value: met-cron
-- name: APP_GROUP
-  displayName: App Group
-  description: The name assigned to all of the deployments in this project.
-  required: true
-  value: met-app
-- name: GIT_REPO_URL
-  displayName: Git Repo URL
-  description: The URL to your GIT repo, don't use the this default unless your just
-    experimenting.
-  required: true
-  value: https://github.com/bcgov/met-public.git
-- name: GIT_REF
-  displayName: Git Reference
-  description: The git reference or branch.
-  required: true
-  value: main
-- name: SOURCE_CONTEXT_DIR
-  displayName: Source Context Directory
-  description: The source context directory.
-  required: true
-  value: met-cron
-- name: SOURCE_IMAGE_KIND
-  displayName: Source Image Kind
-  required: true
-  description: The 'kind' (type) of the  source image; typically ImageStreamTag, or
-    DockerImage.
-  value: ImageStreamTag
-- name: SOURCE_IMAGE_NAME_SPACE
-  displayName: Source Image Name Space
-  required: true
-  description: The name space of the  source image.
-  value: e903c2-tools
-- name: SOURCE_IMAGE_NAME
-  displayName: Source Image Name
-  required: true
-  description: The name of the source image.
-  value: python
-- name: SOURCE_IMAGE_TAG
-  displayName: Source Image Tag
-  required: true
-  description: The tag of the source image.
-  value: '3.7'
-- name: OUTPUT_IMAGE_TAG
-  displayName: Output Image Tag
-  description: The tag given to the built image.
-  required: true
-  value: latest
-- name: DOCKER_FILE_PATH
-  displayName: Docker File Path
-  description: The path to the docker file defining the build.
-  required: false
-  value: Dockerfile
+  - name: NAME
+    displayName: Name
+    description:
+      The name assigned to all of the objects defined in this template. You
+      should keep this as default unless you know what you're doing.
+    required: true
+    value: met-cron
+  - name: APP_GROUP
+    displayName: App Group
+    description: The name assigned to all of the deployments in this project.
+    required: true
+    value: met-app
+  - name: GIT_REPO_URL
+    displayName: Git Repo URL
+    description:
+      The URL to your GIT repo, don't use the this default unless you're just
+      experimenting.
+    required: true
+    value: https://github.com/bcgov/met-public.git
+  - name: GIT_REF
+    displayName: Git Reference
+    description: The git reference or branch.
+    required: true
+    value: main
+  - name: SOURCE_CONTEXT_DIR
+    displayName: Source Context Directory
+    description: The source context directory.
+    required: true
+    value: met-cron
+  - name: SOURCE_IMAGE_KIND
+    displayName: Source Image Kind
+    required: true
+    description:
+      The 'kind' (type) of the  source image; typically ImageStreamTag, or
+      DockerImage.
+    value: ImageStreamTag
+  - name: SOURCE_IMAGE_NAME_SPACE
+    displayName: Source Image Name Space
+    required: true
+    description: The name space of the source image.
+    value: e903c2-tools
+  - name: SOURCE_IMAGE_NAME
+    displayName: Source Image Name
+    required: true
+    description: The name of the source image.
+    value: python
+  - name: SOURCE_IMAGE_TAG
+    displayName: Source Image Tag
+    required: true
+    description: The tag of the source image.
+    value: "3.7"
+  - name: OUTPUT_IMAGE_TAG
+    displayName: Output Image Tag
+    description: The tag given to the built image.
+    required: true
+    value: latest
+  - name: DOCKER_FILE_PATH
+    displayName: Docker File Path
+    description: The path to the docker file defining the build.
+    required: false
+    value: Dockerfile


### PR DESCRIPTION
*Description of changes:*
- **Task** Openshift - Update the buildconfig for the MET-cron job runner [🎟️ DESENG-559](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-559)
  - Versioning now uses the openshift.io namespace
  - Changed some item descriptions
  - This solves an error where `oc process` wouldn't read the file and create JSONs for it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
