### PR TITLE
DESENG-797: Update GitHub Actions workflows to use ubuntu-latest instead of 20.04

### DIFF
--- a/.github/workflows/analytics-api-cd.yml
+++ b/.github/workflows/analytics-api-cd.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   analytics-api-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
     environment:

--- a/.github/workflows/analytics-api-ci.yml
+++ b/.github/workflows/analytics-api-ci.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
 
@@ -24,7 +24,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -75,7 +75,7 @@ jobs:
 
       SQLALCHEMY_DATABASE_URI: "postgresql://postgres:postgres@localhost:5432/postgres"
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -121,7 +121,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   met-deployment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.environment }}
     steps:

--- a/.github/workflows/met-api-cd.yml
+++ b/.github/workflows/met-api-cd.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   met-api-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
     environment:

--- a/.github/workflows/met-api-ci.yml
+++ b/.github/workflows/met-api-ci.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
 
@@ -27,7 +27,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -82,7 +82,7 @@ jobs:
       USE_TEST_KEYCLOAK_DOCKER: "YES"
       SQLALCHEMY_DATABASE_URI: "postgresql://postgres:postgres@localhost:5432/postgres"
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -132,7 +132,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/met-cron-cd.yml
+++ b/.github/workflows/met-cron-cd.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   met-cron-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
     environment:

--- a/.github/workflows/met-cron-ci.yml
+++ b/.github/workflows/met-cron-ci.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
 
@@ -25,7 +25,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -51,7 +51,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/met-etl-cd.yml
+++ b/.github/workflows/met-etl-cd.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   met-etl-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
     environment:

--- a/.github/workflows/met-web-cd.yml
+++ b/.github/workflows/met-web-cd.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   met-web-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
     environment:

--- a/.github/workflows/met-web-ci.yml
+++ b/.github/workflows/met-web-ci.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
 
@@ -27,7 +27,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -51,7 +51,7 @@ jobs:
 
   testing:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/notify-api-cd.yml
+++ b/.github/workflows/notify-api-cd.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   notify-api-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
     environment:

--- a/.github/workflows/notify-api-ci.yml
+++ b/.github/workflows/notify-api-ci.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/met-public'
 
@@ -24,7 +24,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -50,7 +50,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,19 +1,26 @@
+## April 15, 2025
+
+- **Bugfix** Update GitHub Actions workflows to use ubuntu-latest instead of ubuntu-20.04
+  - This is to stay ahead of the deprecation of ubuntu-20.04 in GitHub Actions as of today's date
+
 ## October 2, 2024
 
 - **Feature** New Who is Listening widget front end [🎟️ DESENG-695](https://citz-gdx.atlassian.net/browse/DESENG-695)
-	- Implemented Figma design
-	- Added widget_listening table to db for widget instance data
-	- Added option to enter widget description text (below title, above contacts)
-	- Adjusted CSS to accomodate multiple viewports
-	- Added ARIA labels for accessibility
-	- Updated contact create/edit form
-	- Updated Who is Listening widget form
+
+  - Implemented Figma design
+  - Added widget_listening table to db for widget instance data
+  - Added option to enter widget description text (below title, above contacts)
+  - Adjusted CSS to accomodate multiple viewports
+  - Added ARIA labels for accessibility
+  - Updated contact create/edit form
+  - Updated Who is Listening widget form
 
 - **Feature** New Video Widget front end [🎟️ DESENG-692](https://citz-gdx.atlassian.net/browse/DESENG-692)
-	- Changed icon colour from yellow to white to accomodate company branding requests
+
+  - Changed icon colour from yellow to white to accomodate company branding requests
 
 - **Feature** New Map Widget front end [🎟️ DESENG-693](https://citz-gdx.atlassian.net/browse/DESENG-693)
-	- Adjusted viewport settings of expand map link to accomodate breakpoints of engagement view page
+  - Adjusted viewport settings of expand map link to accomodate breakpoints of engagement view page
 
 ## September 26, 2024
 
@@ -24,6 +31,7 @@
 ## September 25, 2024
 
 - **Feature** New Video Widget front end [🎟️ DESENG-692](https://citz-gdx.atlassian.net/browse/DESENG-692)
+
   - Removed unneeded tables from db
   - Updated all other met_api and met_web logic to accomodate this
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,6 @@
 ## April 15, 2025
 
-- **Bugfix** Update GitHub Actions workflows to use ubuntu-latest instead of ubuntu-20.04
+- **Chore** Update GitHub Actions workflows to use ubuntu-latest instead of ubuntu-20.04
   - This is to stay ahead of the deprecation of ubuntu-20.04 in GitHub Actions as of today's date
 
 ## October 2, 2024


### PR DESCRIPTION

Issue #: https://citz-gdx.atlassian.net/browse/DESENG-797

Related issue: https://github.com/actions/runner-images/issues/11101

**Description of changes:**
- **Chore** Update GitHub Actions workflows to use ubuntu-latest instead of ubuntu-20.04
  - This is to stay ahead of the deprecation of ubuntu-20.04 in GitHub Actions as of today's date

**User Guide update ticket (if applicable):**
N/A