### PR TITLE
[Hotfix - To Main] DESENG 665: Fix MET-web CI build errors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+## July 17, 2024
+
+- **Hotfix** Fix MET-web CI build errors [🎟️ DESENG-665](https://citz-gdx.atlassian.net/browse/DESENG-665)
+  - Update the `npm install` command in CI for the web app to use `--legacy-peer-deps`, resolving a dependency issue that was causing the build to fail
+
 ## July 11, 2024
 
 - **Feature** Add the existing engagement form fields to the engagement authoring wizard [🎟️ DESENG-655](https://citz-gdx.atlassian.net/browse/DESENG-655)

--- a/met-web/Dockerfile
+++ b/met-web/Dockerfile
@@ -19,7 +19,7 @@ COPY package.json ./
 COPY package-lock.json ./
 COPY .npmrc ./
 
-RUN npm install --silent
+RUN npm install --legacy-peer-deps --silent
 RUN npm install react-scripts@3.4.1 -g --silent
 
 # create and set user permissions to app folder


### PR DESCRIPTION
Issue #: [🎟️ DESENG-665](https://citz-gdx.atlassian.net/browse/DESENG-665)

*Description of changes:*
- **Hotfix** Fix MET-web CI build errors
  - Update the `npm install` command in CI for the web app to use `--legacy-peer-deps`, resolving a dependency issue that was causing the build to fail


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
