### PR TITLE
DESENG-812: Add automatic updates for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## Jul 9, 2025
+
+- **Feature** Add Dependabot alerts for Github Actions [🎟️ DESENG-812](https://citz-gdx.atlassian.net/browse/DESENG-812)
+  - Added a Dependabot configuration file to automatically check for updates to Github Actions runner images and workflows.
+    If any updates are found, a pull request will be created to update the versions referenced in the workflows.
+
 ## Jun 25, 2025
 
 - **Task** DeploymentConfig -> Deployment conversion for previously undeployed DeploymentConfig yamls.


### PR DESCRIPTION
Issue #: [🎟️ DESENG-812](https://citz-gdx.atlassian.net/browse/DESENG-812)

**Description of changes:**
- **Feature**: Add Dependabot alerts for Github Actions 
  - Added a Dependabot configuration file to automatically check for updates to Github Actions runner images and workflows.
    If any updates are found, a pull request will be created to update the versions referenced in the workflows.

**User Guide update ticket (if applicable):** _N/A_