### PR TITLE
Feature/deseng692: Reverted to previous title logic for video widget

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,13 @@
+## September 25, 2024
+
+- **Feature** New Video Widget front end [🎟️ DESENG-692](https://citz-gdx.atlassian.net/browse/DESENG-692)
+	- Removed unneeded tables from db
+	- Updated all other met_api and met_web logic to accomodate this
+
+- **Feature** New Map Widget front end [🎟️ DESENG-693](https://citz-gdx.atlassian.net/browse/DESENG-693)
+	- Implemented Figma design
+	- Fixed accessibility issue with map labels (white text on white background)
+
 ## September 23, 2024
 
 - **Feature** New Hero Banner page in authoring section [🎟️ DESENG-670](https://citz-gdx.atlassian.net/browse/DESENG-670)
@@ -9,7 +19,6 @@
 ## September 18, 2024
 
 - **Feature** New Video Widget front end [🎟️ DESENG-692](https://citz-gdx.atlassian.net/browse/DESENG-692)
-
   - Implemented Figma design
   - Created custom layover bar for videos that shows video provider and has a custom logo
   - Transcripts will not be implemented at this time

--- a/docs/MET_database_ERD.md
+++ b/docs/MET_database_ERD.md
@@ -124,7 +124,6 @@ erDiagram
         integer widget_id FK "The id from widget"
         integer engagement_id FK "The id from engagement"
         string video_url
-		string title
         string description
         timestamp created_date
         timestamp updated_date

--- a/met-api/migrations/versions/70a410c85b24_removing_title_column_from_widget_video_.py
+++ b/met-api/migrations/versions/70a410c85b24_removing_title_column_from_widget_video_.py
@@ -1,0 +1,26 @@
+"""Removing title column from widget_video table.
+
+Revision ID: 70a410c85b24
+Revises: 58923bf5bda6
+Create Date: 2024-09-25 18:53:39.741012
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '70a410c85b24'
+down_revision = '58923bf5bda6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('widget_translation', 'video_title')
+    op.drop_column('widget_video', 'title')
+
+
+def downgrade():
+    op.add_column('widget_video', sa.Column('title', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column('widget_translation', sa.Column('video_title', sa.TEXT(), autoincrement=False, nullable=True))

--- a/met-api/src/met_api/models/widget_translation.py
+++ b/met-api/src/met_api/models/widget_translation.py
@@ -28,7 +28,6 @@ class WidgetTranslation(BaseModel):  # pylint: disable=too-few-public-methods
     poll_title = db.Column(db.String(255))
     poll_description = db.Column(db.String(2048))
     video_url = db.Column(db.String(255))
-    video_title = db.Column(db.Text(255))
     video_description = db.Column(db.Text())
 
     @classmethod
@@ -63,7 +62,6 @@ class WidgetTranslation(BaseModel):  # pylint: disable=too-few-public-methods
             poll_title=translation.get('poll_title', None),
             poll_description=translation.get('poll_description', None),
             video_url=translation.get('video_url', None),
-            video_title=translation.get('video_title', None),
             video_description=translation.get('video_description', None),
         )
 

--- a/met-api/src/met_api/models/widget_video.py
+++ b/met-api/src/met_api/models/widget_video.py
@@ -18,7 +18,6 @@ class WidgetVideo(BaseModel):  # pylint: disable=too-few-public-methods, too-man
     widget_id = db.Column(db.Integer, ForeignKey('widget.id', ondelete='CASCADE'), nullable=True)
     engagement_id = db.Column(db.Integer, ForeignKey('engagement.id', ondelete='CASCADE'), nullable=True)
     video_url = db.Column(db.String(255), nullable=False)
-    title = db.Column(db.String(255), nullable=True)
     description = db.Column(db.Text())
 
     @classmethod

--- a/met-api/src/met_api/schemas/schemas/video_widget_update.json
+++ b/met-api/src/met_api/schemas/schemas/video_widget_update.json
@@ -21,13 +21,6 @@
           "description": "The description of this video.",
           "examples": ["A video widget description"]
       },
-      "title": {
-          "$id": "#/properties/title",
-          "type": "string",
-          "title": "Video title",
-          "description": "The title of this video.",
-          "examples": ["A video widget title"]
-      },
       "video_url": {
           "$id": "#/properties/video_url",
           "type": "string",

--- a/met-api/src/met_api/schemas/widget_translation.py
+++ b/met-api/src/met_api/schemas/widget_translation.py
@@ -19,6 +19,5 @@ class WidgetTranslationSchema(Schema):
     map_file_name = fields.Str(data_key='map_file_name')
     poll_title = fields.Str(data_key='poll_title')
     poll_description = fields.Str(data_key='poll_description')
-    video_url = fields.Str(data_key='video_url')
     video_title = fields.Str(data_key='video_title')
     video_description = fields.Str(data_key='video_description')

--- a/met-api/src/met_api/schemas/widget_video.py
+++ b/met-api/src/met_api/schemas/widget_video.py
@@ -25,4 +25,4 @@ class WidgetVideoSchema(Schema):  # pylint: disable=too-many-ancestors, too-few-
         """Videos all of the Widget Video fields to a default schema."""
 
         model = WidgetVideoModel
-        fields = ('id', 'widget_id', 'engagement_id', 'video_url', 'title', 'description')
+        fields = ('id', 'widget_id', 'engagement_id', 'video_url', 'description')

--- a/met-api/src/met_api/services/widget_translation_service.py
+++ b/met-api/src/met_api/services/widget_translation_service.py
@@ -130,7 +130,6 @@ class WidgetTranslationService:
             widget_video = WidgetVideoModel.get_video(widget_id)
             if widget_video:
                 translation_data['video_url'] = widget_video[0].video_url
-                translation_data['video_title'] = widget_video[0].title
                 translation_data['video_description'] = widget_video[0].description
 
         return translation_data

--- a/met-api/src/met_api/services/widget_video_service.py
+++ b/met-api/src/met_api/services/widget_video_service.py
@@ -47,7 +47,6 @@ class WidgetVideoService:
         video_model.widget_id = widget_id
         video_model.engagement_id = video_data.get('engagement_id')
         video_model.video_url = video_data.get('video_url')
-        video_model.title = video_data.get('title')
         video_model.description = video_data.get('description')
         video_model.flush()
         return video_model

--- a/met-api/tests/unit/api/test_widget_video.py
+++ b/met-api/tests/unit/api/test_widget_video.py
@@ -120,7 +120,6 @@ def test_patch_video(client, jwt, session,
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     video_edits = {
-        'title': fake.text(max_nb_chars=20),
         'description': fake.text(max_nb_chars=20),
         'video_url': fake.url(),
     }
@@ -137,7 +136,6 @@ def test_patch_video(client, jwt, session,
         content_type=ContentType.JSON.value
     )
     assert rv.status_code == HTTPStatus.OK
-    assert rv.json[0].get('title') == video_edits.get('title')
     assert rv.json[0].get('description') == video_edits.get('description')
 
     with patch.object(WidgetVideoService, 'update_video',

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -526,7 +526,6 @@ def factory_video_model(video_info: dict = TestWidgetVideo.video1):
     """Produce a comment model."""
     video = WidgetVideoModel(
         video_url=video_info.get('video_url'),
-        title=video_info.get('title'),
         description=video_info.get('description'),
         widget_id=video_info.get('widget_id'),
         engagement_id=video_info.get('engagement_id'),

--- a/met-web/src/components/engagement/form/EngagementWidgets/Video/Form.tsx
+++ b/met-web/src/components/engagement/form/EngagementWidgets/Video/Form.tsx
@@ -43,7 +43,6 @@ const Form = () => {
 
     useEffect(() => {
         if (videoWidget) {
-            methods.setValue('title', videoWidget.title);
             methods.setValue('description', videoWidget.description);
             methods.setValue('videoUrl', videoWidget.video_url);
         }
@@ -55,12 +54,11 @@ const Form = () => {
         }
 
         const validatedData = await schema.validate(data);
-        const { videoUrl, title, description } = validatedData;
+        const { videoUrl, description } = validatedData;
         await postVideo(widget.id, {
             widget_id: widget.id,
             engagement_id: widget.engagement_id,
             video_url: videoUrl,
-            title: title || '',
             description: description || '',
             location: widget.location in WidgetLocation ? widget.location : null,
         });
@@ -76,12 +74,10 @@ const Form = () => {
         const updatedDate = updatedDiff(
             {
                 description: videoWidget.description,
-                title: videoWidget.title,
                 video_url: videoWidget.video_url,
             },
             {
                 description: validatedData.description,
-                title: validatedData.title,
                 video_url: validatedData.videoUrl,
             },
         );
@@ -144,19 +140,6 @@ const Form = () => {
                             justifyContent="flex-start"
                             spacing={2}
                         >
-                            <Grid item xs={12}>
-                                <MetLabel>Title (Optional)</MetLabel>
-                                <ControlledTextField
-                                    name="title"
-                                    variant="outlined"
-                                    label=" "
-                                    aria-label="Title: optional."
-                                    InputLabelProps={{
-                                        shrink: false,
-                                    }}
-                                    fullWidth
-                                />
-                            </Grid>
                             <Grid item xs={12}>
                                 <MetLabel>Description (Optional)</MetLabel>
                                 <ControlledTextField

--- a/met-web/src/components/engagement/old-view/widgets/Video/VideoWidgetView.tsx
+++ b/met-web/src/components/engagement/old-view/widgets/Video/VideoWidgetView.tsx
@@ -147,7 +147,7 @@ const VideoWidgetView = ({ widget }: VideoWidgetProps) => {
 
     return (
         <Grid container justifyContent={{ xs: 'center' }} alignItems="center" rowSpacing={2}>
-            <Grid item xs={12} sx={{ height: 0 === videoWidget.title.length ? '0px' : 'auto' }}>
+            <Grid item xs={12} sx={{ height: 0 === widget.title.length ? '0px' : 'auto' }}>
                 <MetHeader3
                     style={{
                         fontWeight: 'lighter',
@@ -157,7 +157,7 @@ const VideoWidgetView = ({ widget }: VideoWidgetProps) => {
                         color: isDarkMode ? colors.surface.white : Palette.text.primary,
                     }}
                 >
-                    {videoWidget.title}
+                    {widget.title}
                 </MetHeader3>
             </Grid>
             <Grid item xs={12}>
@@ -186,7 +186,7 @@ const VideoWidgetView = ({ widget }: VideoWidgetProps) => {
                         url={videoWidget.video_url}
                         controls
                         onReady={(player) => {
-                            setVideoOverlayTitle(getVideoTitle(player, videoSource, videoWidget.title));
+                            setVideoOverlayTitle(getVideoTitle(player, videoSource, widget.title));
                         }}
                         onPlay={() => setShowOverlay(false)}
                         width="100%"

--- a/met-web/src/models/videoWidget.ts
+++ b/met-web/src/models/videoWidget.ts
@@ -3,6 +3,5 @@ export interface VideoWidget {
     widget_id: number;
     engagement_id: number;
     video_url: string;
-    title: string;
     description: string;
 }

--- a/met-web/src/services/widgetService/VideoService/index.tsx
+++ b/met-web/src/services/widgetService/VideoService/index.tsx
@@ -18,7 +18,6 @@ interface PostVideoRequest {
     widget_id: number;
     engagement_id: number;
     video_url: string;
-    title: string;
     description: string;
     location: WidgetLocation | null;
 }
@@ -35,7 +34,6 @@ export const postVideo = async (widget_id: number, data: PostVideoRequest): Prom
 
 interface PatchVideoRequest {
     video_url?: string;
-    title?: string;
     description?: string;
 }
 

--- a/met-web/tests/unit/components/factory.ts
+++ b/met-web/tests/unit/components/factory.ts
@@ -249,7 +249,6 @@ const mockVideo: VideoWidget = {
     id: 1,
     widget_id: 1,
     engagement_id: 1,
-    title: 'Video Title',
     video_url: 'https://youtube.url',
     description: 'Video description',
 };

--- a/met-web/tests/unit/components/widgets/VideoWidget.test.tsx
+++ b/met-web/tests/unit/components/widgets/VideoWidget.test.tsx
@@ -88,7 +88,6 @@ describe('Video Widget tests', () => {
         await waitFor(() => expect(screen.getByText('Select Widget')).toBeVisible());
         fireEvent.click(screen.getByTestId(`widget-drawer-option/${WidgetType.Video}`));
         await waitFor(() => {
-            expect(screen.getByText('Title (Optional)')).toBeVisible();
             expect(screen.getByText('Description (Optional)')).toBeVisible();
         });
     }
@@ -113,7 +112,6 @@ describe('Video Widget tests', () => {
         await addVideoWidget();
 
         expect(getWidgetsMock).toHaveBeenCalled();
-        expect(screen.getByText('Title (Optional)')).toBeVisible();
         expect(screen.getByText('Description (Optional)')).toBeVisible();
         expect(screen.getByText('Video Link')).toBeVisible();
     });


### PR DESCRIPTION
Issue #: https://citz-gdx.atlassian.net/browse/DESENG-692

**Description of changes:**
- Removed unneeded columns from db (title from widget_video table and associated translation column)
- Updated all other met_api and met_web logic to accomodate this
- Title is now pulled from widget table, not widget_video table

**User Guide update ticket (if applicable):**
N/A