### PR TITLE
Always show InternalHeader when logged in, add admin/public view switcher

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,10 @@
+## April 16, 2026
+
+- **Feature** Always show InternalHeader when logged in, add admin/public view switcher [🎟️ DEP-257](https://citz-gdx.atlassian.net/browse/DEP-257)
+  - Updated the InternalHeader component to always be visible when a user is logged in, regardless of whether they are on a public or admin page. This allows for a consistent navigation experience and provides access to the header's features across the entire application.
+  - Added a new view switcher component to the InternalHeader that allows users to easily switch between the admin and public views of the application. This component is visible when a user is logged in and provides quick access to both views without needing to log out or manually navigate to different URLs.
+  - Routes now define their own "equivalents" on the opposite side (public vs admin) to allow the view switcher to direct users to the corresponding page in the other view. For example, if a user is on the admin engagement details page, the view switcher will take them to the public engagement details page for the same engagement, and vice versa. This is achieved using `handle` from react-router route definitions to specify the equivalent route key for the opposite view.
+
 ## April 15, 2026
 
 - **Feature** Merge routers, move authenticated routes to /manage and add AdminAuthGuard [🎟️ DEP-255](https://citz-gdx.atlassian.net/browse/DEP-255)

--- a/web/src/components/appLayouts/PublicLayout.tsx
+++ b/web/src/components/appLayouts/PublicLayout.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import '@bcgov/design-tokens/css-prefixed/variables.css'; // Variables will be within scope within PublicLayout and its children
 import { Outlet } from 'react-router';
 import PublicHeader from '../layout/Header/PublicHeader';
+import InternalHeader from '../layout/Header/InternalHeader';
 import { Notification } from 'components/common/notification';
 import PageViewTracker from 'routes/PageViewTracker';
 import { NotificationModal } from 'components/common/modal';
@@ -11,8 +12,11 @@ import DocumentTitle from 'DocumentTitle';
 import ScrollToTop from 'components/scrollToTop';
 import { Box } from '@mui/material';
 import { colors } from 'components/common';
+import { AuthKeyCloakContext } from 'components/auth/AuthKeycloakContext';
 
 export const PublicLayout = () => {
+    const { isAuthenticated } = useContext(AuthKeyCloakContext);
+
     return (
         <Box
             sx={{
@@ -35,9 +39,11 @@ export const PublicLayout = () => {
                 <PageViewTracker />
                 <Notification />
                 <NotificationModal />
-                <PublicHeader />
+                {isAuthenticated ? <InternalHeader showSideNav={false} /> : <PublicHeader />}
                 <ScrollToTop />
-                <Outlet />
+                <Box component="main" sx={isAuthenticated ? { marginTop: { xs: '3.5em', md: '6.5em' } } : undefined}>
+                    <Outlet />
+                </Box>
                 <FeedbackModal />
                 <Footer />
             </Box>

--- a/web/src/components/layout/Header/InternalHeader.tsx
+++ b/web/src/components/layout/Header/InternalHeader.tsx
@@ -38,11 +38,10 @@ import { USER_ROLES } from 'services/userService/constants';
 import AuthoringSideNav from '../../engagement/admin/create/authoring/AuthoringSideNav';
 import { getAuthoringRoutes } from '../../engagement/admin/create/authoring/AuthoringNavElements';
 import { ROUTES, getPath } from 'routes/routes';
-import { RouterLinkRenderer } from 'components/common/Navigation/Link';
+import { RouterLinkRenderer, Link } from 'components/common/Navigation/Link';
 import { AppConfig } from 'config';
 import { ViewSwitcherHandle } from 'routes/ViewSwitcherHandle';
 import { getMyTenants } from 'services/tenantService';
-import { Link } from 'components/common/Navigation/Link';
 
 let fallbackMyTenantsPromise: Promise<Tenant[]> | null = null;
 

--- a/web/src/components/layout/Header/InternalHeader.tsx
+++ b/web/src/components/layout/Header/InternalHeader.tsx
@@ -10,7 +10,6 @@ import {
     Grid2 as Grid,
     Grow,
     LinearProgress,
-    Link,
     MenuList,
     MenuItem,
     Theme,
@@ -23,9 +22,10 @@ import { ReactComponent as BCLogo } from 'assets/images/BritishColumbiaLogoDark.
 import { useAppSelector } from '../../../hooks';
 import { BodyText } from 'components/common/Typography/Body';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBars, faChevronDown, faClose, faSignOut } from '@fortawesome/pro-regular-svg-icons';
+import { faBars, faChevronDown, faClose, faSignOut, faIdCardClip } from '@fortawesome/pro-regular-svg-icons';
+import { faUserSecret } from '@fortawesome/pro-solid-svg-icons/faUserSecret';
 import UserService from 'services/userService';
-import { Await, useRouteLoaderData, useParams, useNavigation } from 'react-router';
+import { Await, useRouteLoaderData, useParams, useNavigation, useMatches, useLocation } from 'react-router';
 import { Tenant } from 'models/tenant';
 import { When, If, Else, Then } from 'react-if';
 import { Button } from 'components/common/Input/Button';
@@ -39,14 +39,27 @@ import AuthoringSideNav from '../../engagement/admin/create/authoring/AuthoringS
 import { getAuthoringRoutes } from '../../engagement/admin/create/authoring/AuthoringNavElements';
 import { ROUTES, getPath } from 'routes/routes';
 import { RouterLinkRenderer } from 'components/common/Navigation/Link';
+import { AppConfig } from 'config';
+import { ViewSwitcherHandle } from 'routes/ViewSwitcherHandle';
+import { getMyTenants } from 'services/tenantService';
+import { Link } from 'components/common/Navigation/Link';
 
-const InternalHeader = () => {
+let fallbackMyTenantsPromise: Promise<Tenant[]> | null = null;
+
+const getFallbackMyTenants = (): Promise<Tenant[]> => {
+    if (!fallbackMyTenantsPromise) {
+        fallbackMyTenantsPromise = getMyTenants().catch(() => [] as Tenant[]);
+    }
+    return fallbackMyTenantsPromise;
+};
+
+const InternalHeader = ({ showSideNav = true }: { showSideNav?: boolean }) => {
     const isMediumScreenOrLarger = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
     const isMobileScreen = !useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
     const [sideNavOpen, setSideNavOpen] = useState(false);
     const [secondaryMenuOpen, setSecondaryMenuOpen] = useState(false);
     const user = useAppSelector((state) => state.user);
-    const canNavigate = user.roles.length !== 0; // If user has no roles in this tenant, don't show the side nav
+    const canNavigate = showSideNav && user.roles.length !== 0; // If user has no roles or side nav is disabled, don't show the side nav
     const [tenantDrawerOpen, setTenantDrawerOpen] = useState(false);
 
     const handleTenantDrawerOpen = (isOpen: boolean) => {
@@ -77,7 +90,10 @@ const InternalHeader = () => {
         }
     });
 
-    const { myTenants } = useRouteLoaderData('authenticated-root') as AuthenticatedRootLoaderData;
+    const authenticatedRootLoaderData = useRouteLoaderData('authenticated-root') as
+        | AuthenticatedRootLoaderData
+        | undefined;
+    const myTenants = authenticatedRootLoaderData?.myTenants ?? getFallbackMyTenants();
 
     const sidePadding = { xs: '0 1em', md: '0 1.5em 0 2em', lg: '0 3em 0 2em' };
     const navigation = useNavigation();
@@ -475,6 +491,54 @@ const TenantButtonContent = ({
 
 const UserMenu = () => {
     const userGreeting = useRef<HTMLDivElement>(null);
+    const matches = useMatches();
+    const location = useLocation();
+    const currentLanguageId = useAppSelector((state) => state.language.id) || AppConfig.language.defaultLanguageId;
+
+    const [switchTarget, setSwitchTarget] = useState<{ label: string; href: string } | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const isAdminPath = location.pathname === '/manage' || location.pathname.startsWith('/manage/');
+        const defaultTarget = isAdminPath
+            ? { label: 'View Public Page', href: getPath(ROUTES.PUBLIC_LANDING) }
+            : { label: 'View Admin Page', href: getPath(ROUTES.HOME) };
+
+        const setSwitchTargetIfChanged = (nextTarget: { label: string; href: string } | null) => {
+            setSwitchTarget((currentTarget) => {
+                if (currentTarget?.href === nextTarget?.href && currentTarget?.label === nextTarget?.label) {
+                    return currentTarget;
+                }
+                return nextTarget;
+            });
+        };
+
+        const compute = async () => {
+            // Find the deepest route match with a viewSwitcher handler
+            for (let i = matches.length - 1; i >= 0; i--) {
+                const match = matches[i];
+                const viewSwitcher = (match.handle as { viewSwitcher?: ViewSwitcherHandle })?.viewSwitcher;
+
+                if (viewSwitcher) {
+                    try {
+                        const target = await viewSwitcher(match.data, match.params, currentLanguageId);
+                        if (!cancelled) setSwitchTargetIfChanged(target ?? defaultTarget);
+                    } catch {
+                        if (!cancelled) setSwitchTargetIfChanged(defaultTarget);
+                    }
+                    return;
+                }
+            }
+
+            // No viewSwitcher handler found
+            if (!cancelled) setSwitchTargetIfChanged(defaultTarget);
+        };
+
+        compute();
+        return () => {
+            cancelled = true;
+        };
+    }, [matches, currentLanguageId, location.pathname]);
 
     return (
         <DropdownMenu
@@ -494,11 +558,28 @@ const UserMenu = () => {
                 },
             }}
         >
+            {switchTarget && (
+                <MenuItem
+                    component={RouterLinkRenderer}
+                    href={switchTarget.href}
+                    sx={{
+                        width: '100%',
+                        paddingLeft: 2,
+                        paddingRight: 2,
+                        transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+                    }}
+                >
+                    <FontAwesomeIcon
+                        style={{ marginRight: '0.5rem' }}
+                        icon={location.pathname.startsWith('/manage') ? faUserSecret : faIdCardClip}
+                    />
+                    {switchTarget.label}
+                </MenuItem>
+            )}
             <MenuItem
-                component={ButtonBase}
-                onClick={() => {
-                    UserService.doLogout();
-                }}
+                component={Link}
+                role="button"
+                onClick={UserService.doLogout}
                 sx={{
                     width: '100%',
                     paddingLeft: 2,

--- a/web/src/components/layout/SideNav/SideNav.tsx
+++ b/web/src/components/layout/SideNav/SideNav.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import {
     Link,
     ListItemButton,
@@ -13,7 +13,7 @@ import {
     Avatar,
     ThemeProvider,
 } from '@mui/material';
-import { useLocation } from 'react-router';
+import { useLocation, useMatches } from 'react-router';
 import { Routes, Route } from './SideNavElements';
 import { AdminDarkTheme, Palette, colors, ZIndex } from '../../../styles/Theme';
 import { SideNavProps, DrawerBoxProps } from './types';
@@ -21,13 +21,18 @@ import { When } from 'react-if';
 import { useAppSelector } from 'hooks';
 import UserGuideNav from './UserGuideNav';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faIdCardClip } from '@fortawesome/pro-regular-svg-icons';
 import { faLinkSlash } from '@fortawesome/pro-regular-svg-icons/faLinkSlash';
 import { faCheck } from '@fortawesome/pro-solid-svg-icons/faCheck';
+import { faUserSecret } from '@fortawesome/pro-solid-svg-icons/faUserSecret';
 import { RouterLinkRenderer } from 'components/common/Navigation/Link';
 import { BodyText } from 'components/common/Typography/Body';
 import { USER_ROLES } from 'services/userService/constants';
 import UserService from 'services/userService';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import { ROUTES, getPath } from 'routes/routes';
+import { AppConfig } from 'config';
+import { ViewSwitcherHandle } from 'routes/ViewSwitcherHandle';
 
 export const routeItemStyle = {
     padding: 0,
@@ -159,7 +164,52 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen }: DrawerBoxProps) => {
 
 const SideNav = ({ open, setOpen, isMediumScreen }: SideNavProps) => {
     const currentUser = useAppSelector((state) => state.user.userDetail.user);
+    const currentLanguageId = useAppSelector((state) => state.language.id) || AppConfig.language.defaultLanguageId;
+    const matches = useMatches();
+    const location = useLocation();
     const [sideNavOffset, setSideNavOffset] = useState(0);
+    const [switchTarget, setSwitchTarget] = useState<{ label: string; href: string } | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const isAdminPath = location.pathname === '/manage' || location.pathname.startsWith('/manage/');
+        const defaultTarget = isAdminPath
+            ? { label: 'View Public Page', href: getPath(ROUTES.PUBLIC_LANDING) }
+            : { label: 'View Admin Page', href: getPath(ROUTES.HOME) };
+
+        const setSwitchTargetIfChanged = (nextTarget: { label: string; href: string } | null) => {
+            setSwitchTarget((currentTarget) => {
+                if (currentTarget?.href === nextTarget?.href && currentTarget?.label === nextTarget?.label) {
+                    return currentTarget;
+                }
+                return nextTarget;
+            });
+        };
+
+        const compute = async () => {
+            for (let i = matches.length - 1; i >= 0; i--) {
+                const match = matches[i];
+                const viewSwitcher = (match.handle as { viewSwitcher?: ViewSwitcherHandle })?.viewSwitcher;
+
+                if (viewSwitcher) {
+                    try {
+                        const target = await viewSwitcher(match.data, match.params, currentLanguageId);
+                        if (!cancelled) setSwitchTargetIfChanged(target ?? defaultTarget);
+                    } catch {
+                        if (!cancelled) setSwitchTargetIfChanged(defaultTarget);
+                    }
+                    return;
+                }
+            }
+
+            if (!cancelled) setSwitchTargetIfChanged(defaultTarget);
+        };
+
+        compute();
+        return () => {
+            cancelled = true;
+        };
+    }, [matches, currentLanguageId, location.pathname]);
 
     useLayoutEffect(() => {
         if (!isMediumScreen) return;
@@ -261,7 +311,22 @@ const SideNav = ({ open, setOpen, isMediumScreen }: SideNavProps) => {
                                     : (currentUser?.main_role ?? 'User')}
                             </BodyText>
                         </Grid>
-                        <Grid sx={{ marginLeft: 'auto', marginRight: '32px' }}>
+                        {switchTarget && (
+                            <Grid sx={{ marginLeft: 'auto', marginRight: '8px' }}>
+                                <Link
+                                    component={RouterLinkRenderer}
+                                    href={switchTarget.href}
+                                    onClick={() => setOpen(false)}
+                                >
+                                    {switchTarget.label}
+                                    <FontAwesomeIcon
+                                        style={{ marginLeft: '4px' }}
+                                        icon={switchTarget.label.includes('Admin') ? faIdCardClip : faUserSecret}
+                                    />
+                                </Link>
+                            </Grid>
+                        )}
+                        <Grid sx={{ marginLeft: switchTarget ? 0 : 'auto', marginRight: '32px' }}>
                             <Link onClick={UserService.doLogout} href="#">
                                 Logout
                                 <FontAwesomeIcon style={{ marginLeft: '4px' }} icon={faArrowRight} />

--- a/web/src/routes/AuthenticatedRoutes.tsx
+++ b/web/src/routes/AuthenticatedRoutes.tsx
@@ -109,6 +109,17 @@ const AuthenticatedRoutes = resolveLazyRouteTree(
                                     engagementId: engagement.id,
                                 }),
                             })),
+                        viewSwitcher: async (data: unknown, _params: unknown, languageId: string) => {
+                            const loaderData = data as { slug: Promise<string> };
+                            const slug = await loaderData.slug;
+                            return {
+                                label: 'View Public Page',
+                                href: getPath(ROUTES.PUBLIC_ENGAGEMENT_BY_SLUG, {
+                                    slug,
+                                    language: languageId,
+                                }),
+                            };
+                        },
                     }}
                     shouldRevalidate={({ currentParams, nextParams, actionResult }) => {
                         return currentParams.engagementId !== nextParams.engagementId || actionResult === 'success';
@@ -239,8 +250,17 @@ const AuthenticatedRoutes = resolveLazyRouteTree(
                 <LazyRoute
                     path="comments/:dashboardType"
                     ComponentLazy={() => import('engagements/dashboard/comment')}
+                    handleLazy={() =>
+                        import('routes/AuthenticatedViewSwitcherHandles').then((m) => m.adminCommentsBySlugHandle)
+                    }
                 />
-                <LazyRoute path="dashboard/:dashboardType" ComponentLazy={() => import('components/publicDashboard')} />
+                <LazyRoute
+                    path="dashboard/:dashboardType"
+                    ComponentLazy={() => import('components/publicDashboard')}
+                    handleLazy={() =>
+                        import('routes/AuthenticatedViewSwitcherHandles').then((m) => m.adminDashboardBySlugHandle)
+                    }
+                />
             </LazyRoute>
             <LazyRoute
                 path="metadata"

--- a/web/src/routes/AuthenticatedViewSwitcherHandles.ts
+++ b/web/src/routes/AuthenticatedViewSwitcherHandles.ts
@@ -1,0 +1,55 @@
+import { getPath, ROUTES } from './routes';
+import { ViewSwitcherHandle } from './ViewSwitcherHandle';
+
+const adminCommentsByIdViewSwitcher: ViewSwitcherHandle = async (data, params, languageId) => {
+    const loaderData = data as { slug: Promise<string> };
+    const slug = await loaderData.slug;
+    return {
+        label: 'View Public Page',
+        href: getPath(ROUTES.PUBLIC_COMMENTS_BY_SLUG, {
+            slug,
+            dashboardType: params.dashboardType || '',
+            language: languageId,
+        }),
+    };
+};
+
+const adminDashboardByIdViewSwitcher: ViewSwitcherHandle = async (data, params, languageId) => {
+    const loaderData = data as { slug: Promise<string> };
+    const slug = await loaderData.slug;
+    return {
+        label: 'View Public Page',
+        href: getPath(ROUTES.PUBLIC_DASHBOARD_BY_SLUG, {
+            slug,
+            dashboardType: params.dashboardType || '',
+            language: languageId,
+        }),
+    };
+};
+
+const adminCommentsBySlugViewSwitcher: ViewSwitcherHandle = async (_data, params, languageId) => {
+    return {
+        label: 'View Public Page',
+        href: getPath(ROUTES.PUBLIC_COMMENTS_BY_SLUG, {
+            slug: params.slug || '',
+            dashboardType: params.dashboardType || '',
+            language: languageId,
+        }),
+    };
+};
+
+const adminDashboardBySlugViewSwitcher: ViewSwitcherHandle = async (_data, params, languageId) => {
+    return {
+        label: 'View Public Page',
+        href: getPath(ROUTES.PUBLIC_DASHBOARD_BY_SLUG, {
+            slug: params.slug || '',
+            dashboardType: params.dashboardType || '',
+            language: languageId,
+        }),
+    };
+};
+
+export const adminCommentsByIdHandle = { viewSwitcher: adminCommentsByIdViewSwitcher };
+export const adminDashboardByIdHandle = { viewSwitcher: adminDashboardByIdViewSwitcher };
+export const adminCommentsBySlugHandle = { viewSwitcher: adminCommentsBySlugViewSwitcher };
+export const adminDashboardBySlugHandle = { viewSwitcher: adminDashboardBySlugViewSwitcher };

--- a/web/src/routes/UnauthenticatedRoutes.tsx
+++ b/web/src/routes/UnauthenticatedRoutes.tsx
@@ -20,14 +20,23 @@ const UnauthenticatedRoutes = resolveLazyRouteTree(
                     import('engagements/public/view').then((module) => withLanguageParam(module.default))
                 }
                 loaderLazy={() => import('engagements/public/view/EngagementLoaderPublic')}
+                handleLazy={() =>
+                    import('routes/UnauthenticatedViewSwitcherHandles').then((m) => m.publicEngagementHandle)
+                }
             />
             <LazyRoute
                 path="dashboard/:dashboardType/:language"
                 ComponentLazy={() => import('components/publicDashboard').then((m) => withLanguageParam(m.default))}
+                handleLazy={() =>
+                    import('routes/UnauthenticatedViewSwitcherHandles').then((m) => m.publicDashboardHandle)
+                }
             />
             <LazyRoute
                 path="comments/:dashboardType/:language"
                 ComponentLazy={() => import('engagements/dashboard/comment').then((m) => withLanguageParam(m.default))}
+                handleLazy={() =>
+                    import('routes/UnauthenticatedViewSwitcherHandles').then((m) => m.publicCommentsHandle)
+                }
             />
             <LazyRoute
                 path="edit/:token/:language"

--- a/web/src/routes/UnauthenticatedViewSwitcherHandles.ts
+++ b/web/src/routes/UnauthenticatedViewSwitcherHandles.ts
@@ -1,0 +1,36 @@
+import { EngagementLoaderPublicData } from 'components/engagement/public/view/EngagementLoaderPublic';
+import { getPath, ROUTES } from './routes';
+import { ViewSwitcherHandle } from './ViewSwitcherHandle';
+
+const publicEngagementViewSwitcher: ViewSwitcherHandle = async (data) => {
+    const loaderData = data as EngagementLoaderPublicData;
+    const engagement = await loaderData.engagement;
+    return {
+        label: 'Edit Engagement',
+        href: getPath(ROUTES.ENGAGEMENT_DETAILS_AUTHORING, { engagementId: engagement.id }),
+    };
+};
+
+const publicDashboardViewSwitcher: ViewSwitcherHandle = async (_data, params) => {
+    return {
+        label: 'Admin Dashboard View',
+        href: getPath(ROUTES.SLUG_DASHBOARD, {
+            slug: params.slug || '',
+            dashboardType: params.dashboardType || '',
+        }),
+    };
+};
+
+const publicCommentsViewSwitcher: ViewSwitcherHandle = async (_data, params) => {
+    return {
+        label: 'Admin Comments View',
+        href: getPath(ROUTES.SLUG_COMMENTS_DASHBOARD, {
+            slug: params.slug || '',
+            dashboardType: params.dashboardType || '',
+        }),
+    };
+};
+
+export const publicEngagementHandle = { viewSwitcher: publicEngagementViewSwitcher };
+export const publicDashboardHandle = { viewSwitcher: publicDashboardViewSwitcher };
+export const publicCommentsHandle = { viewSwitcher: publicCommentsViewSwitcher };

--- a/web/src/routes/ViewSwitcherHandle.ts
+++ b/web/src/routes/ViewSwitcherHandle.ts
@@ -1,0 +1,11 @@
+import { Params } from 'react-router';
+
+/**
+ * Type for a view switcher handler that can be added to a route's handle.
+ * Routes define their own mapping between admin and public views.
+ */
+export type ViewSwitcherHandle = (
+    loaderData: unknown,
+    params: Params<string>,
+    currentLanguageId: string,
+) => Promise<{ label: string; href: string } | null>;

--- a/web/tests/unit/components/header.test.tsx
+++ b/web/tests/unit/components/header.test.tsx
@@ -22,6 +22,7 @@ jest.mock('hooks', () => ({
         callback({
             user: staffUserState,
             tenant: tenant,
+            language: { id: 'en', name: 'English' },
         }),
 }));
 
@@ -35,6 +36,9 @@ jest.mock('react-router', () => ({
         }
     },
     useNavigation: jest.fn(() => ({ state: 'idle' })),
+    useMatches: jest.fn(() => []),
+    useLocation: jest.fn(() => ({ pathname: '/manage' })),
+    useParams: jest.fn(() => ({})),
 }));
 
 jest.mock('@mui/material', () => ({

--- a/web/tests/unit/components/sidenav.test.tsx
+++ b/web/tests/unit/components/sidenav.test.tsx
@@ -16,6 +16,12 @@ jest.mock('@reduxjs/toolkit/query/react', () => ({
 
 jest.mock('axios');
 
+jest.mock('react-router', () => ({
+    ...jest.requireActual('react-router'),
+    useMatches: jest.fn(() => []),
+    useLocation: jest.fn(() => ({ pathname: '/manage' })),
+}));
+
 jest.mock('hooks', () => ({
     useAppTranslation: () => ({
         t: (key: string) => key, // return the key itself (i.e. no translation)
@@ -35,6 +41,7 @@ jest.mock('hooks', () => ({
                     USER_ROLES.VIEW_LANGUAGES,
                 ],
             } as UserState,
+            language: { id: 'en', name: 'English' },
         }),
 }));
 


### PR DESCRIPTION
Issue #: [🎟️ DEP-257](https://citz-gdx.atlassian.net/browse/DEP-257)

**Description of changes:**
- **Feature** Always show InternalHeader when logged in, add admin/public view switcher
  - Updated the InternalHeader component to always be visible when a user is logged in, regardless of whether they are on a public or admin page. This allows for a consistent navigation experience and provides access to the header's features across the entire application.
  - Added a new view switcher component to the InternalHeader that allows users to easily switch between the admin and public views of the application. This component is visible when a user is logged in and provides quick access to both views without needing to log out or manually navigate to different URLs.
  - Routes now define their own "equivalents" on the opposite side (public vs admin) to allow the view switcher to direct users to the corresponding page in the other view. For example, if a user is on the admin engagement details page, the view switcher will take them to the public engagement details page for the same engagement, and vice versa. This is achieved using `handle` from react-router route definitions to specify the equivalent route key for the opposite view.

**User Guide update ticket (if applicable):**

- - [x] Yes, a user guide update ticket has been created. ([Link to ticket](https://citz-gdx.atlassian.net/browse/DEP-264))
- - [ ] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
