### PR TITLE
Fix filters for "more engagements" authoring section

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## April 20, 2026
+
+- **Bugfix** Use EngagementStatus instead of SubmissionStatus [🎟️ DEP-259](https://citz-gdx.atlassian.net/browse/DEP-259)
+  - Updated the AuthoringMore component to use the correct EngagementStatus enum values when filtering suggested engagements. This fixes a bug where engagements in the Upcoming status were not being suggested as possible related engagements.
+  - Added a unit test to ensure this behavior is correct and to prevent regressions in the future.
+
 ## April 15, 2026
 
 - **Feature** Merge routers, move authenticated routes to /manage and add AdminAuthGuard [🎟️ DEP-255](https://citz-gdx.atlassian.net/browse/DEP-255)

--- a/web/src/components/engagement/admin/create/authoring/AuthoringMore.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringMore.tsx
@@ -7,7 +7,7 @@ import { defaultValuesObject, EngagementUpdateData } from './AuthoringContext';
 import { AuthoringTemplateOutletContext } from './types';
 import UnsavedWorkConfirmation from 'components/common/Navigation/UnsavedWorkConfirmation';
 import { AuthoringFormContainer, AuthoringFormSection } from './AuthoringFormLayout';
-import { SubmissionStatus } from 'constants/engagementStatus';
+import { EngagementStatus } from 'constants/engagementStatus';
 import { AuthoringLoaderData } from './authoringLoader';
 import { Engagement } from 'models/engagement';
 import { Page } from 'services/type';
@@ -76,8 +76,7 @@ const AuthoringMore = () => {
                     eng.tenant_id === tenantId && // Must be engagements from same tenant
                     eng.id !== engagementId && // Can't suggest the current engagement
                     // Only suggest open or closed engagements, not drafts or unpublished
-                    (eng.submission_status === SubmissionStatus.Open ||
-                        eng.submission_status === SubmissionStatus.Closed)
+                    (eng.status_id === EngagementStatus.Published || eng.status_id === EngagementStatus.Closed)
                 ) {
                     filteredOptions.push({
                         label: eng?.name || '',

--- a/web/tests/unit/components/authoring/AuthoringMore.test.tsx
+++ b/web/tests/unit/components/authoring/AuthoringMore.test.tsx
@@ -1,0 +1,192 @@
+import React, { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AuthoringMore from '../../../../src/components/engagement/admin/create/authoring/AuthoringMore';
+import { EngagementStatus, SubmissionStatus } from '../../../../src/constants/engagementStatus';
+import { createDefaultEngagement, Engagement } from '../../../../src/models/engagement';
+import { SuggestedEngagement } from '../../../../src/models/suggestedEngagement';
+import { Page } from '../../../../src/services/type';
+
+const mockUseLoaderData = jest.fn();
+const mockUseOutletContext = jest.fn();
+const mockSetValue = jest.fn();
+const mockGetValues = jest.fn(() => ({}));
+const mockReset = jest.fn();
+const mockSetDefaultValues = jest.fn();
+const mockFieldOnChange = jest.fn();
+
+jest.mock('react-router', () => ({
+    ...jest.requireActual('react-router'),
+    useLoaderData: () => mockUseLoaderData(),
+    useOutletContext: () => mockUseOutletContext(),
+}));
+
+jest.mock('react-hook-form', () => ({
+    ...jest.requireActual('react-hook-form'),
+    Controller: ({ name, render }: { name: string; render: (props: unknown) => ReactNode }) =>
+        render({
+            field: {
+                name,
+                value: -1,
+                onChange: mockFieldOnChange,
+            },
+        }),
+    useFormContext: () => ({
+        setValue: mockSetValue,
+        getValues: mockGetValues,
+        reset: mockReset,
+        control: {},
+        formState: {
+            errors: {},
+            isDirty: false,
+            isSubmitting: false,
+        },
+    }),
+}));
+
+jest.mock('components/common/Input', () => ({
+    FormField: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    TextField: ({ id, value, onChange }: { id: string; value?: string; onChange?: (value: string) => void }) => (
+        <input id={id} value={value ?? ''} onChange={(event) => onChange?.(event.target.value)} />
+    ),
+    Select: ({
+        id,
+        options,
+        value,
+        onChange,
+    }: {
+        id: string;
+        options: { label: string; value: number }[];
+        value: number;
+        onChange: (event: { target: { value: string } }) => void;
+    }) => (
+        <select
+            aria-label={id}
+            data-testid={id}
+            value={value}
+            onChange={(event) => onChange({ target: { value: event.target.value } })}
+        >
+            {options.map((option) => (
+                <option key={`${id}-${option.value}`} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+    ),
+}));
+
+jest.mock('../../../../src/components/engagement/admin/create/authoring/AuthoringFormLayout', () => ({
+    AuthoringFormContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    AuthoringFormSection: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+}));
+
+jest.mock('components/common/Navigation/UnsavedWorkConfirmation', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../../../../src/components/engagement/admin/create/authoring/AuthoringContext', () => ({
+    defaultValuesObject: {},
+}));
+
+const buildEngagement = (
+    overrides: Partial<Engagement> & Pick<Engagement, 'id' | 'name' | 'status_id' | 'tenant_id'>,
+): Engagement => ({
+    ...createDefaultEngagement(),
+    ...overrides,
+});
+
+describe('AuthoringMore', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        const currentEngagement = buildEngagement({
+            id: 42,
+            name: 'Current Engagement',
+            status_id: EngagementStatus.Published,
+            submission_status: SubmissionStatus.Open,
+            tenant_id: 7,
+        });
+
+        const engagementList: Page<Engagement> = {
+            items: [
+                currentEngagement,
+                buildEngagement({
+                    id: 1,
+                    name: 'Upcoming Engagement',
+                    status_id: EngagementStatus.Published,
+                    submission_status: SubmissionStatus.Upcoming,
+                    tenant_id: 7,
+                }),
+                buildEngagement({
+                    id: 2,
+                    name: 'Open Engagement',
+                    status_id: EngagementStatus.Published,
+                    submission_status: SubmissionStatus.Open,
+                    tenant_id: 7,
+                }),
+                buildEngagement({
+                    id: 3,
+                    name: 'Closed Engagement',
+                    status_id: EngagementStatus.Closed,
+                    submission_status: SubmissionStatus.Closed,
+                    tenant_id: 7,
+                }),
+                buildEngagement({
+                    id: 4,
+                    name: 'Draft Engagement',
+                    status_id: EngagementStatus.Draft,
+                    submission_status: SubmissionStatus.Upcoming,
+                    tenant_id: 7,
+                }),
+                buildEngagement({
+                    id: 5,
+                    name: 'Scheduled Engagement',
+                    status_id: EngagementStatus.Scheduled,
+                    submission_status: SubmissionStatus.Upcoming,
+                    tenant_id: 7,
+                }),
+                buildEngagement({
+                    id: 6,
+                    name: 'Unpublished Engagement',
+                    status_id: EngagementStatus.Unpublished,
+                    submission_status: SubmissionStatus.Unpublished,
+                    tenant_id: 7,
+                }),
+            ],
+            total: 7,
+        };
+
+        const suggestions: SuggestedEngagement[] = [];
+
+        mockUseOutletContext.mockReturnValue({
+            setDefaultValues: mockSetDefaultValues,
+            fetcher: { data: null },
+            pageName: 'more',
+            engagement: currentEngagement,
+        });
+
+        mockUseLoaderData.mockReturnValue({
+            engagement: Promise.resolve(currentEngagement),
+            engagementList: Promise.resolve(engagementList),
+            suggestions: Promise.resolve(suggestions),
+        });
+    });
+
+    test('shows upcoming, open, and closed engagements while excluding draft, scheduled, and unpublished', async () => {
+        render(<AuthoringMore />);
+
+        await waitFor(() => {
+            expect(screen.getAllByText('Upcoming Engagement').length).toBeGreaterThan(0);
+        });
+
+        expect(screen.getAllByText('Upcoming Engagement').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Open Engagement').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Closed Engagement').length).toBeGreaterThan(0);
+
+        expect(screen.queryAllByText('Draft Engagement')).toHaveLength(0);
+        expect(screen.queryAllByText('Scheduled Engagement')).toHaveLength(0);
+        expect(screen.queryAllByText('Unpublished Engagement')).toHaveLength(0);
+        expect(screen.queryAllByText('Current Engagement')).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Issue #: [🎟️ DEP-259](https://citz-gdx.atlassian.net/browse/DEP-259)

**Description of changes:**

- **Bugfix** Use EngagementStatus instead of SubmissionStatus
  - Updated the AuthoringMore component to use the correct EngagementStatus enum values when filtering suggested engagements. This fixes a bug where engagements in the Upcoming status were not being suggested as possible related engagements.
  - Added a unit test to ensure this behavior is correct and to prevent regressions in the future.


**User Guide update ticket (if applicable):**

- - [ ] Yes, a user guide update ticket has been created. _(Link to ticket)_
- - [x] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
