### PR TITLE
DESENG-677: Add required dependencies for met-etl

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 ## May 21, 2025
+
 - **Bugfix** Update SQLAlchemy library in MET ETL to match MET API [🎟️ DESENG-677](https://citz-gdx.atlassian.net/browse/DESENG-677)
+- **Bugfix** Add required dependencies for met-etl to requirements.txt [🎟️ DESENG-677](https://citz-gdx.atlassian.net/browse/DESENG-677)
+  - pin flask_restx to 1.3.0
 
 ## May 20, 2025
 

--- a/met-api/requirements.txt
+++ b/met-api/requirements.txt
@@ -31,7 +31,7 @@ six==1.16.0
 SQLAlchemy==1.4.52
 Werkzeug==3.0.3
 flask_mail==0.9.1
-flask_restx
+flask_restx==1.3.0
 secure==0.3.0
 flask-cors==3.0.10
 flask_jwt_oidc==0.3.0

--- a/met-etl/requirements.txt
+++ b/met-etl/requirements.txt
@@ -1,3 +1,11 @@
+flask==2.2.5
+flask-cors==3.0.10
+flask-restx==1.3.0
+flask-moment==1.0.6
+flask-jwt-oidc==0.3.0
+Werkzeug==3.0.3
+marshmallow==3.21.1
+marshmallow-sqlalchemy==1.0.0
 dagster==1.7.15
 dagit==1.7.15
 dagster-docker==0.23.15


### PR DESCRIPTION
Issue #: [🎟️ DESENG-677](https://citz-gdx.atlassian.net/browse/DESENG-677)

**Description of changes:**
- **Bugfix** Add required dependencies for met-etl to requirements.txt 
  - pin flask_restx to 1.3.0

**User Guide update ticket (if applicable):**