### PR TITLE
Add constant ROUTES list, route generator function

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## April 13, 2026
+
+- **Feature** Add constant ROUTES list in routes/routes.ts [🎟️ DEP-254](https://citz-gdx.atlassian.net/browse/DEP-254)
+  - Created a new file `routes/routes.ts` that exports a constant `ROUTES` object containing all the route paths used in the application, organized by section (e.g. ENGAGEMENTS, SURVEYS, USERS, etc.).
+  - Also created a type-safe `getRoute` function based on generatePath from react-router that takes a route key and optional parameters, and returns the corresponding route path with parameters interpolated. This centralizes route management and makes it easier to update routes in the future without having to search through the entire codebase.
+
 ## April 9, 2026
 
 - **Chore** Track CORS config files in-repository and update docs [🎟️ DEP-220](https://citz-gdx.atlassian.net/browse/DEP-220)

--- a/web/src/routes/routes.ts
+++ b/web/src/routes/routes.ts
@@ -1,0 +1,124 @@
+import { generatePath } from 'react-router';
+
+export const ROUTES = {
+    // Public routes
+    PUBLIC_LANDING: '/',
+    PUBLIC_ENGAGEMENT_BY_SLUG: '/:slug/:language',
+    PUBLIC_DASHBOARD_BY_SLUG: '/:slug/dashboard/:dashboardType/:language',
+    PUBLIC_COMMENTS_BY_SLUG: '/:slug/comments/:dashboardType/:language',
+    PUBLIC_SURVEY_EDIT_BY_SLUG: '/:slug/edit/:token/:language',
+    PUBLIC_ENGAGEMENT_CREATE_FORM: '/engagements/create/form/:language',
+    PUBLIC_ENGAGEMENT_VIEW: '/engagements/:engagementId/view/:language',
+    PUBLIC_ENGAGEMENT_VIEW_NO_LANG: '/engagements/:engagementId/view',
+    PUBLIC_ENGAGEMENT_COMMENTS: '/engagements/:engagementId/comments/:dashboardType/:language',
+    PUBLIC_ENGAGEMENT_COMMENTS_NO_LANG: '/engagements/:engagementId/comments/:dashboardType',
+    PUBLIC_ENGAGEMENT_DASHBOARD: '/engagements/:engagementId/dashboard/:dashboardType/:language',
+    PUBLIC_ENGAGEMENT_DASHBOARD_NO_LANG: '/engagements/:engagementId/dashboard/:dashboardType',
+    PUBLIC_ENGAGEMENT_EDIT: '/engagements/:engagementId/edit/:token/:language',
+    PUBLIC_MANAGE_SUBSCRIPTION: '/engagements/:engagementId/:subscriptionStatus/:scriptionKey/:language',
+    PUBLIC_ENGAGEMENT_FORM: '/engagements/:engagementId/form/:language',
+    PUBLIC_SURVEY_SUBMIT: '/surveys/submit/:surveyId/:token/:language',
+    PUBLIC_NOT_AVAILABLE: '/not-available',
+    PUBLIC_NOT_FOUND: '/not-found',
+
+    // Admin routes
+    ADMIN_ENGAGEMENT_PREVIEW: '/engagements/:engagementId/preview',
+    HOME: '/home',
+    SURVEYS: '/surveys',
+    SURVEY_CREATE: '/surveys/create',
+    SURVEY_BUILD: '/surveys/:surveyId/build',
+    SURVEY_REPORT: '/surveys/:surveyId/report',
+    SURVEY_ADMIN_SUBMIT: '/surveys/:surveyId/submit',
+    SURVEY_COMMENTS: '/surveys/:surveyId/comments',
+    SURVEY_COMMENTS_ALL: '/surveys/:surveyId/comments/all',
+    SURVEY_SUBMISSION_REVIEW: '/surveys/:surveyId/submissions/:submissionId/review',
+    ENGAGEMENTS: '/engagements',
+    ENGAGEMENT: '/engagements/:engagementId',
+    ENGAGEMENT_SEARCH: '/engagements/search',
+    ENGAGEMENT_FORM: '/engagements/:engagementId/form',
+    ENGAGEMENT_CREATE: '/engagements/create',
+    ENGAGEMENT_CREATE_WIZARD: '/engagements/create/wizard',
+    ENGAGEMENT_DETAILS: '/engagements/:engagementId/details',
+    ENGAGEMENT_DETAILS_CONFIG_EDIT: '/engagements/:engagementId/details/config/edit',
+    ENGAGEMENT_DETAILS_CONFIG: '/engagements/:engagementId/details/config',
+    ENGAGEMENT_DETAILS_AUTHORING: '/engagements/:engagementId/details/authoring',
+    ENGAGEMENT_DETAILS_ACTIVITY: '/engagements/:engagementId/details/activity',
+    ENGAGEMENT_DETAILS_RESULTS: '/engagements/:engagementId/details/results',
+    ENGAGEMENT_DETAILS_PUBLISH: '/engagements/:engagementId/details/publish',
+    AUTHORING_BANNER: '/engagements/:engagementId/details/authoring/banner',
+    AUTHORING_SUMMARY: '/engagements/:engagementId/details/authoring/summary',
+    AUTHORING_DETAILS: '/engagements/:engagementId/details/authoring/details',
+    AUTHORING_FEEDBACK: '/engagements/:engagementId/details/authoring/feedback',
+    AUTHORING_RESULTS: '/engagements/:engagementId/details/authoring/results',
+    AUTHORING_SUBSCRIBE: '/engagements/:engagementId/details/authoring/subscribe',
+    AUTHORING_MORE: '/engagements/:engagementId/details/authoring/more',
+    AUTHORING_PAGE: '/engagements/:engagementId/details/authoring/:page',
+    ENGAGEMENT_COMMENTS_DASHBOARD: '/engagements/comments/:dashboardType',
+    ENGAGEMENT_DASHBOARD: '/engagements/dashboard/:dashboardType',
+    SLUG_COMMENTS_DASHBOARD: '/:slug/comments/:dashboardType',
+    SLUG_DASHBOARD: '/:slug/dashboard/:dashboardType',
+    METADATA_MANAGEMENT: '/metadatamanagement',
+    LANGUAGES: '/languages',
+    TENANT_ADMIN: '/tenantadmin',
+    TENANT_ADMIN_CREATE: '/tenantadmin/create',
+    TENANT_ADMIN_DETAIL: '/tenantadmin/:tenantShortName/detail',
+    TENANT_ADMIN_EDIT: '/tenantadmin/:tenantShortName/edit',
+    FEEDBACK: '/feedback',
+    CALENDAR: '/calendar',
+    REPORTING: '/reporting',
+    USER_MANAGEMENT: '/usermanagement',
+    USER_MANAGEMENT_SEARCH: '/usermanagement/search',
+    USER_DETAILS: '/usermanagement/:userId/details',
+    UNAUTHORIZED: '/unauthorized',
+    ADMIN_NOT_FOUND: '/not-found',
+} as const;
+
+// A key of ROUTES, e.g. 'HOME' or 'SURVEY_BUILD'.
+type RouteKey = keyof typeof ROUTES;
+
+/**
+ * Extract param names from a route pattern.
+ * '/manage/surveys/:surveyId/build' => 'surveyId'
+ * '/manage/engagements/:engagementId/details/:section' => 'engagementId' | 'section'
+ */
+type ExtractRouteParams<T extends string> = T extends `${string}:${infer Param}/${infer Rest}`
+    ?
+          | (Param extends `${infer CleanParam}?`
+                ? CleanParam
+                : Param extends `${infer CleanParam}*`
+                  ? CleanParam
+                  : Param)
+          | ExtractRouteParams<`/${Rest}`>
+    : T extends `${string}:${infer Param}`
+      ? Param extends `${infer CleanParam}?`
+          ? CleanParam
+          : Param extends `${infer CleanParam}*`
+            ? CleanParam
+            : Param
+      : never;
+
+/**
+ * Get the params object type for a route.
+ * If no params, returns {}; otherwise returns record of required params.
+ */
+type RouteParams<Path extends string> =
+    ExtractRouteParams<Path> extends never ? {} : { [P in ExtractRouteParams<Path>]: string | number };
+
+/**
+ * Type-safe route path generator. (wraps react-router's generatePath)
+ * Automatically extracts required params from the route pattern.
+ *
+ * @example
+ * getPath(ROUTES.HOME)  // '/home'
+ * getPath(ROUTES.ENGAGEMENT_DETAILS, {'enagementId': '123' }) // '/engagements/123/details/authoring'
+ * getPath(ROUTES.HOME, { surveyId: '123' })  // ✗ TS error: HOME has no surveyId param
+ * @see https://reactrouter.com/api/utils/generatePath
+ */
+export function getPath<Path extends (typeof ROUTES)[RouteKey]>(
+    route: Path,
+    ...params: ExtractRouteParams<Path> extends never ? [] : [params: RouteParams<Path>]
+): string {
+    return generatePath(route as string, params[0] as { [key: string]: string | null } | undefined);
+}
+
+export type { RouteKey, RouteParams };

--- a/web/src/routes/routes.ts
+++ b/web/src/routes/routes.ts
@@ -102,7 +102,9 @@ type ExtractRouteParams<T extends string> = T extends `${string}:${infer Param}/
  * If no params, returns {}; otherwise returns record of required params.
  */
 type RouteParams<Path extends string> =
-    ExtractRouteParams<Path> extends never ? {} : { [P in ExtractRouteParams<Path>]: string | number };
+    ExtractRouteParams<Path> extends never
+        ? Record<string, never>
+        : { [P in ExtractRouteParams<Path>]: string | number };
 
 /**
  * Type-safe route path generator. (wraps react-router's generatePath)

--- a/web/tests/unit/components/routes/routes.test.ts
+++ b/web/tests/unit/components/routes/routes.test.ts
@@ -27,7 +27,9 @@ describe('routes/getPath', () => {
 });
 
 // Compile-time type checks.
-// These are intentionally not runtime assertions.
+// These are intentionally not runtime assertions -
+// they will cause TypeScript compilation errors if the types are not correct,
+// which is the main point of these tests.
 const typeSafetyChecks = () => {
     getPath(ROUTES.SURVEY_BUILD, { surveyId: '1' });
     getPath(ROUTES.HOME);
@@ -41,5 +43,3 @@ const typeSafetyChecks = () => {
     // @ts-expect-error - USER_DETAILS requires userId.
     getPath(ROUTES.USER_DETAILS, {});
 };
-
-void typeSafetyChecks;

--- a/web/tests/unit/components/routes/routes.test.ts
+++ b/web/tests/unit/components/routes/routes.test.ts
@@ -1,0 +1,45 @@
+import { ROUTES, getPath } from 'routes/routes';
+
+describe('routes/getPath', () => {
+    test('returns static route without params', () => {
+        expect(getPath(ROUTES.HOME)).toEqual('/home');
+        expect(getPath(ROUTES.PUBLIC_LANDING)).toEqual('/');
+    });
+
+    test('interpolates route params', () => {
+        expect(getPath(ROUTES.SURVEY_BUILD, { surveyId: '123' })).toEqual('/surveys/123/build');
+        expect(getPath(ROUTES.USER_DETAILS, { userId: 42 })).toEqual('/usermanagement/42/details');
+        expect(getPath(ROUTES.PUBLIC_ENGAGEMENT_BY_SLUG, { slug: 'my-engagement', language: 'en' })).toEqual(
+            '/my-engagement/en',
+        );
+    });
+
+    test('supports multi-param interpolation', () => {
+        expect(
+            getPath(ROUTES.PUBLIC_MANAGE_SUBSCRIPTION, {
+                engagementId: '88',
+                subscriptionStatus: 'unsubscribe',
+                scriptionKey: 'abc123',
+                language: 'fr',
+            }),
+        ).toEqual('/engagements/88/unsubscribe/abc123/fr');
+    });
+});
+
+// Compile-time type checks.
+// These are intentionally not runtime assertions.
+const typeSafetyChecks = () => {
+    getPath(ROUTES.SURVEY_BUILD, { surveyId: '1' });
+    getPath(ROUTES.HOME);
+
+    // @ts-expect-error - surveyId is required for SURVEY_BUILD.
+    getPath(ROUTES.SURVEY_BUILD);
+
+    // @ts-expect-error - HOME does not accept params.
+    getPath(ROUTES.HOME, { surveyId: '1' });
+
+    // @ts-expect-error - USER_DETAILS requires userId.
+    getPath(ROUTES.USER_DETAILS, {});
+};
+
+void typeSafetyChecks;


### PR DESCRIPTION
Issue #: [🎟️ DEP-254](https://citz-gdx.atlassian.net/browse/DEP-254)

**Description of changes:**
- **Feature** Add constant ROUTES list in routes/routes.ts
  - Created a new file `routes/routes.ts` that exports a constant `ROUTES` object containing all the route paths used in the application, organized by section (e.g. ENGAGEMENTS, SURVEYS, USERS, etc.).
  - Also created a type-safe `getRoute` function based on generatePath from react-router that takes a route key and optional parameters, and returns the corresponding route path with parameters interpolated. This centralizes route management and makes it easier to update routes in the future without having to search through the entire codebase.

**User Guide update ticket (if applicable):**

- - [ ] Yes, a user guide update ticket has been created. _(Link to ticket)_
- - [x] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
