### PR TITLE
Workflows: switch 'omega-project' branch to 'main' (and restrict environment inputs)

### DIFF
--- a/.github/workflows/analytics-api-cd.yml
+++ b/.github/workflows/analytics-api-cd.yml
@@ -3,15 +3,20 @@ name: MET ANALYTICS API DEV CD
 on:
   push:
     branches:
-      - omega-project
+      - main
     paths:
       - "analytics-api/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment"
         required: true
         default: "dev"
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/analytics-api-ci.yml
+++ b/.github/workflows/analytics-api-ci.yml
@@ -2,8 +2,6 @@ name: MET ANALYTICS API CI
 
 on:
   pull_request:
-    branches:
-      - omega-project
     paths:
       - "analytics-api/**"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["omega-project"]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["omega-project"]
+    branches: ["main"]
   schedule:
     - cron: "42 5 * * 5"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (test/prod)"
+        description: "Environment"
         required: true
         default: "test"
+        type: choice
+        options:
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/met-api-cd.yml
+++ b/.github/workflows/met-api-cd.yml
@@ -3,15 +3,20 @@ name: MET API CD
 on:
   push:
     branches:
-      - omega-project
+      - main
     paths:
       - "met-api/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment"
         required: true
         default: "dev"
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/met-api-ci.yml
+++ b/.github/workflows/met-api-ci.yml
@@ -2,13 +2,11 @@ name: MET API CI
 
 on:
   pull_request:
-    branches:
-      - omega-project
     paths:
       - "met-api/**"
   push:
     branches:
-      - omega-project
+      - main
 
 defaults:
   run:

--- a/.github/workflows/met-cron-cd.yml
+++ b/.github/workflows/met-cron-cd.yml
@@ -3,16 +3,21 @@ name: MET CRON DEV CD
 on:
   push:
     branches:
-      - omega-project
+      - main
     paths:
       - "met-cron/**"
       - "met-api/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment"
         required: true
         default: "dev"
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/met-cron-ci.yml
+++ b/.github/workflows/met-cron-ci.yml
@@ -3,7 +3,7 @@ name: MET CRON JOB CI
 on:
   pull_request:
     branches:
-      - omega-project
+      - main
     paths:
       - "met-cron/**"
       - "met-api/**"

--- a/.github/workflows/met-etl-cd.yml
+++ b/.github/workflows/met-etl-cd.yml
@@ -3,16 +3,21 @@ name: MET ETL CD
 on:
   push:
     branches:
-      - omega-project
+      - main
     paths:
       - "met-etl/**"
       - "met-api/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment"
         required: true
         default: "dev"
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/met-web-cd.yml
+++ b/.github/workflows/met-web-cd.yml
@@ -3,15 +3,20 @@ name: MET WEB DEV CD
 on:
   push:
     branches:
-      - omega-project
+      - main
     paths:
       - "met-web/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment"
         required: true
         default: "dev"
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/met-web-ci.yml
+++ b/.github/workflows/met-web-ci.yml
@@ -6,7 +6,7 @@ on:
       - "met-web/**"
   push:
     branches:
-      - omega-project
+      - main
 
 defaults:
   run:

--- a/.github/workflows/notify-api-cd.yml
+++ b/.github/workflows/notify-api-cd.yml
@@ -3,15 +3,20 @@ name: MET NOTIFY API DEV CD
 on:
   push:
     branches:
-      - omega-project
+      - main
     paths:
       - "notify-api/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment"
         required: true
         default: "dev"
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
 
 defaults:
   run:

--- a/.github/workflows/notify-api-ci.yml
+++ b/.github/workflows/notify-api-ci.yml
@@ -2,8 +2,6 @@ name: MET NOTIFY API CI
 
 on:
   pull_request:
-    branches:
-      - omega-project
     paths:
       - "notify-api/**"
 


### PR DESCRIPTION
**Description of changes:**
- Prepare Github Actions to be switched back to the main branch for CI/CD
- Also lift unnecessary restrictions on branches - CI should run on every pull request, not just ones to main
- Extra: Restrict workflow inputs to valid options in CD runs