### PR TITLE
Fix Upcoming and Closed states in hero banner

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+## April 20, 2026
+
+- **Bugfix** Ensure Upcoming and Closed state texts appear in the hero banner (and nowhere else) [🎟️ DEP-260](https://citz-gdx.atlassian.net/browse/DEP-260)
+  - Fixed a bug where the Upcoming and Closed state texts could appear in the Provide Feedback section of the engagement details page, which was not the intended behavior. These status texts are now only displayed in the hero banner of the engagement page when the engagement is in the corresponding status.
+
 ## April 15, 2026
 
 - **Feature** Merge routers, move authenticated routes to /manage and add AdminAuthGuard [🎟️ DEP-255](https://citz-gdx.atlassian.net/browse/DEP-255)

--- a/web/src/components/engagement/public/view/EngagementHero.tsx
+++ b/web/src/components/engagement/public/view/EngagementHero.tsx
@@ -6,7 +6,11 @@ import { getEditorStateFromRaw } from 'components/common/RichTextEditor/utils';
 import { Engagement } from 'models/engagement';
 import { Box, Grid2 as Grid, Skeleton } from '@mui/material';
 import { colors } from 'components/common';
-import { EngagementStatusChip, getSubmissionStatusFromPreviewState } from 'components/common/Indicators';
+import {
+    EngagementStatusChip,
+    getStatusFromStatusId,
+    getSubmissionStatusFromPreviewState,
+} from 'components/common/Indicators';
 import dayjs from 'dayjs';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/pro-regular-svg-icons';
@@ -17,7 +21,7 @@ import { usePreview } from 'components/engagement/preview/PreviewContext';
 import { SubmissionStatus } from 'constants/engagementStatus';
 import { BlueprintImagePlaceholder } from 'components/engagement/preview/placeholders/BlueprintImagePlaceholder';
 import { TextPlaceholder } from 'components/engagement/preview/placeholders/TextPlaceholder';
-import { previewValue, PreviewRender, PreviewSwitch } from 'engagements/preview/PreviewSwitch';
+import { previewValue, PreviewRender, PreviewSwitch } from 'components/engagement/preview/PreviewSwitch';
 import { EngagementPreviewTag } from './EngagementPreviewTag';
 import { useEngagementLoaderData } from 'components/engagement/preview/PreviewLoaderDataContext';
 
@@ -121,6 +125,13 @@ export const EngagementHero = () => {
                     <Await resolve={engagementInfo}>
                         {([engagement, startDate, endDate]: [Engagement, dayjs.Dayjs | null, dayjs.Dayjs | null]) => {
                             const usePreviewState = Boolean(isPreviewMode && previewStateType);
+                            const effectiveSurveyStatus =
+                                previewValue<string | null>({
+                                    isPreviewMode,
+                                    hasValue: usePreviewState,
+                                    value: previewStateType ?? null,
+                                    fallback: getStatusFromStatusId(engagement.submission_status),
+                                }) ?? getStatusFromStatusId(engagement.submission_status);
 
                             const effectiveStatusId =
                                 previewValue<SubmissionStatus>({
@@ -130,28 +141,29 @@ export const EngagementHero = () => {
                                     fallback: engagement.submission_status,
                                 }) ?? engagement.submission_status;
 
-                            const effectiveBlock = previewValue({
-                                isPreviewMode,
-                                hasValue: usePreviewState,
-                                value: engagement.status_block.find(
-                                    (block) =>
-                                        block.survey_status === previewStateType && block.link_type === 'internal',
-                                ),
-                                fallback: engagement.status_block.find((block) => block.link_type === 'internal'),
-                            });
-
-                            const stateMessageBlock =
-                                previewValue({
-                                    isPreviewMode,
-                                    hasValue: usePreviewState,
-                                    value: engagement.status_block.find(
-                                        (block) => block.survey_status === previewStateType,
-                                    ),
-                                    fallback: null,
-                                }) ?? null;
-
+                            const activeStatusBlock = effectiveSurveyStatus
+                                ? engagement.status_block.find((block) => block.survey_status === effectiveSurveyStatus)
+                                : null;
                             const shouldShowStateMessage =
-                                isPreviewMode && (previewStateType === 'Upcoming' || previewStateType === 'Closed');
+                                effectiveSurveyStatus === 'Upcoming' || effectiveSurveyStatus === 'Closed';
+                            const heroButtonContent =
+                                activeStatusBlock && activeStatusBlock.link_type !== 'none'
+                                    ? {
+                                          href:
+                                              activeStatusBlock.link_type === 'external'
+                                                  ? activeStatusBlock.external_link || '#'
+                                                  : `#${activeStatusBlock.internal_link || 'detailsTabs'}`,
+                                          label: activeStatusBlock.button_text || 'Learn More',
+                                      }
+                                    : null;
+                            const previewHeroButtonFallback =
+                                isPreviewMode && (previewStateType === 'Open' || previewStateType === 'ViewResults')
+                                    ? {
+                                          href:
+                                              previewStateType === 'ViewResults' ? '#viewResults' : '#provideFeedback',
+                                          label: previewStateType === 'ViewResults' ? 'View results' : 'Learn More',
+                                      }
+                                    : null;
 
                             return (
                                 <>
@@ -185,17 +197,17 @@ export const EngagementHero = () => {
                                             </BodyText>
                                         </Grid>
                                     </Grid>
-                                    {/* State message for Upcoming / Closed in preview mode */}
                                     {shouldShowStateMessage && (
                                         <Box sx={{ color: 'error.main', mt: '24px', mb: '8px' }}>
                                             <PreviewSwitch
-                                                hasValue={Boolean(stateMessageBlock?.block_text)}
+                                                hasValue={Boolean(activeStatusBlock?.block_text)}
                                                 value={
                                                     <RichTextArea
+                                                        key={effectiveSurveyStatus}
                                                         readOnly
                                                         toolbarHidden
                                                         editorState={getEditorStateFromRaw(
-                                                            stateMessageBlock?.block_text || '',
+                                                            activeStatusBlock?.block_text || '',
                                                         )}
                                                     />
                                                 }
@@ -203,28 +215,27 @@ export const EngagementHero = () => {
                                             />
                                         </Box>
                                     )}
-                                    <PreviewRender
-                                        hasValue={Boolean(effectiveBlock)}
-                                        value={{
-                                            href: effectiveBlock?.internal_link || '#detailsTabs',
-                                            label: effectiveBlock?.button_text || 'Learn More',
-                                        }}
-                                        previewFallback={{ href: '#detailsTabs', label: 'Learn More' }}
-                                    >
-                                        {(buttonContent) => (
-                                            <Button
-                                                href={buttonContent.href}
-                                                LinkComponent={'a'}
-                                                variant="primary"
-                                                size="large"
-                                                icon={<FontAwesomeIcon fontSize={24} icon={faChevronRight} />}
-                                                iconPosition="right"
-                                                sx={{ borderRadius: '8px' }}
-                                            >
-                                                {buttonContent.label}
-                                            </Button>
-                                        )}
-                                    </PreviewRender>
+                                    {(heroButtonContent || previewHeroButtonFallback) && (
+                                        <PreviewRender<{ href: string; label: string }>
+                                            hasValue={Boolean(heroButtonContent)}
+                                            value={(heroButtonContent ?? previewHeroButtonFallback)!}
+                                            previewFallback={previewHeroButtonFallback ?? undefined}
+                                        >
+                                            {(buttonContent) => (
+                                                <Button
+                                                    href={buttonContent.href}
+                                                    LinkComponent={'a'}
+                                                    variant="primary"
+                                                    size="large"
+                                                    icon={<FontAwesomeIcon fontSize={24} icon={faChevronRight} />}
+                                                    iconPosition="right"
+                                                    sx={{ borderRadius: '8px' }}
+                                                >
+                                                    {buttonContent.label}
+                                                </Button>
+                                            )}
+                                        </PreviewRender>
+                                    )}
                                 </>
                             );
                         }}

--- a/web/src/components/engagement/public/view/EngagementSurveyBlock.tsx
+++ b/web/src/components/engagement/public/view/EngagementSurveyBlock.tsx
@@ -3,26 +3,26 @@ import { Button } from 'components/common/Input/Button';
 import { Box, Grid2 as Grid, Skeleton, ThemeProvider } from '@mui/material';
 import { useParams } from 'react-router';
 import { SubmissionStatus } from 'constants/engagementStatus';
-import { RichTextArea } from 'components/common/Input/RichTextArea';
-import { getStatusFromStatusId, getSubmissionStatusFromPreviewState } from 'components/common/Indicators';
-import { getEditorStateFromRaw } from 'components/common/RichTextEditor/utils';
+import { getSubmissionStatusFromPreviewState } from 'components/common/Indicators';
 import { WidgetLocation } from 'models/widget';
 import { BaseTheme, DarkTheme } from 'styles/Theme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/pro-regular-svg-icons';
 import { Switch, Case } from 'react-if';
 import { useAppSelector, useAppTranslation } from 'hooks';
-import EmailModal from 'engagements/public/email/EmailModal';
+import EmailModal from 'components/engagement/public/email/EmailModal';
 import { EngagementViewSections } from '.';
-import { EngagementPreviewTag } from 'engagements/public/view/EngagementPreviewTag';
+import { EngagementPreviewTag } from './EngagementPreviewTag';
 import { usePreview } from 'components/engagement/preview/PreviewContext';
 import { useEngagementLoaderData } from 'components/engagement/preview/PreviewLoaderDataContext';
 import { EngagementWidgetDisplay } from './EngagementWidgetDisplay';
 import { TextPlaceholder } from 'components/engagement/preview/placeholders/TextPlaceholder';
-import { previewValue, PreviewSwitch } from 'engagements/preview/PreviewSwitch';
+import { previewValue, PreviewSwitch } from 'components/engagement/preview/PreviewSwitch';
 import { BodyText, Heading2 } from 'components/common/Typography';
 import { ROUTES, getPath } from 'routes/routes';
 import { AppConfig } from 'config';
+import { RichTextArea } from 'components/common/Input/RichTextArea';
+import { getEditorStateFromRaw } from 'components/common/RichTextEditor/utils';
 
 const gridContainerStyles = {
     bgcolor: 'blue.90',
@@ -43,7 +43,6 @@ const EngagementSurveyContent = ({}) => {
     const loadedEngagement = React.use(engagement);
     const loadedWidgets = React.use(widgets);
     const hasWidget = loadedWidgets.some((widget) => widget.location === WidgetLocation.Feedback);
-    const baseSurveyStatus = getStatusFromStatusId(loadedEngagement.submission_status);
     const [currentPanel, setCurrentPanel] = React.useState('email');
     const [isEmailModalOpen, setIsEmailModalOpen] = React.useState(false);
     const languageId = sessionStorage.getItem('languageId') ?? language ?? AppConfig.language.defaultLanguageId;
@@ -61,13 +60,6 @@ const EngagementSurveyContent = ({}) => {
         setIsEmailModalOpen(false);
     };
 
-    const effectiveSurveyStatus =
-        previewValue<string>({
-            isPreviewMode,
-            hasValue: Boolean(isPreviewMode && previewStateType),
-            value: previewStateType ?? baseSurveyStatus,
-            fallback: baseSurveyStatus,
-        }) ?? baseSurveyStatus;
     const effectiveStatus =
         previewValue<SubmissionStatus>({
             isPreviewMode,
@@ -75,20 +67,16 @@ const EngagementSurveyContent = ({}) => {
             value: getSubmissionStatusFromPreviewState(previewStateType),
             fallback: loadedEngagement.submission_status,
         }) ?? loadedEngagement.submission_status;
-    const isErrorMessage = isPreviewMode && (previewStateType === 'Upcoming' || previewStateType === 'Closed');
-    const statusBlockEditorState = getEditorStateFromRaw(
-        loadedEngagement.status_block.find((block) => block.survey_status === effectiveSurveyStatus)?.block_text ?? '',
-    );
-    const hasStatusBlockText = Boolean(statusBlockEditorState?.getCurrentContent()?.hasText?.());
     const feedbackBodyEditorState = getEditorStateFromRaw(loadedEngagement.feedback_body || '');
     const hasFeedbackContent =
         Boolean(loadedEngagement.feedback_heading?.trim()) ||
         Boolean(feedbackBodyEditorState?.getCurrentContent()?.hasText?.());
     const shouldDisplayFeedbackColumn =
-        isPreviewMode || (hasStatusBlockText && !isErrorMessage) || effectiveStatus !== SubmissionStatus.Upcoming;
+        isPreviewMode || hasFeedbackContent || effectiveStatus !== SubmissionStatus.Upcoming;
 
-    // Outside preview mode, skip if there's nothing to show.
-    if (!isPreviewMode && !hasStatusBlockText && !hasWidget && !hasFeedbackContent) return null;
+    // Outside preview mode, skip when the page has no feedback content, widgets, or status-specific feedback actions.
+    if (!isPreviewMode && !hasWidget && !hasFeedbackContent && effectiveStatus === SubmissionStatus.Upcoming)
+        return null;
 
     return (
         <Grid container size={12} spacing={4} justifyContent="space-between" sx={gridContainerStyles}>
@@ -120,10 +108,6 @@ const EngagementSurveyContent = ({}) => {
                             previewFallback={<TextPlaceholder type="paragraph" />}
                         />
                     </BodyText>
-                    {/* block_text only shown when it's not in the hero (not Upcoming/Closed in preview) */}
-                    {!isPreviewMode && !isErrorMessage && hasStatusBlockText && (
-                        <RichTextArea readOnly toolbarHidden editorState={statusBlockEditorState} />
-                    )}
                     <ThemeProvider theme={BaseTheme}>
                         <EmailModal
                             engagement={loadedEngagement}

--- a/web/tests/unit/components/engagement/EngagementStateContent.test.tsx
+++ b/web/tests/unit/components/engagement/EngagementStateContent.test.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ContentState, convertToRaw } from 'draft-js';
+import { createDefaultEngagement, Engagement } from '../../../../src/models/engagement';
+import { SubmissionStatus } from '../../../../src/constants/engagementStatus';
+import { EngagementHero } from '../../../../src/components/engagement/public/view/EngagementHero';
+import { EngagementSurveyBlock } from '../../../../src/components/engagement/public/view/EngagementSurveyBlock';
+
+const mockUsePreview = jest.fn();
+const mockUseEngagementLoaderData = jest.fn();
+
+jest.mock('react-router', () => {
+    const React = jest.requireActual('react');
+    return {
+        ...jest.requireActual('react-router'),
+        Await: ({
+            resolve,
+            children,
+        }: {
+            resolve: Promise<unknown>;
+            children: (value: unknown) => React.ReactNode;
+        }) => {
+            const [resolvedValue, setResolvedValue] = React.useState();
+
+            React.useEffect(() => {
+                let active = true;
+                Promise.resolve(resolve).then((value) => {
+                    if (active) {
+                        setResolvedValue(value);
+                    }
+                });
+
+                return () => {
+                    active = false;
+                };
+            }, [resolve]);
+
+            if (resolvedValue === undefined) {
+                return null;
+            }
+
+            return <>{children(resolvedValue)}</>;
+        },
+        useParams: () => ({ language: 'en', slug: 'test-engagement' }),
+        useLoaderData: () => ({}),
+    };
+});
+
+jest.mock('components/engagement/preview/PreviewContext', () => ({
+    usePreview: () => mockUsePreview(),
+}));
+
+jest.mock('components/engagement/preview/PreviewLoaderDataContext', () => ({
+    useEngagementLoaderData: () => mockUseEngagementLoaderData(),
+}));
+
+jest.mock('../../../../src/components/engagement/preview/PreviewSwitch', () => {
+    const resolveValue = <T,>({
+        isPreviewMode,
+        hasValue,
+        value,
+        previewFallback,
+        fallback,
+    }: {
+        isPreviewMode?: boolean;
+        hasValue: boolean;
+        value: T;
+        previewFallback?: T;
+        fallback?: T;
+    }): T | undefined => {
+        const previewMode = isPreviewMode ?? mockUsePreview().isPreviewMode;
+        if (hasValue) return value;
+        return previewMode ? (previewFallback ?? fallback) : fallback;
+    };
+
+    return {
+        previewValue: resolveValue,
+        PreviewSwitch: ({ isPreviewMode, hasValue, value, previewFallback, fallback }: any) => {
+            const resolvedValue = resolveValue({ isPreviewMode, hasValue, value, previewFallback, fallback });
+            return <>{resolvedValue ?? null}</>;
+        },
+        PreviewRender: ({ isPreviewMode, hasValue, value, previewFallback, fallback, children }: any) => {
+            const resolvedValue = resolveValue({ isPreviewMode, hasValue, value, previewFallback, fallback });
+            if (resolvedValue === undefined || resolvedValue === null) return null;
+            return <>{children(resolvedValue)}</>;
+        },
+    };
+});
+
+jest.mock('../../../../src/components/engagement/public/view/EngagementPreviewTag', () => ({
+    EngagementPreviewTag: () => null,
+}));
+
+jest.mock('../../../../src/components/engagement/public/view', () => ({
+    EngagementViewSections: {
+        HERO: 'hero',
+        PROVIDE_FEEDBACK: 'provideFeedback',
+        VIEW_RESULTS: 'viewResults',
+    },
+}));
+
+jest.mock('components/common/Input/Button', () => ({
+    Button: ({ children, href, onClick }: { children: React.ReactNode; href?: string; onClick?: () => void }) =>
+        href ? <a href={href}>{children}</a> : <button onClick={onClick}>{children}</button>,
+}));
+
+jest.mock('components/common/Input/RichTextArea', () => ({
+    RichTextArea: ({ editorState }: { editorState: { getCurrentContent: () => { getPlainText: () => string } } }) => (
+        <div>{editorState?.getCurrentContent()?.getPlainText?.() ?? ''}</div>
+    ),
+}));
+
+jest.mock('components/common/Typography', () => ({
+    BodyText: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    EyebrowText: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Heading1: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+    Heading2: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+jest.mock('@fortawesome/react-fontawesome', () => ({
+    FontAwesomeIcon: () => <span aria-hidden="true" />,
+}));
+
+jest.mock('hooks', () => ({
+    useAppSelector: jest.fn((selector) => selector({ user: { authentication: { authenticated: false } } })),
+    useAppTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../../src/components/engagement/public/email/EmailModal', () => () => null);
+
+jest.mock('components/engagement/widgets/WidgetSwitch', () => ({
+    WidgetSwitch: () => null,
+}));
+
+const rawText = (text: string) => JSON.stringify(convertToRaw(ContentState.createFromText(text)));
+
+const createEngagement = (overrides: Partial<Engagement> = {}): Engagement => ({
+    ...createDefaultEngagement(),
+    id: 99,
+    name: 'Water Use Review',
+    sponsor_name: 'Environment',
+    start_date: '2026-04-01',
+    end_date: '2026-05-01',
+    submission_status: SubmissionStatus.Upcoming,
+    feedback_heading: 'Provide feedback',
+    feedback_body: rawText('Feedback section body'),
+    status_block: [
+        {
+            survey_status: 'Open',
+            block_text: '',
+            button_text: 'Learn more',
+            link_type: 'internal',
+            internal_link: 'provideFeedback',
+        },
+        {
+            survey_status: 'ViewResults',
+            block_text: '',
+            button_text: 'Review results',
+            link_type: 'internal',
+            internal_link: 'viewResults',
+        },
+        {
+            survey_status: 'Closed',
+            block_text: rawText('This engagement is closed. Results are pending.'),
+            link_type: 'none',
+        },
+        {
+            survey_status: 'Upcoming',
+            block_text: rawText('This engagement is not available for feedback yet.'),
+            link_type: 'none',
+        },
+    ],
+    surveys: [{ id: 1, name: 'Main Survey', engagement_id: 99 } as any],
+    ...overrides,
+});
+
+const renderPublicSections = async () => {
+    await act(async () => {
+        render(
+            <>
+                <EngagementHero />
+                <EngagementSurveyBlock />
+            </>,
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+};
+
+describe('Public engagement state content', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUsePreview.mockReturnValue({
+            isPreviewMode: false,
+            previewStateType: null,
+        });
+    });
+
+    test('renders the upcoming state message only once in the hero on the live page', async () => {
+        mockUseEngagementLoaderData.mockReturnValue({
+            engagement: Promise.resolve(createEngagement()),
+            widgets: Promise.resolve([]),
+        });
+
+        await renderPublicSections();
+
+        await waitFor(() => {
+            expect(screen.getAllByText('This engagement is not available for feedback yet.')).toHaveLength(1);
+        });
+
+        expect(screen.getByText('Feedback section body')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Learn more' })).not.toBeInTheDocument();
+    });
+
+    test('renders the closed state message in the hero and keeps the feedback CTA in the survey section', async () => {
+        mockUseEngagementLoaderData.mockReturnValue({
+            engagement: Promise.resolve(
+                createEngagement({
+                    submission_status: SubmissionStatus.Closed,
+                }),
+            ),
+            widgets: Promise.resolve([]),
+        });
+
+        await renderPublicSections();
+
+        await waitFor(() => {
+            expect(screen.getAllByText('This engagement is closed. Results are pending.')).toHaveLength(1);
+        });
+
+        expect(screen.getByRole('link', { name: 'buttonText.viewFeedback' })).toBeInTheDocument();
+    });
+
+    test('renders the open-state hero CTA in the banner while keeping the feedback action in the survey section', async () => {
+        mockUseEngagementLoaderData.mockReturnValue({
+            engagement: Promise.resolve(
+                createEngagement({
+                    submission_status: SubmissionStatus.Open,
+                }),
+            ),
+            widgets: Promise.resolve([]),
+        });
+
+        await renderPublicSections();
+
+        expect(screen.getByRole('link', { name: 'Learn more' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Provide Feedback Now' })).toBeInTheDocument();
+    });
+
+    test('renders preview upcoming state text in the hero without duplicating it in the survey body', async () => {
+        mockUsePreview.mockReturnValue({
+            isPreviewMode: true,
+            previewStateType: 'Upcoming',
+        });
+        mockUseEngagementLoaderData.mockReturnValue({
+            engagement: Promise.resolve(
+                createEngagement({
+                    submission_status: SubmissionStatus.Open,
+                }),
+            ),
+            widgets: Promise.resolve([]),
+        });
+
+        await renderPublicSections();
+
+        await waitFor(() => {
+            expect(screen.getAllByText('This engagement is not available for feedback yet.')).toHaveLength(1);
+        });
+
+        expect(screen.getByText('Feedback section body')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Issue #: [🎟️ DEP-260](https://citz-gdx.atlassian.net/browse/DEP-260)

**Description of changes:**
- **Bugfix** Ensure Upcoming and Closed state texts appear in the hero banner (and nowhere else)
  - Fixed a bug where the Upcoming and Closed state texts could appear in the Provide Feedback section of the engagement details page, which was not the intended behavior. These status texts are now only displayed in the hero banner of the engagement page when the engagement is in the corresponding status.

**User Guide update ticket (if applicable):**

- - [ ] Yes, a user guide update ticket has been created. _(Link to ticket)_
- - [x] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
