### PR TITLE
[To Main] DESENG-478 - Override _add_tenant_filter to check in user group membership table for tenant mapping

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## May 7, 2024
+
+- **Feature** Ensure users can belong to more than one tenant [🎟️ DESENG-478](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-478)
+  - Tested users can belong to more than one tenant.
+  - Overide the default tenant filter for staff_user table to check with user_group_membership table.
+
 ## May 2, 2024
 
 - **Feature** Added a new landing page for tenant management [🎟️ DESENG-591](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-591)

--- a/met-api/tests/unit/api/test_user.py
+++ b/met-api/tests/unit/api/test_user.py
@@ -83,7 +83,6 @@ def test_get_staff_users(client, jwt, session, setup_admin_user_and_claims, setu
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.get('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == HTTPStatus.OK
-    print(rv.json.get('items'))
     assert rv.json.get('total') == 5
     assert len(rv.json.get('items')) == 5
 

--- a/met-api/tests/unit/api/test_user.py
+++ b/met-api/tests/unit/api/test_user.py
@@ -67,15 +67,23 @@ def test_get_staff_users(client, jwt, session, setup_admin_user_and_claims, setu
     staff_2 = dict(TestUserInfo.user_staff_1)
     staff_other_tenant = dict(TestUserInfo.user_staff_2)
     staff_other_tenant['tenant_id'] = factory_tenant_model(TestTenantInfo.tenant2).id
-    factory_staff_user_model(user_info=staff_1)
-    factory_staff_user_model(user_info=staff_2)
-    factory_staff_user_model(user_info=staff_other_tenant)
+    user1 = factory_staff_user_model(user_info=staff_1)
+    # Mapping user1 to its tenant via user group membership
+    factory_user_group_membership_model(str(user1.external_id), user1.tenant_id)
+    user2 = factory_staff_user_model(user_info=staff_2)
+    # Mapping user2 to its tenant via user group membership
+    factory_user_group_membership_model(str(user2.external_id), user2.tenant_id)
+
+    user3 = factory_staff_user_model(user_info=staff_other_tenant)
+    # Mapping user3 to its tenant via user group membership
+    factory_user_group_membership_model(str(user3.external_id), user3.tenant_id)
 
     # Check that staff admins can see users within the same tenant
     _, claims = setup_admin_user_and_claims
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.get('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == HTTPStatus.OK
+    print(rv.json.get('items'))
     assert rv.json.get('total') == 5
     assert len(rv.json.get('items')) == 5
 


### PR DESCRIPTION
Issue #: https://apps.itsm.gov.bc.ca/jira/browse/DESENG-478

*Description of changes:*
 - Tested users can belong to more than one tenant.
  - Override the default tenant filter for the **staff_user** table to check with the **user_group_membership** table.
  
  Note : tenant_id is left as it is in the staff_user table to track the tenant_id of the user when it is created first time. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
