### PR TITLE
DESENG-811: Add MET Cron deployment & config to MET API helm chart

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,13 @@
+## May 12, 2025
+
+- **Feature** Add MET Cron job to OpenShift [🎟️ DESENG-811](https://citz-gdx.atlassian.net/browse/DESENG-811)
+  - Added the met-cron deployment to the met-api helm chart.
+  - Removed an unneeded Service, as the Cron does not serve any traffic.
+  - Set up injection of HashiCorp Vault secrets to the Cron job
+  - Merged met-cron ConfigMap into the met-api ConfigMap, as they differed very little.
+  - Renamed config key "OFFSET_DAYS" to "CLOSING_SOON_EMAIL_ADVANCE_NOTICE_DAYS" to be more descriptive.
+  - Removed the old met-cron deployment YAML files.
+
 ## May 7, 2025
 
 - **Feature** Add Helm chart and templates for MET Web [🎟️ DESENG-811](https://citz-gdx.atlassian.net/browse/DESENG-811)
@@ -6,7 +16,7 @@
   - Removed several unused ConfigMap values
   - Removed JWT/OIDC related values in favor of requesting the data from the MET API (single source of truth).
     - Created an endpoint at `/api/oidc_config` to return the OIDC configuration for the MET API.
-  - Modified the Docker entrypoint to generate a config script from REACT*APP* environment variables at startup.
+  - Modified the Docker entrypoint to generate a config script from REACT_APP\_\* environment variables at startup.
     - The config script is then served alongside the app at runtime.
 - **Bugfix** Updated existing templates to set minReplicas and maxReplicas for the HPA (matching met-web) rather than trying to configure it on the Deployment, which has no effect.
 

--- a/met-cron/config.py
+++ b/met-cron/config.py
@@ -229,7 +229,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     MAIL_BATCH_SIZE = os.getenv('MAIL_BATCH_SIZE', 10)
 
     # config for offset days to send reminder emails
-    OFFSET_DAYS = os.getenv('OFFSET_DAYS', 2)
+    MAIL_ADVANCE_NOTICE_DAYS = os.getenv('CLOSING_SOON_EMAIL_ADVANCE_NOTICE_DAYS', 2)
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
     """Dev Config."""

--- a/met-cron/pre-hook-update-db.sh
+++ b/met-cron/pre-hook-update-db.sh
@@ -1,4 +1,0 @@
-#! /bin/sh
-# cd /opt/app-root
-#echo 'starting upgrade'
-#python3 manage.py db upgrade

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -170,9 +170,10 @@ oc project e903c2-prod
 helm upgrade --install met-web . --values values_prod.yaml
 ```
 
-**Deploy the `API` application**:
+**Deploy the `API` (and `cron`) applications**:
 
 > This deployment uses the helm chart located in the `openshift/api` folder.
+> This creates 2 deployments as the met-api and met-cron submodules are deployed together.
 > Use one of dev, test or prod and the corresponding values.yaml file to deploy the api application.
 
 ```bash
@@ -196,19 +197,6 @@ oc process -f ./notify-api.dc.yml \
  -p IMAGE_TAG=<dev/test/prod> \
  -p KC_DOMAIN=met-oidc-test.apps.gold.devops.gov.bc.ca \
  -p GC_NOTIFY_API_KEY=<GC_NOTIFY_API_KEY> \
- | oc create -f -
-```
-
-Deploy the cron job application:
-
-```bash
-oc process -f ./cron.dc.yml \
- -p ENV=<dev/test/prod> \
- -p IMAGE_TAG=<dev/test/prod> \
- -p KC_DOMAIN=met-oidc-test.apps.gold.devops.gov.bc.ca \
- -p SITE_URL=https://met-web-test.apps.gold.devops.gov.bc.ca \
- -p MET_ADMIN_CLIENT_SECRET=<SERVICE_ACCOUNT_SECRET> \
- -p NOTIFICATIONS_EMAIL_ENDPOINT=https://met-notify-api-test.apps.gold.devops.gov.bc.ca/api/v1/notifications/email \
  | oc create -f -
 ```
 

--- a/openshift/api/templates/configmap.yaml
+++ b/openshift/api/templates/configmap.yaml
@@ -8,13 +8,17 @@ metadata:
         app-group: met-app
 data:
     # MET configuration
-    FLASK_ENV: production
     CORS_ORIGINS: {{ .Values.site.url }}
     DEFAULT_TENANT_SHORT_NAME: {{ .Values.tenant.shortName }}
     ACCESS_REQUEST_EMAIL_TEMPLATE_ID: {{ .Values.email.templateID.accessRequest }}
     CORS_MAX_AGE: {{ .Values.cors.maxAge | quote }}
     CLOSED_ENGAGEMENT_REJECTED_EMAIL_TEMPLATE_ID: {{ .Values.email.templateID.closedEngagementRejected }}
+    CLOSEOUT_EMAIL_TEMPLATE_ID: {{ .Values.email.templateID.closeout }}
+    CLOSING_SOON_EMAIL_TEMPLATE_ID: {{ .Values.email.templateID.closingSoon }}
+    CLOSING_SOON_EMAIL_ADVANCE_NOTICE_DAYS: {{ .Values.email.closingSoonAdvanceNoticeDays | quote }}
+    EMAIL_ENVIRONMENT: {{ .Values.email.environment }}
     NOTIFICATIONS_EMAIL_ENDPOINT: {{ .Values.email.notificationsEndpoint }}
+    PUBLISH_EMAIL_TEMPLATE_ID: {{ .Values.email.templateID.publish }}
     REJECTED_EMAIL_TEMPLATE_ID: {{ .Values.email.templateID.rejected }}
     SEND_EMAIL_INTERNAL_ONLY: {{ .Values.email.sendInternalOnly | quote }}
     SITE_URL: https://{{ .Values.site.url }}/

--- a/openshift/api/templates/deploymentconfig-cron.yaml
+++ b/openshift/api/templates/deploymentconfig-cron.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: {{ .Values.app_cron.name }}
+  labels:
+    app: {{ .Values.app.name }}
+    app-group: met-app
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+        - {{ .Values.app_cron.name }}
+        from:
+          kind: ImageStreamTag
+          namespace: {{ .Values.image.namespace }}
+          name: "{{ .Values.app_cron.name }}:{{ .Values.image.tag }}"
+    - type: ConfigChange
+  replicas: {{ .Values.app_cron.deployment.replicas }}
+  test: false
+  selector:
+    app: {{ .Values.app_cron.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app_cron.name }}
+        app-group: met-app
+        environment: {{ .Values.environment }}
+      annotations:
+        vault.hashicorp.com/agent-inject: 'true'
+        vault.hashicorp.com/agent-init-first: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
+        vault.hashicorp.com/namespace: platform-services
+        vault.hashicorp.com/role: {{ .Values.vault.engine }}
+        vault.hashicorp.com/auth-path: auth/k8s-gold
+        vault.hashicorp.com/agent-inject-secret-email: {{ .Values.vault.engine }}{{ .Values.vault.path }}/email
+        # Iterate over the secret data and export each key-value pair as an environment variable
+        vault.hashicorp.com/agent-inject-template-email: |
+          {{`{{- with secret `}}"{{ .Values.vault.engine }}{{ .Values.vault.path }}/email"{{` }}
+          {{- range $k, $v := .Data.data }}
+          export {{ $k }}='{{ $v }}'
+          {{- end }}
+          {{- end }}`}}
+        vault.hashicorp.com/agent-inject-secret-met-jwt-oidc: {{ .Values.vault.engine }}{{ .Values.vault.path }}/jwt-oidc
+        vault.hashicorp.com/agent-inject-template-met-jwt-oidc: |
+          {{`{{- with secret `}}"{{ .Values.vault.engine }}{{ .Values.vault.path }}/jwt-oidc"{{` }}
+          {{- range $k, $v := .Data.data }}
+          export {{ $k }}='{{ $v }}'
+          {{- end }}
+          {{- end }}`}}
+        vault.hashicorp.com/agent-inject-secret-met-patroni: {{ .Values.vault.engine }}{{ .Values.vault.path }}/met-patroni
+        # Custom built URI for met-patroni by indexing into the secret data object
+        # All patroni logins are stored in the same secret, so we shouldn't inject them all
+        vault.hashicorp.com/agent-inject-template-met-patroni: |
+          {{`{{- with secret `}}"{{ .Values.vault.engine }}{{ .Values.vault.path }}/met-patroni"{{` }}
+          export SQLALCHEMY_DATABASE_URI='postgresql://{{ index .Data.data "met-username" }}:{{ index .Data.data "met-password" }}@{{ index .Data.data "hostname" }}:5432/{{ index .Data.data "met-app-db-name" }}'
+          {{- end }}`}}
+    spec:
+      serviceAccountName: {{ .Values.app.licenseplate }}-vault
+      containers:
+      - name: {{ .Values.app_cron.name }}
+        image: {{ .Values.image.repository }}/{{ .Values.app_cron.name }}:{{ .Values.image.tag }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          source /vault/secrets/email && \
+          source /vault/secrets/met-jwt-oidc && \
+          source /vault/secrets/met-patroni && \
+          bash /met-cron/docker-entrypoint.sh
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.app.name }}
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 750m
+            memory: 2Gi

--- a/openshift/api/values.yaml
+++ b/openshift/api/values.yaml
@@ -2,6 +2,11 @@ app:
   name: met-api
   licenseplate: 'e903c2'
 
+app_cron:
+  name: met-cron
+  deployment:
+    replicas: 1
+
 cors:
   maxAge: 7200
 
@@ -10,10 +15,15 @@ deployment:
   maxReplicas: 3
 
 email:
+  # How many days before an engagement closes to send the "closing soon" email
+  closingSoonAdvanceNoticeDays: 2
   templateID:
     accessRequest: '41afa792-4c75-425a-9ad9-c558561d6669'
     closedEngagementRejected: 'e942dea1-094e-4021-9aac-21a0ac1f240d'
+    closeout: 'b7ea041b-fc30-4ad3-acb2-82119dd4f95d'
+    closingSoon: '30344886-ea33-4ca2-83e1-e5ebe9c3457d'
     rejected: '8410c055-587b-4788-bd2f-b563562bcb2d'
+    publish: '7bf2ffcd-d69e-4c3f-9aa0-e8e89b491e92'
     submissionResponse: '07f0f037-5ccb-44c5-89c6-9fe86078323e'
     subscribe: '9cd4942b-8ac9-49ae-a869-c800c57a7472'
     verification: 'c4cc1633-321a-4400-8a22-272acecd836a'


### PR DESCRIPTION
Issue #: [🎟️ DESENG-811](https://citz-gdx.atlassian.net/browse/DESENG-811)

**Description of changes:**
- **Feature** Add MET Cron job to OpenShift
  - Added the met-cron deployment to the met-api helm chart.
  - Removed an unneeded Service, as the Cron does not serve any traffic.
  - Set up injection of HashiCorp Vault secrets to the Cron job
  - Merged met-cron ConfigMap into the met-api ConfigMap, as they differed very little.
  - Renamed config key "OFFSET_DAYS" to "CLOSING_SOON_EMAIL_ADVANCE_NOTICE_DAYS" to be more descriptive.
  - Removed the old met-cron deployment YAML files.

**User Guide update ticket (if applicable):** *N/A*