### PR TITLE
[To Main] DESENG-654: Add skeleton for new Engagement Authoring page

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## July 10, 2024
+
+- **Feature** Add a skeleton page for the new engagement authoring wizard [🎟️ DESENG-654](https://citz-gdx.atlassian.net/browse/DESENG-654)
+  - Users are taken to the new page when pressing the "create engagement" button.
+  - This route will be updated in future tickets to include the full authoring wizard, and will eventually replace the old authoring flow.
+
 ## July 9, 2024
 
 - **Task** Add data router features to survey pages [DESENG-642](https://citz-gdx.atlassian.net/browse/DESENG-642)
@@ -7,6 +13,7 @@
   - Add useBlocker() call to the survey authoring and survey submission pages to prevent users from navigating away from the page while in the middle of creating or submitting a survey
 
 ## June 28, 2024
+
 - **Task** Improve screen reader support for home/engagement search page [DESENG-617](https://citz-gdx.atlassian.net/browse/DESENG-617)
 
 ## June 27, 2024

--- a/met-web/src/components/engagement/listing/AdvancedSearch/SearchComponent.tsx
+++ b/met-web/src/components/engagement/listing/AdvancedSearch/SearchComponent.tsx
@@ -10,9 +10,9 @@ import {
     useMediaQuery,
     Theme,
 } from '@mui/material';
-import { MetParagraphOld, MetLabel } from 'components/common';
 import { EngagementDisplayStatus } from 'constants/engagementStatus';
-import { PrimaryButtonOld, SecondaryButtonOld } from '../../../common';
+import { Button } from 'components/common/Input';
+import { BodyText } from 'components/common/Typography';
 import dayjs from 'dayjs';
 import { formatToUTC } from 'components/common/dateHelper';
 import { SearchOptions } from './SearchTypes';
@@ -115,7 +115,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
         >
             <Grid item xs={12} lg={2}>
                 <FormControl component="fieldset">
-                    <MetLabel>Status</MetLabel>
+                    <BodyText bold>Status</BodyText>
                     <FormGroup row={isMediumScreen}>
                         <FormControlLabel
                             control={
@@ -130,11 +130,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                                     }}
                                 />
                             }
-                            label={
-                                <MetParagraphOld>
-                                    {EngagementDisplayStatus[EngagementDisplayStatus.Draft]}
-                                </MetParagraphOld>
-                            }
+                            label={<BodyText>{EngagementDisplayStatus[EngagementDisplayStatus.Draft]}</BodyText>}
                         />
                         <FormControlLabel
                             control={
@@ -149,11 +145,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                                     }}
                                 />
                             }
-                            label={
-                                <MetParagraphOld>
-                                    {EngagementDisplayStatus[EngagementDisplayStatus.Scheduled]}
-                                </MetParagraphOld>
-                            }
+                            label={<BodyText>{EngagementDisplayStatus[EngagementDisplayStatus.Scheduled]}</BodyText>}
                         />
                         <FormControlLabel
                             control={
@@ -168,11 +160,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                                     }}
                                 />
                             }
-                            label={
-                                <MetParagraphOld>
-                                    {EngagementDisplayStatus[EngagementDisplayStatus.Upcoming]}
-                                </MetParagraphOld>
-                            }
+                            label={<BodyText>{EngagementDisplayStatus[EngagementDisplayStatus.Upcoming]}</BodyText>}
                         />
                         <FormControlLabel
                             control={
@@ -187,11 +175,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                                     }}
                                 />
                             }
-                            label={
-                                <MetParagraphOld>
-                                    {EngagementDisplayStatus[EngagementDisplayStatus.Open]}
-                                </MetParagraphOld>
-                            }
+                            label={<BodyText>{EngagementDisplayStatus[EngagementDisplayStatus.Open]}</BodyText>}
                         />
                         <FormControlLabel
                             control={
@@ -206,11 +190,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                                     }}
                                 />
                             }
-                            label={
-                                <MetParagraphOld>
-                                    {EngagementDisplayStatus[EngagementDisplayStatus.Closed]}
-                                </MetParagraphOld>
-                            }
+                            label={<BodyText>{EngagementDisplayStatus[EngagementDisplayStatus.Closed]}</BodyText>}
                         />
                         <FormControlLabel
                             control={
@@ -225,11 +205,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                                     }}
                                 />
                             }
