### PR TITLE
DESENG-675 Make widget component "reusable"

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## August 21, 2024
+
+- **Feature** Reusable widget component [🎟️ DESENG-675](https://citz-gdx.atlassian.net/browse/DESENG-675)
+
 ## August 15, 2024
 
 - **Feature** Add engagement configuration summary [🎟️ DESENG-667](https://citz-gdx.atlassian.net/browse/DESENG-667)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,4 @@ Examples of when to Request Changes
   - `StatusIcon`: A simple component that displays a status icon based on the status string passed to it.
   - `FormStep`: A wrapper around a form component that accepts a completion criteria and displays the user's progress. Accepts a `step` prop that is a number (from 1 to 9) that represents the current step in the form. This will be rendered as an icon with a checkmark if the step is complete, and a number if it's the current step or if it's incomplete.
   - `SystemMessage`: An informational message that can be displayed to the user. Accepts a `type` prop that can be "error", "warning", "info", or "success", which affects the display of the message.
+  - `WidgetPicker`: A modular widget picker component that can be placed anywhere in the engagement editing area. In order to align widgets in the backend with the frontend, a "location" prop is required. Add new locations to the `WidgetLocation` enum.

--- a/met-api/migrations/versions/c2a384ddfe6a_add_widget_location.py
+++ b/met-api/migrations/versions/c2a384ddfe6a_add_widget_location.py
@@ -1,0 +1,24 @@
+"""Add locations to widgets
+
+Revision ID: c2a384ddfe6a
+Revises: 901a6724bca2
+Create Date: 2024-08-21 16:04:25.726651
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c2a384ddfe6a'
+down_revision = '901a6724bca2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('widget', sa.Column('location', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('widget', 'location')

--- a/met-api/src/met_api/models/widget.py
+++ b/met-api/src/met_api/models/widget.py
@@ -29,6 +29,7 @@ class Widget(BaseModel):  # pylint: disable=too-few-public-methods
     title = db.Column(db.String(100), comment='Custom title for the widget.')
     items = db.relationship('WidgetItem', backref='widget', cascade='all, delete', order_by='WidgetItem.sort_index')
     sort_index = db.Column(db.Integer, nullable=False, default=1)
+    location = db.Column(db.Integer, nullable=False)
 
     @classmethod
     def get_widget_by_id(cls, widget_id):
@@ -67,6 +68,7 @@ class Widget(BaseModel):  # pylint: disable=too-few-public-methods
             created_by=widget.get('created_by', None),
             updated_by=widget.get('updated_by', None),
             title=widget.get('title', None),
+            location=widget.get('location', None),
         )
 
     @classmethod

--- a/met-api/src/met_api/schemas/widget.py
+++ b/met-api/src/met_api/schemas/widget.py
@@ -23,3 +23,4 @@ class WidgetSchema(Schema):
     updated_date = fields.Str(data_key='updated_date')
     sort_index = fields.Int(data_key='sort_index')
     items = fields.List(fields.Nested(WidgetItemSchema))
+    location = fields.Int(data_key='location')

--- a/met-web/src/components/engagement/admin/create/widgets/WidgetPickerButton.tsx
+++ b/met-web/src/components/engagement/admin/create/widgets/WidgetPickerButton.tsx
@@ -1,0 +1,82 @@
+import React, { useContext, useEffect } from 'react';
+import { WidgetDrawerContext } from 'components/engagement/form/EngagementWidgets/WidgetDrawerContext';
+import { Grid, Skeleton } from '@mui/material';
+import { If, Else, Then } from 'react-if';
+import { useAppDispatch } from 'hooks';
+import { colors } from 'styles/Theme';
+import { WidgetCardSwitch } from 'components/engagement/form/EngagementWidgets/WidgetCardSwitch';
+import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
+import { WidgetLocation } from 'models/widget';
+
+export const WidgetPickerButton = ({ location }: { location: WidgetLocation }) => {
+    const { widgets, deleteWidget, handleWidgetDrawerOpen, isWidgetsLoading, setWidgetLocation } =
+        useContext(WidgetDrawerContext);
+    const dispatch = useAppDispatch();
+
+    useEffect(() => {
+        setWidgetLocation(location);
+        return () => setWidgetLocation(0);
+    }, []);
+
+    const removeWidget = (widgetId: number) => {
+        dispatch(
+            openNotificationModal({
+                open: true,
+                data: {
+                    header: 'Remove Widget',
+                    subText: [
+                        { text: 'You will be removing this widget from the engagement.' },
+                        { text: 'Do you want to remove this widget?' },
+                    ],
+                    handleConfirm: () => {
+                        deleteWidget(widgetId);
+                    },
+                },
+                type: 'confirm',
+            }),
+        );
+    };
+
+    return (
+        <Grid container spacing={2} direction="column">
+            <If condition={isWidgetsLoading}>
+                <Then>
+                    <Grid item xs={12}>
+                        <Skeleton width="100%" height="3em" />
+                    </Grid>
+                </Then>
+                <Else>
+                    <Grid item>
+                        {/* Only ever render the first selected widget. This may change in the future. */}
+                        {widgets.length > 0 ? (
+                            <WidgetCardSwitch
+                                singleSelection={true}
+                                key={`${widgets[0].widget_type_id}`}
+                                widget={widgets[0]}
+                                removeWidget={removeWidget}
+                            />
+                        ) : (
+                            <button
+                                onClick={() => handleWidgetDrawerOpen(true)}
+                                style={{
+                                    width: '100%',
+                                    borderRadius: '8px',
+                                    borderColor: colors.surface.blue[90],
+                                    borderWidth: '2px',
+                                    borderStyle: 'dashed',
+                                    backgroundColor: colors.surface.blue[10],
+                                    padding: '3rem',
+                                    fontSize: '16px',
+                                    color: colors.surface.blue[90],
+                                    cursor: 'pointer',
+                                }}
+                            >
+                                Optional Content Widgets
+                            </button>
+                        )}
+                    </Grid>
+                </Else>
+            </If>
+        </Grid>
+    );
+};

--- a/met-web/src/components/engagement/admin/create/widgets/WidgetPickerButton.tsx
+++ b/met-web/src/components/engagement/admin/create/widgets/WidgetPickerButton.tsx
@@ -23,6 +23,7 @@ export const WidgetPickerButton = ({ location }: { location: WidgetLocation }) =
             openNotificationModal({
                 open: true,
                 data: {
+                    style: 'warning',
                     header: 'Remove Widget',
                     subText: [
                         { text: 'You will be removing this widget from the engagement.' },

--- a/met-web/src/components/engagement/admin/create/widgets/index.tsx
+++ b/met-web/src/components/engagement/admin/create/widgets/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import WidgetDrawer from 'components/engagement/form/EngagementWidgets/WidgetDrawer';
+import { WidgetDrawerProvider } from 'components/engagement/form/EngagementWidgets/WidgetDrawerContext';
+import { WidgetPickerButton } from './WidgetPickerButton';
+import { WidgetLocation } from 'models/widget';
+import { ActionProvider } from 'components/engagement/form/ActionContext';
+
+export const WidgetPicker = ({ location }: { location: WidgetLocation }) => {
+    return (
+        <ActionProvider>
+            <WidgetDrawerProvider>
+                <WidgetPickerButton location={location} />
+                <WidgetDrawer />
+            </WidgetDrawerProvider>
+        </ActionProvider>
+    );
+};
+
+export default WidgetPicker;

--- a/met-web/src/components/engagement/admin/view/ConfigSummary.tsx
+++ b/met-web/src/components/engagement/admin/view/ConfigSummary.tsx
@@ -15,6 +15,8 @@ import { ENGAGEMENT_MEMBERSHIP_STATUS, EngagementTeamMember } from 'models/engag
 import { Button } from 'components/common/Input';
 import { faPen } from '@fortawesome/pro-regular-svg-icons';
 import { LiveAnnouncer, LiveMessage } from 'react-aria-live';
+import { WidgetPicker } from 'components/engagement/admin/create/widgets';
+import { WidgetLocation } from 'models/widget';
 
 export const ConfigSummary = () => {
     const siteUrl = getBaseUrl();
@@ -178,6 +180,10 @@ export const ConfigSummary = () => {
                         </Grid>
                     </OutlineBox>
                 </Grid>
+                <Grid item>
+                    <WidgetPicker location={WidgetLocation.engagementAuthoring} />
+                </Grid>
+
                 <Grid item sx={{ pt: '40px' }}>
                     <Button href="../config" variant="secondary" icon={<FontAwesomeIcon icon={faPen} />}>
                         Edit Configuration

--- a/met-web/src/components/engagement/admin/view/ConfigSummary.tsx
+++ b/met-web/src/components/engagement/admin/view/ConfigSummary.tsx
@@ -15,8 +15,6 @@ import { ENGAGEMENT_MEMBERSHIP_STATUS, EngagementTeamMember } from 'models/engag
 import { Button } from 'components/common/Input';
 import { faPen } from '@fortawesome/pro-regular-svg-icons';
 import { LiveAnnouncer, LiveMessage } from 'react-aria-live';
-import { WidgetPicker } from 'components/engagement/admin/create/widgets';
-import { WidgetLocation } from 'models/widget';
 
 export const ConfigSummary = () => {
     const siteUrl = getBaseUrl();
@@ -180,10 +178,6 @@ export const ConfigSummary = () => {
                         </Grid>
                     </OutlineBox>
                 </Grid>
-                <Grid item>
-                    <WidgetPicker location={WidgetLocation.engagementAuthoring} />
-                </Grid>
-
                 <Grid item sx={{ pt: '40px' }}>
                     <Button href="../config" variant="secondary" icon={<FontAwesomeIcon icon={faPen} />}>
                         Edit Configuration

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/AddFileDrawer.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/AddFileDrawer.tsx
@@ -15,6 +15,7 @@ import ControlledSelect from 'components/common/ControlledInputComponents/Contro
 import { postDocument, patchDocument, PatchDocumentRequest } from 'services/widgetService/DocumentService';
 import { DOCUMENT_TYPE, DocumentItem } from 'models/document';
 import { updatedDiff } from 'deep-object-diff';
+import { WidgetLocation } from 'models/widget';
 
 const schema = yup
     .object({
@@ -91,6 +92,7 @@ const AddFileDrawer = () => {
             url: data.link,
             widget_id: widget.id,
             type: 'file',
+            location: widget.location in WidgetLocation ? widget.location : null,
         });
         dispatch(
             openNotification({

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -7,9 +7,8 @@ import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { postDocument } from 'services/widgetService/DocumentService';
 import { WidgetDrawerContext } from '../WidgetDrawerContext';
-import { WidgetType } from 'models/widget';
+import { WidgetType, WidgetLocation } from 'models/widget';
 import { DOCUMENT_TYPE } from 'models/document';
-import { WidgetLocation } from 'models/widget';
 
 const CreateFolderForm = () => {
     const { loadDocuments, handleAddFileDrawerOpen, setUploadFileDrawerOpen } = useContext(DocumentsContext);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/CreateFolderForm.tsx
@@ -9,6 +9,7 @@ import { postDocument } from 'services/widgetService/DocumentService';
 import { WidgetDrawerContext } from '../WidgetDrawerContext';
 import { WidgetType } from 'models/widget';
 import { DOCUMENT_TYPE } from 'models/document';
+import { WidgetLocation } from 'models/widget';
 
 const CreateFolderForm = () => {
     const { loadDocuments, handleAddFileDrawerOpen, setUploadFileDrawerOpen } = useContext(DocumentsContext);
@@ -48,6 +49,7 @@ const CreateFolderForm = () => {
                 title: folderName,
                 widget_id: widget.id,
                 type: DOCUMENT_TYPE.FOLDER,
+                location: widget.location in WidgetLocation ? widget.location : null,
             });
             await loadDocuments();
             setCreatingFolder(false);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Documents/UploadFileDrawer.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Documents/UploadFileDrawer.tsx
@@ -24,6 +24,7 @@ import { DOCUMENT_TYPE, DocumentItem } from 'models/document';
 import { saveObject } from 'services/objectStorageService';
 import FileUpload from 'components/common/FileUpload';
 import { If, Then, Else } from 'react-if';
+import { WidgetLocation } from 'models/widget';
 
 const schema = yup
     .object({
@@ -94,6 +95,7 @@ const UploadFileDrawer = () => {
             widget_id: widget.id,
             type: 'file',
             is_uploaded: true,
+            location: widget.location in WidgetLocation ? widget.location : null,
         });
         dispatch(
             openNotification({

--- a/met-web/src/components/engagement/form/EngagementWidgets/Events/InPersonEventFormDrawer.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Events/InPersonEventFormDrawer.tsx
@@ -18,6 +18,7 @@ import { formEventDates } from './utils';
 import dayjs from 'dayjs';
 import tz from 'dayjs/plugin/timezone';
 import { updatedDiff } from 'deep-object-diff';
+import { WidgetLocation } from 'models/widget';
 
 dayjs.extend(tz);
 
@@ -113,6 +114,7 @@ const InPersonEventFormDrawer = () => {
                         end_date: formatToUTC(dateTo),
                     },
                 ],
+                location: widget.location in WidgetLocation ? widget.location : null,
             });
 
             setEvents((prevWidgetEvents: Event[]) => [...prevWidgetEvents, createdWidgetEvent]);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Events/VirtualSessionFormDrawer.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Events/VirtualSessionFormDrawer.tsx
@@ -17,6 +17,7 @@ import { formatToUTC, formatDate } from 'components/common/dateHelper';
 import { formEventDates } from './utils';
 import dayjs from 'dayjs';
 import tz from 'dayjs/plugin/timezone';
+import { WidgetLocation } from 'models/widget';
 
 dayjs.extend(tz);
 
@@ -108,6 +109,7 @@ const VirtualSessionFormDrawer = () => {
                         end_date: formatToUTC(dateTo),
                     },
                 ],
+                location: widget.location in WidgetLocation ? widget.location : null,
             });
 
             setEvents((prevWidgetEvents: Event[]) => [...prevWidgetEvents, createdWidgetEvent]);

--- a/met-web/src/components/engagement/form/EngagementWidgets/Map/Form.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Map/Form.tsx
@@ -27,6 +27,7 @@ import { faCircleXmark } from '@fortawesome/pro-regular-svg-icons/faCircleXmark'
 import { When } from 'react-if';
 import * as turf from '@turf/turf';
 import { WidgetTitle } from '../WidgetTitle';
+import { WidgetLocation } from 'models/widget';
 
 const schema = yup
     .object({
@@ -98,6 +99,7 @@ const Form = () => {
             longitude: longitude,
             latitude: latitude,
             file: shapefile,
+            location: widget.location in WidgetLocation ? widget.location : null,
         });
         dispatch(openNotification({ severity: 'success', text: 'A new map was successfully added' }));
     };

--- a/met-web/src/components/engagement/form/EngagementWidgets/Poll/Form.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Poll/Form.tsx
@@ -16,6 +16,7 @@ import { PollStatus } from 'constants/engagementStatus';
 import Alert from '@mui/material/Alert';
 import usePollWidgetState from './PollWidget.hook';
 import PollAnswerForm from './PollAnswerForm';
+import { WidgetLocation } from 'models/widget';
 
 interface DetailsForm {
     title: string;
@@ -79,6 +80,7 @@ const Form = () => {
             description: description,
             answers: answers,
             status: status,
+            location: widget.location in WidgetLocation ? widget.location : null,
         });
         dispatch(openNotification({ severity: 'success', text: 'A new Poll was successfully added' }));
     };

--- a/met-web/src/components/engagement/form/EngagementWidgets/Timeline/Form.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Timeline/Form.tsx
@@ -10,6 +10,7 @@ import { TimelineContext } from './TimelineContext';
 import { patchTimeline, postTimeline } from 'services/widgetService/TimelineService';
 import { WidgetTitle } from '../WidgetTitle';
 import { TimelineEvent } from 'models/timelineWidget';
+import { WidgetLocation } from 'models/widget';
 
 interface DetailsForm {
     title: string;
@@ -81,6 +82,7 @@ const Form = () => {
             title: title,
             description: description,
             events: events,
+            location: widget.location in WidgetLocation ? widget.location : null,
         });
         dispatch(openNotification({ severity: 'success', text: 'A new timeline was successfully added' }));
     };

--- a/met-web/src/components/engagement/form/EngagementWidgets/Video/Form.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Video/Form.tsx
@@ -13,6 +13,7 @@ import { VideoContext } from './VideoContext';
 import { patchVideo, postVideo } from 'services/widgetService/VideoService';
 import { updatedDiff } from 'deep-object-diff';
 import { WidgetTitle } from '../WidgetTitle';
+import { WidgetLocation } from 'models/widget';
 
 const schema = yup
     .object({
@@ -61,6 +62,7 @@ const Form = () => {
             engagement_id: widget.engagement_id,
             video_url: videoUrl,
             description: description,
+            location: widget.location in WidgetLocation ? widget.location : null,
         });
         dispatch(openNotification({ severity: 'success', text: 'A new video was successfully added' }));
     };

--- a/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningForm.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningForm.tsx
@@ -19,8 +19,8 @@ const WhoIsListeningForm = () => {
     const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
     const [savingWidgetItems, setSavingWidgetItems] = useState(false);
     const [createWidgetItems] = useCreateWidgetItemsMutation();
-
     const widget = widgets.filter((widget) => widget.widget_type_id === WidgetType.WhoIsListening)[0] || null;
+
     useEffect(() => {
         const savedContacts = widget.items
             .map((widget_item) => {

--- a/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningOptionCard.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningOptionCard.tsx
@@ -6,13 +6,12 @@ import { WidgetTabValues } from '../type';
 import { ActionContext } from '../../ActionContext';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { useAppDispatch } from 'hooks';
-import { WidgetType } from 'models/widget';
+import { WidgetType, WidgetLocation } from 'models/widget';
 import { Else, If, Then } from 'react-if';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserGroupSimple } from '@fortawesome/pro-regular-svg-icons/faUserGroupSimple';
 import { useCreateWidgetMutation } from 'apiManager/apiSlices/widgets';
 import { optionCardStyle } from '../constants';
-import { WidgetLocation } from 'models/widget';
 
 const Title = 'Who is Listening';
 const WhoIsListeningOptionCard = () => {

--- a/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningOptionCard.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WhoIsListening/WhoIsListeningOptionCard.tsx
@@ -12,11 +12,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserGroupSimple } from '@fortawesome/pro-regular-svg-icons/faUserGroupSimple';
 import { useCreateWidgetMutation } from 'apiManager/apiSlices/widgets';
 import { optionCardStyle } from '../constants';
+import { WidgetLocation } from 'models/widget';
 
 const Title = 'Who is Listening';
 const WhoIsListeningOptionCard = () => {
     const { savedEngagement } = useContext(ActionContext);
-    const { widgets, loadWidgets, handleWidgetDrawerTabValueChange } = useContext(WidgetDrawerContext);
+    const { widgets, loadWidgets, handleWidgetDrawerTabValueChange, widgetLocation } = useContext(WidgetDrawerContext);
     const dispatch = useAppDispatch();
     const [createWidget] = useCreateWidgetMutation();
     const [isCreatingWidget, setIsCreatingWidget] = useState(false);
@@ -34,6 +35,7 @@ const WhoIsListeningOptionCard = () => {
                 widget_type_id: WidgetType.WhoIsListening,
                 engagement_id: savedEngagement.id,
                 title: Title,
+                location: widgetLocation in WidgetLocation ? widgetLocation : 0,
             });
             await loadWidgets();
             dispatch(

--- a/met-web/src/components/engagement/form/EngagementWidgets/WidgetCardSwitch.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WidgetCardSwitch.tsx
@@ -6,10 +6,11 @@ import { WidgetDrawerContext } from './WidgetDrawerContext';
 import { WidgetTabValues } from './type';
 
 interface WidgetCardSwitchProps {
+    singleSelection?: boolean;
     widget: Widget;
     removeWidget: (widgetId: number) => void;
 }
-export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps) => {
+export const WidgetCardSwitch = ({ singleSelection = false, widget, removeWidget }: WidgetCardSwitchProps) => {
     const { handleWidgetDrawerOpen, handleWidgetDrawerTabValueChange } = useContext(WidgetDrawerContext);
 
     return (
@@ -17,6 +18,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
             <Switch>
                 <Case condition={widget.widget_type_id === WidgetType.WhoIsListening}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`who-is-listening-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -30,6 +32,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Document}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`document-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -43,6 +46,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Subscribe}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`subscribe-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -56,6 +60,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Events}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`event-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -69,6 +74,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Map}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`event-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -82,6 +88,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Video}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`event-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -95,6 +102,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Timeline}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`event-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {
@@ -108,6 +116,7 @@ export const WidgetCardSwitch = ({ widget, removeWidget }: WidgetCardSwitchProps
                 </Case>
                 <Case condition={widget.widget_type_id === WidgetType.Poll}>
                     <MetWidget
+                        sortable={!singleSelection}
                         testId={`event-${widget.widget_type_id}`}
                         title={widget.title}
                         onDelete={() => {

--- a/met-web/src/components/engagement/form/EngagementWidgets/WidgetDrawerContext.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/WidgetDrawerContext.tsx
@@ -18,6 +18,8 @@ export interface WidgetDrawerContextProps {
     loadWidgets: () => Promise<void>;
     deleteWidget: (widgetIndex: number) => void;
     updateWidgetsSorting: (widgets: Widget[]) => void;
+    widgetLocation: number;
+    setWidgetLocation: (widgetLocation: number) => void;
 }
 
 export type EngagementParams = {
@@ -45,6 +47,10 @@ export const WidgetDrawerContext = createContext<WidgetDrawerContextProps>({
     updateWidgetsSorting: (widgets: Widget[]) => {
         /* empty default method  */
     },
+    widgetLocation: 0,
+    setWidgetLocation: (widgetLocation: number) => {
+        /* empty default method  */
+    },
 });
 
 export const WidgetDrawerProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
@@ -56,6 +62,7 @@ export const WidgetDrawerProvider = ({ children }: { children: JSX.Element | JSX
     const [widgetDrawerTabValue, setWidgetDrawerTabValue] = React.useState(WidgetTabValues.WIDGET_OPTIONS);
     const [removeWidget] = useDeleteWidgetMutation();
     const [sortWidgets] = useSortWidgetsMutation();
+    const [widgetLocation, setWidgetLocation] = useState(0);
 
     const deleteWidget = async (widgetId: number) => {
         try {
@@ -116,6 +123,8 @@ export const WidgetDrawerProvider = ({ children }: { children: JSX.Element | JSX
                 handleWidgetDrawerTabValueChange,
                 isWidgetsLoading,
                 loadWidgets,
+                widgetLocation,
+                setWidgetLocation,
             }}
         >
             {children}

--- a/met-web/src/models/widget.tsx
+++ b/met-web/src/models/widget.tsx
@@ -11,6 +11,7 @@ export interface Widget {
     engagement_id: number;
     items: WidgetItem[];
     title: string;
+    location: WidgetLocation;
 }
 
 export enum WidgetType {
@@ -23,4 +24,8 @@ export enum WidgetType {
     CACForm = 8,
     Timeline = 9,
     Poll = 10,
+}
+
+export enum WidgetLocation {
+    engagementAuthoring = 1,
 }

--- a/met-web/src/services/widgetService/DocumentService/index.tsx
+++ b/met-web/src/services/widgetService/DocumentService/index.tsx
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import { DocumentItem, DocumentType } from 'models/document';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
+import { WidgetLocation } from 'models/widget';
 
 export const fetchDocuments = async (widget_id: number): Promise<DocumentItem[]> => {
     try {
@@ -20,6 +21,7 @@ interface PostDocumentRequest {
     url?: string;
     type: DocumentType;
     is_uploaded?: boolean;
+    location: WidgetLocation | null;
 }
 export const postDocument = async (widget_id: number, data: PostDocumentRequest): Promise<DocumentItem> => {
     try {

--- a/met-web/src/services/widgetService/EventService/index.tsx
+++ b/met-web/src/services/widgetService/EventService/index.tsx
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl, replaceAllInURL } from 'helper';
 import { Event, EventTypeLabel } from 'models/event';
+import { WidgetLocation } from 'models/widget';
 
 export const getEvents = async (widget_id: number): Promise<Event[]> => {
     try {
@@ -26,6 +27,7 @@ interface PostEventProps {
         url?: string;
         url_label?: string;
     }[];
+    location: WidgetLocation | null;
 }
 export const postEvent = async (widget_id: number, data: PostEventProps): Promise<Event> => {
     try {

--- a/met-web/src/services/widgetService/MapService/index.tsx
+++ b/met-web/src/services/widgetService/MapService/index.tsx
@@ -3,6 +3,7 @@ import { WidgetMap } from 'models/widgetMap';
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
 import { GeoJSON } from 'geojson';
+import { WidgetLocation } from 'models/widget';
 
 export const fetchMaps = async (widget_id: number): Promise<WidgetMap[]> => {
     try {
@@ -21,6 +22,7 @@ interface PostMapRequest {
     latitude: number;
     marker_label?: string;
     file?: File;
+    location: WidgetLocation | null;
 }
 
 export const postMap = async (widget_id: number, data: PostMapRequest): Promise<WidgetMap> => {

--- a/met-web/src/services/widgetService/PollService/index.tsx
+++ b/met-web/src/services/widgetService/PollService/index.tsx
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
 import { PollWidget, PollAnswer, PollResponse, PollResultResponse } from 'models/pollWidget';
+import { WidgetLocation } from 'models/widget';
 
 interface PostPollRequest {
     widget_id: number;
@@ -10,6 +11,7 @@ interface PostPollRequest {
     description: string;
     answers: PollAnswer[];
     status: string;
+    location: WidgetLocation | null;
 }
 
 interface PostPollResponse {

--- a/met-web/src/services/widgetService/TimelineService/index.tsx
+++ b/met-web/src/services/widgetService/TimelineService/index.tsx
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
 import { TimelineWidget, TimelineEvent } from 'models/timelineWidget';
+import { WidgetLocation } from 'models/widget';
 
 interface PostTimelineRequest {
     widget_id: number;
@@ -9,6 +10,7 @@ interface PostTimelineRequest {
     title: string;
     description: string;
     events: TimelineEvent[];
+    location: WidgetLocation | null;
 }
 
 interface PatchTimelineRequest {

--- a/met-web/src/services/widgetService/VideoService/index.tsx
+++ b/met-web/src/services/widgetService/VideoService/index.tsx
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
 import { VideoWidget } from 'models/videoWidget';
+import { WidgetLocation } from 'models/widget';
 
 export const fetchVideoWidgets = async (widget_id: number): Promise<VideoWidget[]> => {
     try {
@@ -18,6 +19,7 @@ interface PostVideoRequest {
     engagement_id: number;
     video_url: string;
     description: string;
+    location: WidgetLocation | null;
 }
 
 export const postVideo = async (widget_id: number, data: PostVideoRequest): Promise<VideoWidget> => {

--- a/met-web/tests/unit/components/engagement/old-engagement.test.tsx
+++ b/met-web/tests/unit/components/engagement/old-engagement.test.tsx
@@ -47,6 +47,7 @@ const whoIsListeningWidget: Widget = {
     widget_type_id: WidgetType.WhoIsListening,
     engagement_id: 1,
     items: [widgetItem],
+    location: 1,
 };
 
 const mockLocationData = { state: { open: true }, pathname: '', search: '', hash: '', key: '' };

--- a/met-web/tests/unit/components/factory.ts
+++ b/met-web/tests/unit/components/factory.ts
@@ -141,6 +141,7 @@ const eventWidget: Widget = {
     widget_type_id: WidgetType.Events,
     engagement_id: 1,
     items: [eventWidgetItem],
+    location: 1,
 };
 
 const mapWidgetItem: WidgetItem = {
@@ -156,6 +157,7 @@ const mapWidget: Widget = {
     widget_type_id: WidgetType.Map,
     engagement_id: 1,
     items: [mapWidgetItem],
+    location: 1,
 };
 
 const mockMap: WidgetMap = {
@@ -182,6 +184,7 @@ const pollWidget: Widget = {
     widget_type_id: WidgetType.Poll,
     engagement_id: 1,
     items: [],
+    location: 1,
 };
 
 const videoWidget: Widget = {
@@ -190,6 +193,7 @@ const videoWidget: Widget = {
     widget_type_id: WidgetType.Video,
     engagement_id: 1,
     items: [],
+    location: 1,
 };
 
 const subscribeWidget: Widget = {
@@ -198,6 +202,7 @@ const subscribeWidget: Widget = {
     widget_type_id: WidgetType.Subscribe,
     engagement_id: 1,
     items: [],
+    location: 1,
 };
 
 const timeLineWidget: Widget = {
@@ -206,6 +211,7 @@ const timeLineWidget: Widget = {
     widget_type_id: WidgetType.Timeline,
     engagement_id: 1,
     items: [],
+    location: 1,
 };
 
 const mockPollAnswer1: PollAnswer = {

--- a/met-web/tests/unit/components/widgets/DocumentWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/DocumentWidget.test.tsx
@@ -68,6 +68,7 @@ const documentWidget: Widget = {
     widget_type_id: WidgetType.Document,
     engagement_id: 1,
     items: [],
+    location: 1,
 };
 
 jest.mock('axios');

--- a/met-web/tests/unit/components/widgets/PollWidgetView.test.tsx
+++ b/met-web/tests/unit/components/widgets/PollWidgetView.test.tsx
@@ -44,6 +44,7 @@ describe('PollWidgetView Component Tests', () => {
         widget_type_id: 10,
         engagement_id: 1,
         items: [],
+        location: 1,
     };
 
     const mockPoll = {

--- a/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/WhoIsListeningWidget.test.tsx
@@ -53,6 +53,7 @@ const whoIsListeningWidget: Widget = {
     widget_type_id: WidgetType.WhoIsListening,
     engagement_id: 1,
     items: [contactWidgetItem],
+    location: 1,
 };
 
 const mockEngagementSettings: EngagementSettings = {
@@ -226,6 +227,7 @@ describe('Who is Listening widget  tests', () => {
             widget_type_id: WidgetType.WhoIsListening,
             engagement_id: draftEngagement.id,
             title: whoIsListeningWidget.title,
+            location: 0,
         });
         expect(getWidgetsMock).toHaveBeenCalled();
         expect(screen.getByText('Add This Contact')).toBeVisible();


### PR DESCRIPTION
Issue #: https://citz-gdx.atlassian.net/browse/DESENG-675

**Description of changes:**
- Widget component can now be placed anywhere within an engagement
- Update Changelog to include instructions for use

**Tips for reviewers**
- The PR is smaller than it looks, most substantive changes are under `met-web/src/components/engagement/admin/create/widgets/*` and the rest are just updating dependencies and adding a few props/flags to support the new functionality 

**User Guide update ticket (if applicable):** N/A