### PR TITLE
DESENG-837: Fix routing issue in engagement "old view"

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,11 @@
+## Jun 10, 2025
+
+- **Bugfix** Fix routing issue in engagement "old view" [🎟️ DESENG-837](https://citz-gdx.atlassian.net/browse/DESENG-837)
+  - Add correct loaders to the engagement "old view" route
+  - Update implementation of route loaders to use `useLoaderData` instead of `useRouteLoaderData`
+  - Update permission checks on the API side to allow public users to access engagement metadata
+    (accidentally broken in PR #2506 for DESENG-603)
+
 ## May 22, 2025
 
 - **Bugfix** Fix survey ID access in MET ETL [🎟️ DESENG-677](https://citz-gdx.atlassian.net/browse/DESENG-677)

--- a/met-api/src/met_api/resources/engagement_metadata.py
+++ b/met-api/src/met_api/resources/engagement_metadata.py
@@ -71,26 +71,16 @@ class EngagementMetadata(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
-    @API.doc(security='apikey')
     @API.marshal_list_with(metadata_return_model)
-    @_jwt.requires_auth
     def get(engagement_id):
         """Fetch engagement metadata entries by engagement id."""
-        authorization.check_auth(
-            one_of_roles=(
-                MembershipType.TEAM_MEMBER.name,
-                Role.VIEW_ENGAGEMENT.value
-            ),
-            engagement_id=engagement_id
-        )
         return metadata_service.get_by_engagement(engagement_id)
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
     @API.doc(security='apikey')
     @API.expect(metadata_create_model)
-    # type: ignore
-    @API.marshal_with(metadata_return_model, code=HTTPStatus.CREATED)
+    @API.marshal_with(metadata_return_model, code=HTTPStatus.CREATED) # type: ignore
     @_jwt.requires_auth
     def post(engagement_id: int):
         """Create a new metadata entry for an engagement."""

--- a/met-web/src/components/engagement/old-view/ActionContext.tsx
+++ b/met-web/src/components/engagement/old-view/ActionContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { useNavigate, useParams, useRouteLoaderData, useRevalidator } from 'react-router-dom';
+import { useNavigate, useParams, useLoaderData, useRevalidator } from 'react-router-dom';
 import { patchEngagement } from '../../../services/engagementService';
 import { createDefaultEngagement, Engagement } from '../../../models/engagement';
 import { useAppDispatch } from 'hooks';
@@ -74,11 +74,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element | JSX.Eleme
     const [isWidgetsLoading, setIsWidgetsLoading] = useState(true);
     const [content, setContent] = useState<EngagementContent[]>([]);
 
-    const {
-        engagement,
-        widgets,
-        content: contentPromise,
-    } = useRouteLoaderData('single-engagement') as EngagementLoaderData;
+    const { engagement, widgets, content: contentPromise } = useLoaderData() as EngagementLoaderData;
 
     // Load the engagement from the shared individual engagement loader and watch the engagement variable for any changes.
     useEffect(() => {
@@ -93,7 +89,7 @@ export const ActionProvider = ({ children }: { children: JSX.Element | JSX.Eleme
             setSavedEngagement(result);
             setEngagementLoading(false);
         });
-    }, [engagement]);
+    }, [engagement, engagementId, slug, navigate]);
 
     // Load the widgets from the shared individual engagement loader and watch the engagement variable for any changes.
     useEffect(() => {

--- a/met-web/src/config.ts
+++ b/met-web/src/config.ts
@@ -1,4 +1,3 @@
-import { hasKey } from 'utils';
 declare global {
     interface Window {
         _env_: {

--- a/met-web/src/routes/UnauthenticatedRoutes.tsx
+++ b/met-web/src/routes/UnauthenticatedRoutes.tsx
@@ -42,7 +42,7 @@ const UnauthenticatedRoutes = () => {
             <Route path="/engagements">
                 <Route path="create/form/:language" element={<RedirectLoginWrapper />} />
                 <Route path=":engagementId">
-                    <Route path="view/:language" element={<EngagementViewWrapper />} />
+                    <Route path="view/:language" loader={engagementLoader} element={<EngagementViewWrapper />} />
                     <Route path="comments/:dashboardType/:language" element={<EngagementCommentsWrapper />} />
                     <Route path="dashboard/:dashboardType/:language" element={<PublicDashboardWrapper />} />
                     <Route path="edit/:token/:language" loader={SurveyLoader} element={<EditSurveyWrapper />} />
@@ -56,7 +56,7 @@ const UnauthenticatedRoutes = () => {
                 <Route path="comments/:dashboardType/:language" element={<EngagementCommentsWrapper />} />
                 <Route path="edit/:token/:language" loader={SurveyLoader} element={<EditSurveyWrapper />} />
                 <Route path="cacform/:widgetId/:language" element={<FormCACWrapper />} />
-                <Route path=":language" element={<EngagementViewWrapper />} />
+                <Route path=":language" loader={engagementLoader} element={<EngagementViewWrapper />} />
             </Route>
             <Route path="/not-available" element={<NotAvailable />} />
             <Route path="/not-found" element={<NotFound />} />


### PR DESCRIPTION
Issue #: [🎟️ DESENG-837](https://citz-gdx.atlassian.net/browse/DESENG-837)

**Description of changes:**
- **Bugfix** Fix routing issue in engagement "old view"
  - Add correct loaders to the engagement "old view" route
  - Update implementation of route loaders to use `useLoaderData` instead of `useRouteLoaderData`
  - Update permission checks on the API side to allow public users to access engagement metadata
    (accidentally broken in PR #2506 for DESENG-603)

**User Guide update ticket (if applicable):**