-                            label={
-                                <MetParagraphOld>
-                                    {EngagementDisplayStatus[EngagementDisplayStatus.Unpublished]}
-                                </MetParagraphOld>
-                            }
+                            label={<BodyText>{EngagementDisplayStatus[EngagementDisplayStatus.Unpublished]}</BodyText>}
                         />
                     </FormGroup>
                 </FormControl>
@@ -256,7 +232,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                     spacing={2}
                 >
                     <Grid item xs={12} sm={6}>
-                        <MetLabel>Date Created - From</MetLabel>
+                        <BodyText bold>Date Created - From</BodyText>
                         <TextField
                             id="createdFrom-date"
                             data-testid="createdFrom-date"
@@ -272,7 +248,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                         />
                     </Grid>
                     <Grid item xs={12} sm={6}>
-                        <MetLabel>Date Created - To</MetLabel>
+                        <BodyText bold>Date Created - To</BodyText>
                         <TextField
                             id="createdTo-date"
                             data-testid="createdTo-date"
@@ -290,7 +266,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                     </Grid>
 
                     <Grid item xs={12} sm={6}>
-                        <MetLabel>Date Published - From</MetLabel>
+                        <BodyText bold>Date Published - From</BodyText>
                         <TextField
                             id="publishedFrom-date"
                             data-testid="publishedFrom-date"
@@ -306,7 +282,7 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                         />
                     </Grid>
                     <Grid item xs={12} sm={6}>
-                        <MetLabel>Date Published - To</MetLabel>
+                        <BodyText bold>Date Published - To</BodyText>
                         <TextField
                             id="createdTo-date"
                             data-testid="createdTo-date"
@@ -330,19 +306,22 @@ const AdvancedSearch: React.FC<filterParams> = ({ setFilterParams }) => {
                         width="100%"
                         justifyContent="flex-end"
                     >
-                        <SecondaryButtonOld
+                        <Button
+                            size="small"
                             data-testid="reset-filter-button"
                             onClick={() => handleResetSearchFilters()}
                         >
                             Reset All Filters
-                        </SecondaryButtonOld>
-                        <PrimaryButtonOld
+                        </Button>
+                        <Button
+                            size="small"
+                            variant="primary"
                             data-testid="search-button"
                             sx={{ marginLeft: 1 }}
                             onClick={() => handleSearch()}
                         >
                             Search
-                        </PrimaryButtonOld>
+                        </Button>
                     </Stack>
                 </Grid>
             </Grid>

--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { When } from 'react-if';
-import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown } from '@fortawesome/pro-solid-svg-icons/faChevronDown';
@@ -12,7 +11,7 @@ import { faXmark } from '@fortawesome/pro-regular-svg-icons/faXmark';
 import { faCommentsQuestionCheck } from '@fortawesome/pro-regular-svg-icons/faCommentsQuestionCheck';
 import Collapse from '@mui/material/Collapse';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { MetPageGridContainer, MetTooltip, PrimaryButtonOld, SecondaryButtonOld } from 'components/common';
+import { MetPageGridContainer, MetTooltip } from 'components/common';
 import { Engagement } from 'models/engagement';
 import { useAppDispatch, useAppSelector } from 'hooks';
 import { createDefaultPageInfo, HeadCell, PageInfo, PaginationOptions } from 'components/common/Table/types';
@@ -31,6 +30,8 @@ import { CommentStatus } from 'constants/commentStatus';
 import { ActionsDropDown } from './ActionsDropDown';
 import { updateURLWithPagination } from 'components/common/Table/utils';
 import AdvancedSearch from './AdvancedSearch/SearchComponent';
