### PR TITLE
Hotfix: add pytz to api "prod" requirements

### DIFF
--- a/analytics-api/requirements.txt
+++ b/analytics-api/requirements.txt
@@ -42,7 +42,7 @@ pyasn1==0.6.3
 pyrsistent==0.19.3
 python-dotenv==1.0.1
 python-jose==3.5.0
-pytz==2024.1
+pytz==2026.1.post1
 requests==2.33.0
 rsa==4.9
 secure==0.3.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,7 @@ pyrsistent==0.17.3
 python-dateutil==2.8.2
 python-dotenv==1.0.1
 python-editor==1.0.4
-pytz==2024.1
+pytz==2026.1.post1
 PyYAML==6.0.1
 six==1.16.0
 SQLAlchemy==1.4.52

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -34,3 +34,4 @@ requests
 anytree
 geopandas
 awesome-slugify==1.6.5
+pytz==2026.1.post1

--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -13,6 +13,6 @@ SQLAlchemy-Utils==0.38.3
 SQLAlchemy==1.4.52
 packaging==25.0
 python-dotenv==0.21.0
-pytz==2022.5
+pytz==2026.1.post1
 -e git+https://github.com/bcgov/dep-public.git#egg=api&subdirectory=api
 -e git+https://github.com/bcgov/dep-public.git#egg=analytics-api&subdirectory=analytics-api

--- a/etl/src/etl_project/services/repo.py
+++ b/etl/src/etl_project/services/repo.py
@@ -15,9 +15,9 @@ for candidate in (PROJECT_ROOT, LEGACY_ROOT):
         if candidate_str not in sys.path:
             sys.path.insert(0, candidate_str)
 
-from etl_project.services.jobs.engagement_data_ingestion import engagement_data_ingestion  # noqa: E402
+from etl_project.services.jobs.engagement_data_ingestion import engagement_data_ingestion  # noqa: E402, E501
 from etl_project.services.jobs.test_db import job_sample_db_test  # noqa: E402
-from etl_project.services.jobs.cleanup_old_logs import cleanup_old_logs, vacuum_dagster_db  # noqa: E402
+from etl_project.services.jobs.cleanup_old_logs import cleanup_old_logs, vacuum_dagster_db  # noqa: E402, E501
 from etl_project.services.schedules.engagement_data_ingestion_schedule import (  # noqa: E402
     engagement_data_ingestion_schedule,
 )

--- a/notify-api/requirements.txt
+++ b/notify-api/requirements.txt
@@ -25,7 +25,7 @@ pyrsistent==0.17.3
 python-dateutil==2.8.2
 python-dotenv==1.0.1
 python-editor==1.0.4
-pytz==2024.1
+pytz==2026.1.post1
 PyYAML==6.0.1
 six==1.16.0
 SQLAlchemy==1.4.52


### PR DESCRIPTION
Issue #: N/A

**Description of changes:**
Hotfix an issue in `cron` where `pytz` was not being installed, causing crashes like the below.
This is because in `api/setup.py`, only `prod.txt` is installed as requirements for the `api` package.
Also upgrade `pytz` to 2026.1.post1 globally for consistency (BC has a new time zone!)

<img width="1071" height="722" alt="image" src="https://github.com/user-attachments/assets/2f4b09c7-3688-4d12-8571-5052a40d6b9e" />

