### PR TITLE
[To Feature] DESENG-660 Part 2: Admin Header UI updates

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,10 @@
 
 - **Feature** New admin header [🎟️ DESENG-660](https://citz-gdx.atlassian.net/browse/DESENG-660)
   - Added a new API endpoint to fetch a list of a user's tenants, required for the new header
+  - Redesigned the admin header to match the new design system
+  - Added a new dropdown to the header to allow users to switch between tenants
+  - Added a user menu, which for now only contains a logout button
+  - Added a "drawer" view for the tenant switcher and user menu on mobile
 
 ## July 25, 2024
 

--- a/met-web/src/App.tsx
+++ b/met-web/src/App.tsx
@@ -27,13 +27,13 @@ import { AuthKeyCloakContext } from './components/auth/AuthKeycloakContext';
 import { determinePathSegments, findTenantInPath } from './utils';
 import { AuthenticatedLayout } from 'components/appLayouts/AuthenticatedLayout';
 import { PublicLayout } from 'components/appLayouts/PublicLayout';
+import { authenticatedRootLoader } from 'routes/AuthenticatedRootRouteLoader';
 
 interface Translations {
     [languageId: string]: { [key: string]: string };
 }
 
 const App = () => {
-    const drawerWidth = 300;
     const dispatch = useAppDispatch();
     const roles = useAppSelector((state) => state.user.roles);
     const authenticationLoading = useAppSelector((state) => state.user.authentication.loading);
@@ -186,7 +186,7 @@ const App = () => {
         loadTranslation();
     }, [language.id, translations]);
 
-    if (authenticationLoading || tenant.loading) {
+    if (authenticationLoading || tenant.loading || !tenant.short_name) {
         return <MidScreenLoader />;
     }
 
@@ -222,13 +222,15 @@ const App = () => {
         const router = createBrowserRouter(
             [
                 {
-                    element: <AuthenticatedLayout drawerWidth={0} />,
+                    element: <AuthenticatedLayout />,
                     children: [
                         {
                             path: '*',
                             element: <NoAccess />,
                         },
                     ],
+                    loader: authenticatedRootLoader,
+                    id: 'authenticated-root',
                 },
             ],
             { basename: `/${basename}` },
@@ -240,11 +242,13 @@ const App = () => {
     const router = createBrowserRouter(
         [
             {
-                element: <AuthenticatedLayout drawerWidth={drawerWidth} />,
+                element: <AuthenticatedLayout />,
                 children: createRoutesFromElements(AuthenticatedRoutes()),
                 handle: {
                     crumb: () => ({ name: 'Dashboard', link: '/home' }),
                 },
+                id: 'authenticated-root',
+                loader: authenticatedRootLoader,
             },
         ],
         { basename: `/${basename}` },

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -174,8 +174,9 @@ const Endpoints = {
     },
     Tenants: {
         CREATE: `${AppConfig.apiUrl}/tenants/`,
-        GET_LIST: `${AppConfig.apiUrl}/tenants/`,
         GET: `${AppConfig.apiUrl}/tenants/tenant_id`,
+        GET_LIST: `${AppConfig.apiUrl}/tenants/`,
+        GET_OWN: `${AppConfig.apiUrl}/user/me/tenants`,
         UPDATE: `${AppConfig.apiUrl}/tenants/tenant_id`,
         DELETE: `${AppConfig.apiUrl}/tenants/tenant_id`,
     },

--- a/met-web/src/components/appLayouts/AuthenticatedLayout.tsx
+++ b/met-web/src/components/appLayouts/AuthenticatedLayout.tsx
@@ -14,15 +14,15 @@ import FormioListener from 'components/FormioListener';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 
-export const AuthenticatedLayout = ({ drawerWidth = 280 }: { drawerWidth?: number }) => {
+export const AuthenticatedLayout = () => {
     return (
         <>
             <DocumentTitle />
             <Box sx={{ display: 'flex' }}>
-                <InternalHeader drawerWidth={drawerWidth} />
+                <InternalHeader />
                 <Notification />
                 <NotificationModal />
-                <Box component="main" sx={{ flexGrow: 1, marginTop: '80px' }}>
+                <Box component="main" sx={{ flexGrow: 1, marginTop: { xs: '3.5em', md: '6.5em' } }}>
                     <ScrollToTop />
                     <FormioListener />
                     <LocalizationProvider

--- a/met-web/src/components/common/Layout/index.tsx
+++ b/met-web/src/components/common/Layout/index.tsx
@@ -8,8 +8,7 @@ export const ResponsiveContainer: React.FC<BoxProps> = (props: BoxProps) => {
         <Box
             {...props}
             sx={{
-                marginTop: '1em',
-                padding: { xs: '1.5em 1em', md: '1.5em 1.5em', lg: '1.5em 2em' },
+                padding: { xs: '2em 1em', md: '2em 1.5em', lg: '2em 3em' },
                 ...props.sx,
             }}
         >

--- a/met-web/src/components/common/Navigation/DropdownMenu.tsx
+++ b/met-web/src/components/common/Navigation/DropdownMenu.tsx
@@ -1,0 +1,128 @@
+import React, { useId, useRef, useState } from 'react';
+import {
+    ButtonBase,
+    Grid,
+    MenuList,
+    Popper,
+    ClickAwayListener,
+    MenuListProps,
+    ButtonBaseProps,
+    PopperProps,
+} from '@mui/material';
+import TrapFocus from '@mui/base/TrapFocus';
+import { colors } from 'styles/Theme';
+import { BodyText } from 'components/common/Typography';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown } from '@fortawesome/pro-regular-svg-icons';
+import { When, Unless } from 'react-if';
+import { elevations } from 'components/common';
+
+export const dropdownMenuStyles = {
+    padding: '1rem',
+    borderRadius: '8px',
+    border: '1px solid transparent',
+    '&:hover': { backgroundColor: colors.surface.blue[80] },
+    '&:focus-visible': {
+        backgroundColor: colors.surface.blue[80],
+        border: '1px dashed white',
+    },
+};
+
+export const DropdownMenu = ({
+    name,
+    buttonContent,
+    buttonProps,
+    children,
+    popperProps,
+    ...props
+}: {
+    name: string;
+    buttonContent?: ({ isOpen }: { isOpen: boolean }) => React.ReactNode;
+    buttonProps?: ButtonBaseProps;
+    popperProps?: Partial<PopperProps>;
+    children?: React.ReactNode;
+} & MenuListProps) => {
+    const [open, setOpen] = useState(false);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const dropdownId = useId();
+
+    return (
+        <>
+            {/* Dropdown Button */}
+            <ButtonBase
+                ref={buttonRef}
+                aria-haspopup
+                aria-controls={open ? dropdownId : undefined}
+                aria-expanded={open}
+                aria-label={name || 'Dropdown Menu'}
+                onClick={() => {
+                    setOpen(!open);
+                }}
+                {...buttonProps}
+                sx={{
+                    ...dropdownMenuStyles,
+                    ...buttonProps?.sx,
+                }}
+            >
+                {/* Pass the "open" state to the button contents in case they want to change based on dropdown state */}
+                <Unless condition={buttonContent === undefined}>{buttonContent?.({ isOpen: open })}</Unless>
+                {/* A basic button label if no custom content is provided */}
+                <When condition={buttonContent === undefined}>
+                    <Grid container direction="row" alignItems="center" spacing={1}>
+                        <Grid item>
+                            <BodyText sx={{ userSelect: 'none', textTransform: 'capitalize' }}>{name}</BodyText>
+                        </Grid>
+                        <Grid item hidden={!children}>
+                            <FontAwesomeIcon color="white" icon={faChevronDown} rotation={open ? 180 : undefined} />
+                        </Grid>
+                    </Grid>
+                </When>
+            </ButtonBase>
+            <ClickAwayListener
+                mouseEvent="onMouseUp"
+                onClickAway={(e) => {
+                    if (e.target !== buttonRef.current && !buttonRef.current?.contains(e.target as Node))
+                        setOpen(false);
+                }}
+            >
+                {/* Dropdown Contents */}
+                <Popper
+                    onKeyDown={(e) => {
+                        // listen for escape key to close menu
+                        if (e.key === 'Escape') setOpen(false);
+                    }}
+                    id={dropdownId}
+                    anchorEl={buttonRef.current}
+                    placement="bottom-start"
+                    modifiers={[{ name: 'offset', options: { offset: [0, 8] } }]}
+                    open={open}
+                    {...popperProps}
+                    sx={{
+                        zIndex: 10000,
+                        boxShadow: elevations.default,
+                        backgroundColor: colors.surface.blue[90],
+                        padding: '2px',
+                        borderRadius: '16px',
+                        minWidth: 'fit-content',
+                        width: buttonRef.current && buttonRef.current.offsetWidth,
+                        ...popperProps?.sx,
+                    }}
+                >
+                    <TrapFocus open={open}>
+                        <MenuList
+                            sx={{ minWidth: 'fit-content' }}
+                            aria-label={name || 'Dropdown Menu'}
+                            tabIndex={-1}
+                            aria-expanded={open}
+                            autoFocusItem
+                            {...props}
+                        >
+                            {children}
+                        </MenuList>
+                    </TrapFocus>
+                </Popper>
+            </ClickAwayListener>
+        </>
+    );
+};
+export default DropdownMenu;

--- a/met-web/src/components/common/Navigation/DropdownMenu.tsx
+++ b/met-web/src/components/common/Navigation/DropdownMenu.tsx
@@ -104,7 +104,7 @@ export const DropdownMenu = ({
                         padding: '2px',
                         borderRadius: '16px',
                         minWidth: 'fit-content',
-                        width: buttonRef.current && buttonRef.current.offsetWidth,
+                        width: buttonRef.current?.offsetWidth,
                         ...popperProps?.sx,
                     }}
                 >

--- a/met-web/src/components/common/Navigation/DropdownMenu.tsx
+++ b/met-web/src/components/common/Navigation/DropdownMenu.tsx
@@ -36,7 +36,7 @@ export const DropdownMenu = ({
     popperProps,
     ...props
 }: {
-    name: string;
+    name?: string;
     buttonContent?: ({ isOpen }: { isOpen: boolean }) => React.ReactNode;
     buttonProps?: ButtonBaseProps;
     popperProps?: Partial<PopperProps>;

--- a/met-web/src/components/engagement/listing/index.tsx
+++ b/met-web/src/components/engagement/listing/index.tsx
@@ -394,7 +394,9 @@ const EngagementListing = () => {
             columnSpacing={2}
             rowSpacing={1}
         >
-            <AutoBreadcrumbs />
+            <Grid item>
+                <AutoBreadcrumbs />
+            </Grid>
             <Grid item xs={12}>
                 <Stack
                     direction={{ xs: 'column', md: 'row' }}

--- a/met-web/src/components/layout/Header/InternalHeader.tsx
+++ b/met-web/src/components/layout/Header/InternalHeader.tsx
@@ -115,7 +115,7 @@ const InternalHeader = () => {
                             }}
                         />
                         <BodyText thin sx={{ color: colors.surface.blue[80], userSelect: 'none' }}>
-                            engage
+                            engage{/*no space*/}
                             <span style={{ color: colors.surface.blue[90], fontWeight: 'normal' }}>BC</span>
                         </BodyText>
                         <Unless condition={isMediumScreenOrLarger || !canNavigate}>
@@ -234,27 +234,6 @@ const TenantSelector = ({
         );
     }
 
-    const TenantButtonContent = ({ isOpen }: { isOpen: boolean }) => (
-        <Grid container data-testid="tenant-switcher-button" direction="row" alignItems="center" spacing={1}>
-            <Grid item sx={{ flex: '1 1 auto' }}>
-                <BodyText
-                    sx={{
-                        userSelect: 'none',
-                        textTransform: 'capitalize',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                    }}
-                >
-                    {currentTenant.name}
-                </BodyText>
-            </Grid>
-            <Grid item hidden={noOtherTenants} sx={{ flex: '0 0 auto' }}>
-                <FontAwesomeIcon color="white" rotation={isOpen ? 180 : undefined} icon={faChevronDown} />
-            </Grid>
-        </Grid>
-    );
-
     const tenantList = tenants.map((tenant) => (
         <MenuItem
             key={tenant.short_name}
@@ -339,12 +318,39 @@ const TenantSelector = ({
             popperProps={{
                 placement: 'bottom-start',
                 sx: {
-                    width: tenantDropdownButton.current && tenantDropdownButton.current.offsetWidth,
+                    width: tenantDropdownButton.current?.offsetWidth,
                 },
             }}
         >
             {tenantList}
         </DropdownMenu>
+    );
+};
+
+const TenantButtonContent = ({ isOpen }: { isOpen: boolean }) => {
+    const currentTenant = useAppSelector((state) => state.tenant);
+    const noOtherTenants = !(useAsyncValue() as Tenant[]).some(
+        (tenant) => tenant.short_name !== currentTenant.short_name,
+    );
+    return (
+        <Grid container data-testid="tenant-switcher-button" direction="row" alignItems="center" spacing={1}>
+            <Grid item sx={{ flex: '1 1 auto' }}>
+                <BodyText
+                    sx={{
+                        userSelect: 'none',
+                        textTransform: 'capitalize',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                    }}
+                >
+                    {currentTenant.name}
+                </BodyText>
+            </Grid>
+            <Grid item hidden={noOtherTenants} sx={{ flex: '0 0 auto' }}>
+                <FontAwesomeIcon color="white" rotation={isOpen ? 180 : undefined} icon={faChevronDown} />
+            </Grid>
+        </Grid>
     );
 };
 
@@ -355,36 +361,7 @@ const UserMenu = () => {
     return (
         <DropdownMenu
             name="Account Menu"
-            buttonContent={({ isOpen }) => (
-                <Grid container direction="row" alignItems="center" spacing={1} data-testid="user-menu-button">
-                    <Grid item>
-                        <Avatar
-                            sx={{
-                                backgroundColor: colors.surface.blue[10],
-                                height: 32,
-                                width: 32,
-                                fontSize: '16px',
-                            }}
-                        >
-                            {currentUser?.first_name[0]}
-                            {currentUser?.last_name[0]}
-                        </Avatar>
-                    </Grid>
-                    <Grid item ref={userGreeting} sx={{ textAlign: 'left' }}>
-                        <BodyText size="small" sx={{ userSelect: 'none' }}>
-                            Hello {currentUser?.first_name}
-                        </BodyText>
-                        <BodyText sx={{ fontSize: '10px', lineHeight: 1 }}>
-                            {currentUser?.roles.includes(USER_ROLES.SUPER_ADMIN)
-                                ? 'Super Admin'
-                                : currentUser?.main_role ?? 'User'}
-                        </BodyText>
-                    </Grid>
-                    <Grid item>
-                        <FontAwesomeIcon color="white" rotation={isOpen ? 180 : undefined} icon={faChevronDown} />
-                    </Grid>
-                </Grid>
-            )}
+            buttonContent={UserButtonContent}
             buttonProps={{
                 sx: {
                     marginLeft: 'auto' /* float to the right */,
@@ -409,6 +386,40 @@ const UserMenu = () => {
                 Logout
             </MenuItem>
         </DropdownMenu>
+    );
+};
+
+const UserButtonContent = ({ isOpen }: { isOpen: boolean }) => {
+    const currentUser = useAppSelector((state) => state.user.userDetail.user);
+    return (
+        <Grid container direction="row" alignItems="center" spacing={1}>
+            <Grid item>
+                <Avatar
+                    sx={{
+                        backgroundColor: colors.surface.blue[10],
+                        height: 32,
+                        width: 32,
+                        fontSize: '16px',
+                    }}
+                >
+                    {currentUser?.first_name[0]}
+                    {currentUser?.last_name[0]}
+                </Avatar>
+            </Grid>
+            <Grid item>
+                <BodyText size="small" sx={{ userSelect: 'none' }}>
+                    Hello {currentUser?.first_name}
+                </BodyText>
+                <BodyText sx={{ fontSize: '10px', lineHeight: 1 }}>
+                    {currentUser?.roles.includes(USER_ROLES.SUPER_ADMIN)
+                        ? 'Super Admin'
+                        : currentUser?.main_role ?? 'User'}
+                </BodyText>
+            </Grid>
+            <Grid item>
+                <FontAwesomeIcon color="white" rotation={isOpen ? 180 : undefined} icon={faChevronDown} />
+            </Grid>
+        </Grid>
     );
 };
 

--- a/met-web/src/components/layout/Header/InternalHeader.tsx
+++ b/met-web/src/components/layout/Header/InternalHeader.tsx
@@ -355,7 +355,6 @@ const TenantButtonContent = ({ isOpen }: { isOpen: boolean }) => {
 };
 
 const UserMenu = () => {
-    const currentUser = useAppSelector((state) => state.user.userDetail.user);
     const userGreeting = useRef<HTMLDivElement>(null);
 
     return (

--- a/met-web/src/components/layout/Header/InternalHeader.tsx
+++ b/met-web/src/components/layout/Header/InternalHeader.tsx
@@ -1,104 +1,414 @@
-import React, { useState } from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import { Button } from 'components/common/Input';
-import UserService from 'services/userService';
-import { useMediaQuery, Theme, IconButton } from '@mui/material';
-import SideNav from '../SideNav/SideNav';
-import CssBaseline from '@mui/material/CssBaseline';
-import { Palette } from 'styles/Theme';
-import EnvironmentBanner from './EnvironmentBanner';
+import React, { Suspense, useEffect, useRef, useState } from 'react';
+import {
+    AppBar,
+    Box,
+    Toolbar,
+    useMediaQuery,
+    Theme,
+    ThemeProvider,
+    ButtonBase,
+    Grid,
+    Avatar,
+    MenuItem,
+    Drawer,
+    MenuList,
+    Collapse,
+    CssBaseline,
+} from '@mui/material';
+import { colors, DarkTheme, Palette } from 'styles/Theme';
 import { ReactComponent as BCLogo } from 'assets/images/BritishColumbiaLogoDark.svg';
-import { When } from 'react-if';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBars } from '@fortawesome/pro-regular-svg-icons/faBars';
-import { HeaderProps } from './types';
-import { useNavigate } from 'react-router-dom';
-import { TenantState } from 'reduxSlices/tenantSlice';
 import { useAppSelector } from '../../../hooks';
-import { BodyText, Header1 } from 'components/common/Typography';
+import { BodyText } from 'components/common/Typography';
+import { Link } from 'components/common/Navigation';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars, faChevronDown, faClose, faSignOut } from '@fortawesome/pro-regular-svg-icons';
+import UserService from 'services/userService';
+import { Await, useAsyncValue, useRouteLoaderData } from 'react-router-dom';
+import { Tenant } from 'models/tenant';
+import { When, Unless } from 'react-if';
+import { Button } from 'components/common/Input';
+import DropdownMenu, { dropdownMenuStyles } from 'components/common/Navigation/DropdownMenu';
+import { elevations } from 'components/common';
+import TrapFocus from '@mui/base/TrapFocus';
+import SideNav from '../SideNav/SideNav';
+import { USER_ROLES } from 'services/userService/constants';
 
-const InternalHeader = ({ drawerWidth = 280 }: HeaderProps) => {
-    const isMediumScreen: boolean = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
-    const [open, setOpen] = useState(false);
-    const tenant: TenantState = useAppSelector((state) => state.tenant);
-    const navigate = useNavigate();
+const InternalHeader = () => {
+    const isMediumScreenOrLarger = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
+    const isMobileScreen = !useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
+    const [sideNavOpen, setSideNavOpen] = useState(false);
+    const [secondaryMenuOpen, setSecondaryMenuOpen] = useState(false);
+    const tenant = useAppSelector((state) => state.tenant);
+    const user = useAppSelector((state) => state.user);
+    const canNavigate = user.roles.length !== 0; // If user has no roles in this tenant, don't show the side nav
+    const [tenantDrawerOpen, setTenantDrawerOpen] = useState(false);
+
+    const handleTenantDrawerOpen = (isOpen: boolean) => {
+        setTenantDrawerOpen(isOpen);
+    };
+
+    useEffect(() => {
+        if (isMediumScreenOrLarger || sideNavOpen) {
+            const timer = setTimeout(() => {
+                setSecondaryMenuOpen(true);
+            }, 200); // Delay to allow the sidenav to open first
+            return () => clearTimeout(timer);
+        } else {
+            setSecondaryMenuOpen(false);
+        }
+    }, [isMediumScreenOrLarger, sideNavOpen]);
+
+    const { myTenants } = useRouteLoaderData('authenticated-root') as { myTenants: Tenant[] };
+
+    const sidePadding = { xs: '0 1em', md: '0 1.5em 0 2em', lg: '0 3em 0 2em' };
 
     return (
-        <>
-            <AppBar
-                position="fixed"
+        // Keep focus within the app bar + sidenav when sidenav is open on mobile
+        <TrapFocus open={sideNavOpen && isMobileScreen}>
+            <Box
                 sx={{
-                    zIndex: (theme: Theme) => (isMediumScreen ? theme.zIndex.drawer + 1 : theme.zIndex.drawer),
-                    backgroundColor: Palette.internalHeader.backgroundColor,
-                    color: Palette.internalHeader.color,
+                    '& div.PrivateSwipeArea-root': {
+                        zIndex: (theme: Theme) => theme.zIndex.drawer + 4,
+                    },
                 }}
-                data-testid="appbar-header"
             >
-                <CssBaseline />
-                <Toolbar>
-                    <When condition={!isMediumScreen && drawerWidth}>
-                        <IconButton
-                            color="info"
-                            sx={{
-                                height: '2em',
-                                width: '2em',
-                                marginRight: { xs: '1em' },
-                            }}
-                            onClick={() => setOpen(!open)}
-                        >
-                            <FontAwesomeIcon icon={faBars} style={{ fontSize: '20px' }} />
-                        </IconButton>
-                    </When>
-                    <Box
-                        component={BCLogo}
+                <AppBar
+                    position="fixed"
+                    sx={{
+                        zIndex: (theme: Theme) => theme.zIndex.drawer + 4, // render above sidenav
+                        backgroundColor: 'transparent',
+                        color: Palette.internalHeader.color,
+                        borderBottomRightRadius: '16px',
+                        backgroundClip: 'padding-box',
+                        overflow: 'hidden',
+                        left: 0,
+                        boxShadow: tenantDrawerOpen ? 'none' : elevations.default,
+                    }}
+                    data-testid="appbar-header"
+                >
+                    <CssBaseline />
+                    <Toolbar
                         sx={{
-                            cursor: 'pointer',
-                            height: '5em',
-                            width: { xs: '7em', md: '15em' },
-                            marginRight: { xs: '1em', md: '3em' },
+                            height: '4em',
+                            padding: sidePadding,
+                            backgroundColor: Palette.internalHeader.backgroundColor,
                         }}
-                        onClick={() => {
-                            navigate('/home');
-                        }}
-                        alt="British Columbia Logo"
-                    />
-                    {isMediumScreen ? (
-                        <Header1
-                            onClick={() => {
-                                navigate('/home');
+                    >
+                        <Link underline="none" href="https://gov.bc.ca" sx={{ height: '100%', mr: '2px' }}>
+                            <Box
+                                component={BCLogo}
+                                sx={{
+                                    height: '100%',
+                                    width: 'auto',
+                                    padding: '0 0',
+                                    ml: '-13px',
+                                }}
+                                alt="British Columbia Logo"
+                            />
+                        </Link>
+                        <Box
+                            sx={{
+                                borderLeft: `1px solid ${colors.surface.gray[80]}`,
+                                height: '1.5em',
+                                width: '1px',
+                                marginRight: '1em',
                             }}
-                            sx={{ flexGrow: 1, cursor: 'pointer', margin: 0 }}
-                        >
-                            {tenant.name}
-                        </Header1>
-                    ) : (
-                        <Header1
-                            onClick={() => {
-                                navigate('/home');
-                            }}
-                            sx={{ flexGrow: 1, cursor: 'pointer', textTransform: 'capitalize', margin: 0 }}
-                        >
-                            {tenant.short_name}
-                        </Header1>
-                    )}
-                    <Button data-testid="button-header" variant="tertiary" onClick={() => UserService.doLogout()}>
-                        <BodyText bold size="large">
-                            Logout
+                        />
+                        <BodyText thin sx={{ color: colors.surface.blue[80], userSelect: 'none' }}>
+                            engage
+                            <span style={{ color: colors.surface.blue[90], fontWeight: 'normal' }}>BC</span>
                         </BodyText>
-                    </Button>
-                </Toolbar>
-                <EnvironmentBanner />
-            </AppBar>
-            <SideNav
-                setOpen={setOpen}
-                data-testid="sidenav-header"
-                isMediumScreen={isMediumScreen}
-                open={open}
-                drawerWidth={drawerWidth}
-            />
-        </>
+                        <Unless condition={isMediumScreenOrLarger || !canNavigate}>
+                            <Button
+                                variant="secondary"
+                                onClick={() => {
+                                    setSideNavOpen(!sideNavOpen);
+                                }}
+                                icon={
+                                    <FontAwesomeIcon
+                                        icon={sideNavOpen ? faClose : faBars}
+                                        fontSize={20}
+                                        style={{
+                                            transform: `rotate(${sideNavOpen ? '180deg' : '0'})`,
+                                            transition: 'transform 0.3s',
+                                            position: isMobileScreen ? 'relative' : undefined,
+                                            left: isMobileScreen ? '6px' : undefined,
+                                        }}
+                                    />
+                                }
+                                sx={{
+                                    marginLeft: 'auto',
+                                    minWidth: 'unset',
+                                    alignContent: 'center',
+                                    justifyContent: 'center',
+                                }}
+                            >
+                                <Unless condition={isMobileScreen}>
+                                    <BodyText>Menu</BodyText>
+                                </Unless>
+                            </Button>
+                        </Unless>
+                    </Toolbar>
+                    <Collapse
+                        in={secondaryMenuOpen}
+                        timeout={{
+                            appear: 0,
+                            enter: 200,
+                            exit: 200,
+                        }}
+                    >
+                        <Box
+                            sx={{
+                                zIndex: (theme: Theme) => theme.zIndex.drawer + 3, // render above sidenav
+                                background: colors.surface.blue[90],
+                                height: '3.5em',
+                                minHeight: 0,
+                                justifyContent: 'space-between',
+                                padding: sidePadding,
+                                display: 'flex',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <ThemeProvider theme={DarkTheme}>
+                                <Suspense
+                                    fallback={
+                                        <Link to="/home">
+                                            <BodyText sx={{ userSelect: 'none' }}>{tenant.name}</BodyText>
+                                        </Link>
+                                    }
+                                >
+                                    <Await resolve={myTenants}>
+                                        <TenantSelector
+                                            isVisible={isMediumScreenOrLarger || sideNavOpen}
+                                            onStateChange={handleTenantDrawerOpen}
+                                        />
+                                    </Await>
+                                </Suspense>
+                                <When condition={isMediumScreenOrLarger}>
+                                    <UserMenu />
+                                </When>
+                            </ThemeProvider>
+                        </Box>
+                    </Collapse>
+                </AppBar>
+                <When condition={canNavigate}>
+                    <SideNav
+                        open={sideNavOpen}
+                        setOpen={setSideNavOpen}
+                        data-testid="sidenav-header"
+                        isMediumScreen={isMediumScreenOrLarger}
+                    />
+                </When>
+            </Box>
+        </TrapFocus>
+    );
+};
+
+const TenantSelector = ({
+    isVisible,
+    onStateChange,
+}: {
+    isVisible: boolean;
+    onStateChange?: (isOpen: boolean) => void;
+}) => {
+    const shouldUseMobileView = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
+    const currentTenant = useAppSelector((state) => state.tenant);
+    const tenants = (useAsyncValue() as Tenant[]).filter((tenant) => tenant.short_name !== currentTenant.short_name);
+    const noOtherTenants = tenants.length === 0;
+    const tenantDropdownButton = useRef<HTMLButtonElement>(null);
+    const [tenantDrawerOpen, setTenantDrawerOpen] = useState(false);
+
+    useEffect(() => {
+        if (!isVisible) setTenantDrawerOpen(false);
+    }, [isVisible, setTenantDrawerOpen]);
+
+    useEffect(() => {
+        if (onStateChange) onStateChange(tenantDrawerOpen);
+    }, [tenantDrawerOpen, onStateChange]);
+
+    if (noOtherTenants) {
+        return (
+            <Link to="/home">
+                <BodyText sx={{ userSelect: 'none' }}>{currentTenant.name}</BodyText>
+            </Link>
+        );
+    }
+
+    const TenantButtonContent = ({ isOpen }: { isOpen: boolean }) => (
+        <Grid container data-testid="tenant-switcher-button" direction="row" alignItems="center" spacing={1}>
+            <Grid item sx={{ flex: '1 1 auto' }}>
+                <BodyText
+                    sx={{
+                        userSelect: 'none',
+                        textTransform: 'capitalize',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                    }}
+                >
+                    {currentTenant.name}
+                </BodyText>
+            </Grid>
+            <Grid item hidden={noOtherTenants} sx={{ flex: '0 0 auto' }}>
+                <FontAwesomeIcon color="white" rotation={isOpen ? 180 : undefined} icon={faChevronDown} />
+            </Grid>
+        </Grid>
+    );
+
+    const tenantList = tenants.map((tenant) => (
+        <MenuItem
+            key={tenant.short_name}
+            component={Link}
+            href={`/${tenant.short_name}/home`}
+            sx={{
+                paddingLeft: 2,
+                paddingRight: 2,
+                fontSize: '16px',
+                textTransform: 'capitalize',
+            }}
+        >
+            {tenant.name}
+        </MenuItem>
+    ));
+
+    if (shouldUseMobileView) {
+        return (
+            <>
+                <ButtonBase
+                    aria-haspopup
+                    aria-controls={tenantDrawerOpen ? 'tenant-drawer' : undefined}
+                    aria-expanded={tenantDrawerOpen}
+                    aria-label={'Tenant Switcher'}
+                    onClick={() => {
+                        setTenantDrawerOpen(!tenantDrawerOpen);
+                    }}
+                    sx={{
+                        height: 'calc( 100% - 2px )' /* 1px on either side to show border*/,
+                        ...dropdownMenuStyles,
+                    }}
+                >
+                    <TenantButtonContent isOpen={tenantDrawerOpen} />
+                </ButtonBase>
+                <Drawer
+                    anchor="top"
+                    open={tenantDrawerOpen}
+                    onClose={() => {
+                        setTenantDrawerOpen(false);
+                    }}
+                    sx={{
+                        zIndex: (theme: Theme) => theme.zIndex.drawer + 3, // render under app bar but above side nav
+                        '& .MuiDrawer-paper': {
+                            padding: '1rem',
+                            top: '6.5rem',
+                            backgroundImage: 'none',
+                            borderBottomRightRadius: '16px',
+                        },
+                    }}
+                >
+                    <MenuList
+                        sx={{
+                            mt: 0,
+                            '& .MuiMenuItem-root': {
+                                marginBottom: '1rem',
+                                '&:first-of-type': {
+                                    paddingTop: '4px',
+                                },
+                                '&:last-of-type': {
+                                    marginBottom: 0,
+                                },
+                            },
+                        }}
+                    >
+                        {tenantList}
+                    </MenuList>
+                </Drawer>
+            </>
+        );
+    }
+
+    return (
+        <DropdownMenu
+            name="Tenant Switcher"
+            buttonContent={TenantButtonContent}
+            buttonProps={{
+                sx: {
+                    marginLeft: '-16px' /*Visual alignment with nav bar*/,
+                    height: 'calc( 100% - 2px )' /* 1px on either side to show border*/,
+                },
+            }}
+            popperProps={{
+                placement: 'bottom-start',
+                sx: {
+                    width: tenantDropdownButton.current && tenantDropdownButton.current.offsetWidth,
+                },
+            }}
+        >
+            {tenantList}
+        </DropdownMenu>
+    );
+};
+
+const UserMenu = () => {
+    const currentUser = useAppSelector((state) => state.user.userDetail.user);
+    const userGreeting = useRef<HTMLDivElement>(null);
+
+    return (
+        <DropdownMenu
+            name="Account Menu"
+            buttonContent={({ isOpen }) => (
+                <Grid container direction="row" alignItems="center" spacing={1} data-testid="user-menu-button">
+                    <Grid item>
+                        <Avatar
+                            sx={{
+                                backgroundColor: colors.surface.blue[10],
+                                height: 32,
+                                width: 32,
+                                fontSize: '16px',
+                            }}
+                        >
+                            {currentUser?.first_name[0]}
+                            {currentUser?.last_name[0]}
+                        </Avatar>
+                    </Grid>
+                    <Grid item ref={userGreeting} sx={{ textAlign: 'left' }}>
+                        <BodyText size="small" sx={{ userSelect: 'none' }}>
+                            Hello {currentUser?.first_name}
+                        </BodyText>
+                        <BodyText sx={{ fontSize: '10px', lineHeight: 1 }}>
+                            {currentUser?.roles.includes(USER_ROLES.SUPER_ADMIN)
+                                ? 'Super Admin'
+                                : currentUser?.main_role ?? 'User'}
+                        </BodyText>
+                    </Grid>
+                    <Grid item>
+                        <FontAwesomeIcon color="white" rotation={isOpen ? 180 : undefined} icon={faChevronDown} />
+                    </Grid>
+                </Grid>
+            )}
+            buttonProps={{
+                sx: {
+                    marginLeft: 'auto' /* float to the right */,
+                    height: 'calc( 100% - 2px )' /* 1px on either side to show border*/,
+                },
+            }}
+            popperProps={{
+                placement: 'bottom-end',
+                sx: {
+                    width: userGreeting.current && userGreeting.current.offsetWidth + 34 + 13,
+                },
+            }}
+        >
+            <MenuItem
+                component={ButtonBase}
+                onClick={() => {
+                    UserService.doLogout();
+                }}
+                sx={{ width: '100%', paddingLeft: 2, paddingRight: 2 }}
+            >
+                <FontAwesomeIcon style={{ marginRight: '0.5rem' }} icon={faSignOut} />
+                Logout
+            </MenuItem>
+        </DropdownMenu>
     );
 };
 

--- a/met-web/src/components/layout/SideNav/SideNav.tsx
+++ b/met-web/src/components/layout/SideNav/SideNav.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
-import { ListItemButton, List, ListItem, Box, Drawer, Toolbar, Divider } from '@mui/material';
-import { useLocation, useNavigate } from 'react-router-dom';
+import {
+    ListItemButton,
+    List,
+    ListItem,
+    Box,
+    Drawer,
+    Toolbar,
+    Divider,
+    SwipeableDrawer,
+    Grid,
+    Avatar,
+    ThemeProvider,
+} from '@mui/material';
+import { useLocation } from 'react-router-dom';
 import { Routes, Route } from './SideNavElements';
-import { Palette, colors } from '../../../styles/Theme';
-import { SideNavProps, DrawerBoxProps, CloseButtonProps } from './types';
-import { When, Unless } from 'react-if';
+import { DarkTheme, Palette, colors } from '../../../styles/Theme';
+import { SideNavProps, DrawerBoxProps } from './types';
+import { When } from 'react-if';
 import { useAppSelector } from 'hooks';
 import UserGuideNav from './UserGuideNav';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLinkSlash } from '@fortawesome/pro-regular-svg-icons/faLinkSlash';
 import { faCheck } from '@fortawesome/pro-solid-svg-icons/faCheck';
-import { faArrowLeft } from '@fortawesome/pro-solid-svg-icons/faArrowLeft';
+import { Link } from 'components/common/Navigation';
+import { BodyText } from 'components/common/Typography';
+import { USER_ROLES } from 'services/userService/constants';
+import UserService from 'services/userService';
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
 export const routeItemStyle = {
     padding: 0,
@@ -32,34 +48,7 @@ export const routeItemStyle = {
     },
 };
 
-const CloseButton = ({ setOpen }: CloseButtonProps) => {
-    return (
-        <>
-            <ListItem key={'closeMenu'} sx={routeItemStyle}>
-                <ListItemButton
-                    onClick={() => setOpen(false)}
-                    disableRipple
-                    sx={{
-                        padding: 2,
-                        pr: 4,
-                        justifyContent: 'flex-end',
-                        color: Palette.text.primary,
-                        '&:hover, &:active, &:focus': {
-                            backgroundColor: 'transparent',
-                        },
-                    }}
-                >
-                    <FontAwesomeIcon icon={faArrowLeft} style={{ paddingRight: '0.75rem' }} />
-                    Close Menu
-                </ListItemButton>
-            </ListItem>
-            <Divider sx={{ backgroundColor: colors.surface.gray[30] }} />
-        </>
-    );
-};
-
 const DrawerBox = ({ isMediumScreenOrLarger, setOpen }: DrawerBoxProps) => {
-    const navigate = useNavigate();
     const location = useLocation();
     const permissions = useAppSelector((state) => state.user.roles);
 
@@ -85,7 +74,7 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen }: DrawerBoxProps) => {
                     }}
                 >
                     <ListItemButton
-                        component="a"
+                        component={Link}
                         disableRipple
                         sx={{
                             '&:hover, &:active, &:focus': {
@@ -95,8 +84,8 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen }: DrawerBoxProps) => {
                             pl: 4,
                         }}
                         data-testid={`SideNav/${route.name}-button`}
+                        to={route.path}
                         onClick={() => {
-                            navigate(route.path);
                             setOpen(false);
                         }}
                     >
@@ -148,10 +137,7 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen }: DrawerBoxProps) => {
                 mt: '5.625rem',
             }}
         >
-            <List sx={{ pt: '0', pb: '0' }}>
-                <Unless condition={isMediumScreenOrLarger}>
-                    <CloseButton setOpen={setOpen} />
-                </Unless>
+            <List sx={{ pt: { xs: 4, md: 0 }, pb: '0' }}>
                 {allowedRoutes.map((route) =>
                     renderListItem(route, currentBaseRoute === route.base ? 'selected' : 'other'),
                 )}
@@ -160,15 +146,18 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen }: DrawerBoxProps) => {
     );
 };
 
-const SideNav = ({ open, setOpen, isMediumScreen, drawerWidth = 300 }: SideNavProps) => {
-    if (!drawerWidth) return <></>;
+const SideNav = ({ open, setOpen, isMediumScreen }: SideNavProps) => {
+    const currentUser = useAppSelector((state) => state.user.userDetail.user);
     if (isMediumScreen)
         return (
             <Drawer
+                ModalProps={{
+                    hideBackdrop: true,
+                }}
                 PaperProps={{
                     sx: {
                         border: 'none',
-                        width: drawerWidth,
+                        width: '300px',
                         boxSizing: 'border-box',
                         backgroundColor: Palette.background.default,
                     },
@@ -177,7 +166,7 @@ const SideNav = ({ open, setOpen, isMediumScreen, drawerWidth = 300 }: SideNavPr
                 variant="permanent"
                 sx={{
                     height: '100vh',
-                    width: drawerWidth,
+                    width: '300px',
                     flexShrink: 0,
                 }}
             >
@@ -186,19 +175,65 @@ const SideNav = ({ open, setOpen, isMediumScreen, drawerWidth = 300 }: SideNavPr
             </Drawer>
         );
     return (
-        <Drawer
-            PaperProps={{ sx: { width: '100%' } }}
+        <SwipeableDrawer
+            PaperProps={{
+                sx: { width: '100%', height: '100%', minHeight: 'calc(100vh)', background: colors.surface.blue[90] },
+            }}
             sx={{
                 mt: '80px',
-                width: '100%',
+                zIndex: (theme) => theme.zIndex.drawer + 3, // render above feedback button
             }}
+            onOpen={() => setOpen(true)}
             onClose={() => setOpen(false)}
-            anchor={'left'}
+            anchor={'top'}
             open={open}
-            hideBackdrop={!open}
+            disableEnforceFocus
+            disablePortal
         >
-            <DrawerBox isMediumScreenOrLarger={isMediumScreen} setOpen={setOpen} />
-        </Drawer>
+            <Box>
+                <DrawerBox isMediumScreenOrLarger={isMediumScreen} setOpen={setOpen} />
+                <ThemeProvider theme={DarkTheme}>
+                    <Grid
+                        m={2}
+                        container
+                        sx={{ width: 'calc(100% - 16px) ' }}
+                        direction="row"
+                        alignItems="center"
+                        spacing={1}
+                    >
+                        <Grid item>
+                            <Avatar
+                                sx={{
+                                    backgroundColor: colors.surface.blue[10],
+                                    height: 32,
+                                    width: 32,
+                                    fontSize: '16px',
+                                }}
+                            >
+                                {currentUser?.first_name[0]}
+                                {currentUser?.last_name[0]}
+                            </Avatar>
+                        </Grid>
+                        <Grid item sx={{ textAlign: 'left' }}>
+                            <BodyText size="small" sx={{ userSelect: 'none' }}>
+                                Hello {currentUser?.first_name}
+                            </BodyText>
+                            <BodyText sx={{ fontSize: '10px', lineHeight: 1 }}>
+                                {currentUser?.roles.includes(USER_ROLES.SUPER_ADMIN)
+                                    ? 'Super Admin'
+                                    : currentUser?.main_role ?? 'User'}
+                            </BodyText>
+                        </Grid>
+                        <Grid item sx={{ marginLeft: 'auto', marginRight: '32px' }}>
+                            <Link onClick={UserService.doLogout} to={'#'}>
+                                Logout
+                                <FontAwesomeIcon style={{ marginLeft: '4px' }} icon={faArrowRight} />
+                            </Link>
+                        </Grid>
+                    </Grid>
+                </ThemeProvider>
+            </Box>
+        </SwipeableDrawer>
     );
 };
 

--- a/met-web/src/components/layout/SideNav/types.ts
+++ b/met-web/src/components/layout/SideNav/types.ts
@@ -1,15 +1,10 @@
 export interface SideNavProps {
     open: boolean;
     isMediumScreen: boolean;
-    drawerWidth: number;
     setOpen: (open: boolean) => void;
 }
 
 export interface DrawerBoxProps {
     isMediumScreenOrLarger: boolean;
-    setOpen: (open: boolean) => void;
-}
-
-export interface CloseButtonProps {
     setOpen: (open: boolean) => void;
 }

--- a/met-web/src/routes/AuthenticatedRootRouteLoader.tsx
+++ b/met-web/src/routes/AuthenticatedRootRouteLoader.tsx
@@ -1,0 +1,8 @@
+import { defer } from 'react-router-dom';
+import { getMyTenants } from 'services/tenantService';
+
+export const authenticatedRootLoader = async () => {
+    // Data that should be available on all authenticated pages
+    const myTenants = getMyTenants();
+    return defer({ myTenants });
+};

--- a/met-web/src/services/tenantService/index.tsx
+++ b/met-web/src/services/tenantService/index.tsx
@@ -20,6 +20,14 @@ export const getAllTenants = async (): Promise<Tenant[]> => {
     return Promise.reject(Error('Failed to fetch tenants'));
 };
 
+export const getMyTenants = async (): Promise<Tenant[]> => {
+    const response = await http.GetRequest<Tenant[]>(Endpoints.Tenants.GET_OWN);
+    if (response.data) {
+        return response.data;
+    }
+    return Promise.reject(Error('Failed to fetch tenants'));
+};
+
 export const createTenant = async (tenant: Tenant): Promise<Tenant> => {
     const response = await http.PostRequest<Tenant>(Endpoints.Tenants.CREATE, tenant);
     if (response.data) {

--- a/met-web/tests/unit/components/factory.ts
+++ b/met-web/tests/unit/components/factory.ts
@@ -17,6 +17,8 @@ import { VideoWidget } from 'models/videoWidget';
 import { TimelineWidget, TimelineEvent, EventStatus } from 'models/timelineWidget';
 import { Tenant } from 'models/tenant';
 import { EngagementContent } from 'models/engagementContent';
+import { UserState } from 'services/userService/types';
+import { USER_ROLES } from 'services/userService/constants';
 
 const tenant: Tenant = {
     name: 'Tenant 1',
@@ -289,6 +291,32 @@ const engagementContentData: EngagementContent = {
     is_internal: true,
 };
 
+const staffUserState: Partial<UserState> = {
+    userDetail: {
+        user: {
+            first_name: 'Test',
+            last_name: 'User',
+            main_role: USER_ROLES.VIEW_ENGAGEMENT,
+            roles: [USER_ROLES.VIEW_ENGAGEMENT, USER_ROLES.MANAGE_METADATA, USER_ROLES.VIEW_USERS],
+            composite_roles: [USER_ROLES.VIEW_ENGAGEMENT],
+            contact_number: '1234567890',
+            email_address: 'blah@example.com',
+            id: 123,
+            created_date: '2021-01-01T00:00:00.000Z',
+            description: 'Test User',
+            external_id: '123',
+            status_id: 1,
+            updated_date: '2021-01-01T00:00:00.000Z',
+            username: 'testuser',
+        },
+    },
+    authentication: {
+        loading: false,
+        authenticated: true,
+    },
+    roles: [USER_ROLES.VIEW_ENGAGEMENT, USER_ROLES.MANAGE_METADATA, USER_ROLES.VIEW_USERS],
+};
+
 export {
     tenant,
     draftEngagement,
@@ -313,4 +341,5 @@ export {
     mockTimeLine,
     subscribeWidget,
     engagementContentData,
+    staffUserState,
 };

--- a/met-web/tests/unit/components/sidenav.test.tsx
+++ b/met-web/tests/unit/components/sidenav.test.tsx
@@ -6,8 +6,8 @@ import ProviderShell from './ProviderShell';
 import { setupEnv } from './setEnvVars';
 import { Routes } from '../../../src/components/layout/SideNav/SideNavElements';
 import { USER_ROLES } from 'services/userService/constants';
-
-const drawerWidth = 280;
+import { UserState } from 'services/userService/types';
+import { staffUserState } from './factory';
 
 jest.mock('@reduxjs/toolkit/query/react', () => ({
     ...jest.requireActual('@reduxjs/toolkit/query/react'),
@@ -16,26 +16,33 @@ jest.mock('@reduxjs/toolkit/query/react', () => ({
 
 jest.mock('axios');
 
-jest.mock('react-redux', () => ({
-    ...jest.requireActual('react-redux'),
-    useSelector: jest.fn(() => {
-        return [
-            USER_ROLES.VIEW_ENGAGEMENT,
-            USER_ROLES.VIEW_ASSIGNED_ENGAGEMENTS,
-            USER_ROLES.VIEW_SURVEYS,
-            USER_ROLES.VIEW_USERS,
-            USER_ROLES.VIEW_FEEDBACKS,
-            USER_ROLES.SUPER_ADMIN,
-            USER_ROLES.MANAGE_METADATA,
-            USER_ROLES.VIEW_LANGUAGES,
-        ];
+jest.mock('hooks', () => ({
+    useAppTranslation: () => ({
+        t: (key: string) => key, // return the key itself (i.e. no translation)
     }),
+    useAppSelector: (callback: any) =>
+        callback({
+            user: {
+                ...staffUserState,
+                roles: [
+                    USER_ROLES.VIEW_ENGAGEMENT,
+                    USER_ROLES.VIEW_ASSIGNED_ENGAGEMENTS,
+                    USER_ROLES.VIEW_SURVEYS,
+                    USER_ROLES.VIEW_USERS,
+                    USER_ROLES.VIEW_FEEDBACKS,
+                    USER_ROLES.SUPER_ADMIN,
+                    USER_ROLES.MANAGE_METADATA,
+                    USER_ROLES.VIEW_LANGUAGES,
+                ],
+            } as UserState,
+        }),
 }));
+
 test('Load SideNav', async () => {
     setupEnv();
     render(
         <ProviderShell>
-            <SideNav setOpen={() => void 0} isMediumScreen={false} open={true} drawerWidth={drawerWidth} />
+            <SideNav setOpen={() => void 0} isMediumScreen={false} open={true} />
         </ProviderShell>,
     );
 


### PR DESCRIPTION
Issue #: [🎟️ DESENG-660](https://citz-gdx.atlassian.net/browse/DESENG-660)

*Description of changes:*
  - Redesigned the admin header to match the new design system
  - Added a new dropdown to the header to allow users to switch between tenants
  - Added a user menu, which for now only contains a logout button
  - Added a "drawer" view for the tenant switcher and user menu on mobile

This is part of a larger feature branch for DESENG-660

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