+import { Button, TextInput } from 'components/common/Input';
+import { faPlus } from '@fortawesome/pro-regular-svg-icons';
 
 const EngagementListing = () => {
     const isMediumScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
@@ -393,30 +394,44 @@ const EngagementListing = () => {
             rowSpacing={1}
         >
             <Grid item xs={12}>
-                <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} width="100%" justifyContent="space-between">
+                <Stack
+                    direction={{ xs: 'column', md: 'row' }}
+                    spacing={1}
+                    width="100%"
+                    justifyContent="space-between"
+                    alignItems="flex-start"
+                >
                     <Stack direction="row" spacing={1} alignItems="center">
-                        <TextField
+                        <TextInput
+                            title={''}
                             id="engagement-name"
                             data-testid="engagement/listing/searchField"
-                            variant="outlined"
-                            label="Search by name"
+                            placeholder="Search by name"
                             name="searchText"
                             value={searchText}
-                            onChange={(e) => setSearchText(e.target.value)}
+                            sx={{ height: '40px', pr: 0 }}
+                            onChange={(value) => setSearchText(value)}
                             size="small"
+                            endAdornment={
+                                <Button
+                                    variant="primary"
+                                    size="small"
+                                    data-testid="engagement/listing/searchButton"
+                                    onClick={() => handleSearchBarClick(searchText)}
+                                    sx={{ m: 0, borderRadius: '0px 8px 8px 0px' }}
+                                >
+                                    <FontAwesomeIcon icon={faMagnifyingGlass} style={{ fontSize: '20px' }} />
+                                </Button>
+                            }
                         />
-                        <PrimaryButtonOld
-                            data-testid="engagement/listing/searchButton"
-                            onClick={() => handleSearchBarClick(searchText)}
-                        >
-                            <FontAwesomeIcon icon={faMagnifyingGlass} style={{ fontSize: '20px' }} />
-                        </PrimaryButtonOld>
                         <When condition={!isMediumScreen}>
-                            <SecondaryButtonOld
+                            <Button
+                                size="small"
+                                sx={{ minWidth: '200px' }}
                                 data-testid="engagement/listing/advancedSearch"
                                 name="advancedSearch"
                                 onClick={() => setAdvancedSearchOpen(!advancedSearchOpen)}
-                                startIcon={
+                                icon={
                                     <FontAwesomeIcon
                                         icon={faChevronDown}
                                         style={{
@@ -428,37 +443,40 @@ const EngagementListing = () => {
                                 }
                             >
                                 Advanced Search
-                            </SecondaryButtonOld>
+                            </Button>
                         </When>
                     </Stack>
                     <When condition={isMediumScreen}>
-                        <SecondaryButtonOld
+                        <Button
+                            size="small"
+                            sx={{ width: '100%' }}
                             data-testid="engagement/listing/advancedSearch"
                             name="advancedSearch"
                             onClick={() => setAdvancedSearchOpen(!advancedSearchOpen)}
-                        >
-                            {
+                            icon={
                                 <FontAwesomeIcon
                                     icon={faChevronDown}
                                     style={{
                                         fontSize: '12px',
                                         transition: 'transform 0.3s ease',
                                         transform: advancedSearchOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-                                        padding: '0px 10px',
                                     }}
                                 />
                             }
+                        >
                             Advanced Search
-                        </SecondaryButtonOld>
+                        </Button>
                     </When>
                     <PermissionsGate scopes={[USER_ROLES.CREATE_ENGAGEMENT]} errorProps={{ disabled: true }}>
-                        <PrimaryButtonOld
-                            component={Link}
-                            to="/engagements/create/form"
-                            data-testid="create-engagement-button-landingPage"
+                        <Button
+                            size="small"
+                            variant="primary"
+                            icon={<FontAwesomeIcon icon={faPlus} />}
+                            href="/engagements/create/wizard"
+                            sx={{ width: { xs: '100%', md: 'unset' } }}
                         >
-                            + Create Engagement
-                        </PrimaryButtonOld>
+                            Create Engagement
+                        </Button>
                     </PermissionsGate>
                 </Stack>
             </Grid>

--- a/met-web/src/components/engagement/new/create/index.tsx
+++ b/met-web/src/components/engagement/new/create/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { ResponsiveContainer } from 'components/common/Layout';
+import { BodyText, Header1 } from 'components/common/Typography';
+import { Button } from 'components/common/Input';
+import ConfirmModal from 'components/common/Modals/ConfirmModal';
+import { useNavigate } from 'react-router-dom';
+import { Modal, Skeleton } from '@mui/material';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/pro-regular-svg-icons';
+
+const EngagementCreationWizard = () => {
+    const [open, setOpen] = React.useState(true);
+    const navigate = useNavigate();
+    return (
+        <ResponsiveContainer>
+            <Modal open={open} onClose={() => setOpen(false)}>
+                <ConfirmModal
+                    style={'default'}
+                    header={'You are using a preview version of the new engagement creation wizard.'}
+                    subHeader={'Do you want to continue using the preview version?'}
+                    subText={[
+                        { text: 'The classic form is available for use if you prefer.' },
+                        { text: 'Some features may not be available or may not work as expected.' },
+                    ]}
+                    handleConfirm={() => setOpen(false)}
+                    handleClose={() => navigate('/engagements/create/form')}
+                    confirmButtonText={'Yes, use wizard preview'}
+                    cancelButtonText={'No, go to classic form'}
+                />
+            </Modal>
+            <Header1>Engagement Configuration</Header1>
+            <BodyText bold size="large">
+                In order to create your new engagement we’ll need to configure a few things first.
+            </BodyText>
+            <br />
+            <BodyText>
+                <FontAwesomeIcon icon={faInfoCircle} style={{ marginRight: '8px' }} />
+                <i>
+                    Not 100% sure about everything yet? Don’t worry. You will always be able to update this
+                    configuration.
+                </i>
+            </BodyText>
+            {/* This will never actually load - this is a page skeleton pending DESENG-655*/}
+            <Skeleton sx={{ width: '100%', maxWidth: '720px', height: '200px' }} />
+            <Button sx={{ mr: '16px' }} disabled variant="primary">
+                Create Engagement
+            </Button>
+            <Button href="/engagements">Cancel</Button>
+        </ResponsiveContainer>
+    );
+};
+
+export default EngagementCreationWizard;

--- a/met-web/src/routes/AuthenticatedRoutes.tsx
+++ b/met-web/src/routes/AuthenticatedRoutes.tsx
@@ -31,6 +31,7 @@ import Language from 'components/language';
 import { Tenant } from 'models/tenant';
 import { getAllTenants, getTenant } from 'services/tenantService';
 import { SurveyLoader } from 'components/survey/building/SurveyLoader';
+import EngagementCreationWizard from 'components/engagement/new/create';
 
 const AuthenticatedRoutes = () => {
     return (
@@ -40,6 +41,7 @@ const AuthenticatedRoutes = () => {
             <Route path="/surveys">
                 <Route index element={<SurveyListing />} />
                 <Route path="create" element={<CreateSurvey />} />
+
                 <Route path=":surveyId" errorElement={<NotFound />} id="survey" loader={SurveyLoader}>
                     <Route path="build" element={<SurveyFormBuilder />} />
                     <Route path="report" element={<ReportSettings />} />
@@ -55,8 +57,9 @@ const AuthenticatedRoutes = () => {
             </Route>
             <Route path="/engagements">
                 <Route index element={<EngagementListing />} />
-                <Route element={<AuthGate allowedRoles={[USER_ROLES.CREATE_ENGAGEMENT]} />}>
-                    <Route path="create/form" element={<EngagementForm />} />
+                <Route path="create" element={<AuthGate allowedRoles={[USER_ROLES.CREATE_ENGAGEMENT]} />}>
+                    <Route path="form" element={<EngagementForm />} />
+                    <Route path="wizard" element={<EngagementCreationWizard />} />
                 </Route>
                 <Route element={<AuthGate allowedRoles={[USER_ROLES.EDIT_ENGAGEMENT]} />}>
                     <Route path=":engagementId/form" element={<EngagementForm />} />


### PR DESCRIPTION
Issue #: [🎟️ DESENG-654](https://citz-gdx.atlassian.net/browse/DESENG-654)

*Description of changes:*
- **Feature** Add a skeleton page for the new engagement authoring wizard
  - Users are taken to the new page when pressing the "create engagement" button.
  - This route will be updated in future tickets to include the full authoring wizard, and will eventually replace the old authoring flow.
  - [Visual change only] Replaced some old components in the Engagement listing section to match new designs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
