### PR TITLE
DEP-262: add SUPER_ADMIN role and associated functionality to db; remove staff_user tenant_id column

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,11 @@
+## May 4, 2026
+
+- **Feature** Sync SUPER_ADMIN tenant membership and protect super admins in user management [🎟️ DEP-262](https://citz-gdx.atlassian.net/browse/DEP-262)
+  - Added a migration to create the `SUPER_ADMIN` group, the `super_admin` role, and their mapping so super admins can be represented in tenant memberships.
+  - Updated the API to add or remove `SUPER_ADMIN` group membership based on the user's Keycloak roles during login/request processing, including unit tests for assignment and removal.
+  - Updated the user management UI to recognize Super Admin as a composite role and prevent administrators and super admins from being deactivated, while showing the correct permission messaging.
+  - Removed the tenant_id column from staff_user table, as tenant membership is determined by group memberships rather than a direct column on the user model, making the column redundant.
+
 ## April 30, 2026
 
 - **Feature** Updated all S3 uploaded objects to dynamically generate document URLs from the bucket and object key, rather than storing the full URL in the database. [🎟️ DEP-261](https://citz-gdx.atlassian.net/browse/DEP-261)

--- a/api/migrations/versions/9d2d16f5f3aa_add_super_admin_role_group_mapping.py
+++ b/api/migrations/versions/9d2d16f5f3aa_add_super_admin_role_group_mapping.py
@@ -1,0 +1,80 @@
+"""Add super admin role/group mapping.
+
+Revision ID: 9d2d16f5f3aa
+Revises: 8e50e47b7d32
+Create Date: 2026-04-30 12:00:00.000000
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '9d2d16f5f3aa'
+down_revision = '8e50e47b7d32'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO user_group (created_date, updated_date, id, name, created_by, updated_by)
+        SELECT NOW(), NOW(), COALESCE((SELECT MAX(id) + 1 FROM user_group), 1), 'SUPER_ADMIN', NULL, NULL
+        WHERE NOT EXISTS (
+            SELECT 1 FROM user_group WHERE name = 'SUPER_ADMIN'
+        )
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO user_role (created_date, updated_date, id, name, description, created_by, updated_by)
+        SELECT NOW(), NOW(), COALESCE((SELECT MAX(id) + 1 FROM user_role), 1),
+               'super_admin', 'Role for system-wide super administrator access', NULL, NULL
+        WHERE NOT EXISTS (
+            SELECT 1 FROM user_role WHERE name = 'super_admin'
+        )
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO group_role_mapping (created_date, updated_date, id, role_id, group_id, created_by, updated_by)
+        SELECT NOW(), NOW(), COALESCE((SELECT MAX(id) + 1 FROM group_role_mapping), 1),
+               r.id, g.id, NULL, NULL
+        FROM user_group g
+        JOIN user_role r ON r.name = 'super_admin'
+        WHERE g.name = 'SUPER_ADMIN'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM group_role_mapping m
+              WHERE m.group_id = g.id
+                AND m.role_id = r.id
+          )
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DELETE FROM user_group_membership
+        WHERE group_id IN (
+            SELECT id FROM user_group WHERE name = 'SUPER_ADMIN'
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM group_role_mapping
+        WHERE group_id IN (
+            SELECT id FROM user_group WHERE name = 'SUPER_ADMIN'
+        )
+        OR role_id IN (
+            SELECT id FROM user_role WHERE name = 'super_admin'
+        )
+        """
+    )
+
+    op.execute("DELETE FROM user_role WHERE name = 'super_admin'")
+    op.execute("DELETE FROM user_group WHERE name = 'SUPER_ADMIN'")

--- a/api/migrations/versions/a6f15ee2c7b4_remove_staff_user_tenant_id.py
+++ b/api/migrations/versions/a6f15ee2c7b4_remove_staff_user_tenant_id.py
@@ -1,0 +1,48 @@
+"""Remove redundant tenant_id from staff_users.
+
+Revision ID: a6f15ee2c7b4
+Revises: 9d2d16f5f3aa
+Create Date: 2026-05-04 16:40:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a6f15ee2c7b4'
+down_revision = '9d2d16f5f3aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    _drop_matching_foreign_keys('staff_users', 'tenant_id', 'tenant')
+    with op.batch_alter_table('staff_users', schema=None) as batch_op:
+        batch_op.drop_column('tenant_id')
+
+
+def downgrade():
+    with op.batch_alter_table('staff_users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('tenant_id', sa.Integer(), nullable=True))
+
+    op.create_foreign_key(None, 'staff_users', 'tenant', ['tenant_id'], ['id'])
+
+
+def _drop_matching_foreign_keys(table_name, local_column, referred_table):
+    """Drop FK constraints for a specific local column and referenced table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    foreign_keys = inspector.get_foreign_keys(table_name)
+
+    for foreign_key in foreign_keys:
+        name = foreign_key.get('name')
+        constrained_columns = foreign_key.get('constrained_columns') or []
+        current_referred_table = foreign_key.get('referred_table')
+
+        if (
+            name
+            and local_column in constrained_columns
+            and current_referred_table == referred_table
+        ):
+            op.drop_constraint(name, table_name, type_='foreignkey')

--- a/api/src/api/__init__.py
+++ b/api/src/api/__init__.py
@@ -205,6 +205,12 @@ def setup_jwt_manager(app_context, jwt_manager):
         # ... so any extraneous roles are discarded
         user_roles = list(set(roles_from_token).intersection(keycloak_forwarded_roles))
 
+        StaffUserService.sync_super_admin_membership(
+            token_info=token_info,
+            token_roles=roles_from_token,
+            tenant_id=getattr(g, 'tenant_id', None),
+        )
+
         # Retrieve user by external ID from token info
         user = StaffUserService.get_user_by_external_id(token_info['sub'])
 

--- a/api/src/api/models/base_model.py
+++ b/api/src/api/models/base_model.py
@@ -19,8 +19,6 @@ from sqlalchemy import Column
 from sqlalchemy.ext.declarative import declared_attr
 
 from .db import db
-from ..utils.token_info import TokenInfo
-
 TENANT_ID = 'tenant_id'
 
 
@@ -48,7 +46,8 @@ class BaseModel(db.Model):
 
         Used to populate the created_by and modified_by relationships on all models.
         """
-        return TokenInfo.get_id()
+        token_info = getattr(g, 'jwt_oidc_token_info', None) or {}
+        return token_info.get('sub')
 
     @classmethod
     def find_by_id(cls, identifier: int):

--- a/api/src/api/models/staff_user.py
+++ b/api/src/api/models/staff_user.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Optional
 
 from flask import g
-from sqlalchemy import Column, ForeignKey, String, asc, desc, func, or_
+from sqlalchemy import Column, ForeignKey, String, asc, desc, func
 from sqlalchemy.orm import column_property
 from sqlalchemy.sql import text
 from sqlalchemy.sql.operators import ilike_op
@@ -36,7 +36,6 @@ class StaffUser(BaseModel):
     contact_number = Column(db.String(50), nullable=True)
     external_id = Column(db.String(50), nullable=False, unique=True)
     status_id = db.Column(db.Integer, ForeignKey('user_status.id'), nullable=False, default=1)
-    tenant_id = db.Column(db.Integer, db.ForeignKey('tenant.id'), nullable=True)
 
     @classmethod
     def get_all_paginated(cls, pagination_options: PaginationOptions, search_text='', include_inactive=False):
@@ -67,18 +66,12 @@ class StaffUser(BaseModel):
     @classmethod
     def _add_tenant_filter(cls, query):
         """Add tenant filtering to the query based on user group membership."""
-        has_tenant_id = hasattr(cls, TENANT_ID)
         has_g_tenant_id = hasattr(g, TENANT_ID) and g.tenant_id
-        if has_tenant_id and has_g_tenant_id:
-            return query.outerjoin(
+        if has_g_tenant_id:
+            return query.join(
                 UserGroupMembership,
                 (UserGroupMembership.staff_user_external_id == cls.external_id) &
                 (UserGroupMembership.tenant_id == g.tenant_id)
-            ).filter(
-                or_(
-                    UserGroupMembership.id != None,  # noqa: E711  # pylint: disable=C0121
-                    cls.tenant_id == g.tenant_id,   # new user, no role yet
-                )
             )
         return query
 

--- a/api/src/api/resources/staff_user.py
+++ b/api/src/api/resources/staff_user.py
@@ -111,8 +111,8 @@ class StaffUser(Resource):
         """Permanently delete an inactive user."""
         try:
             user_data = TokenInfo.get_user_data()
-            StaffUserService.delete_deactivated_user(user_id, user_data.get('external_id'))
-            return {'message': 'User deleted successfully.'}, HTTPStatus.OK
+            response = StaffUserService.delete_deactivated_user(user_id, user_data.get('external_id'))
+            return response, HTTPStatus.OK
         except BusinessException as err:
             return {'message': err.error}, err.status_code
 

--- a/api/src/api/schemas/staff_user.py
+++ b/api/src/api/schemas/staff_user.py
@@ -25,5 +25,4 @@ class StaffUserSchema(Schema):
     created_date = fields.Str(data_key='created_date')
     updated_date = fields.Str(data_key='updated_date')
     roles = fields.List(fields.Str(data_key='roles'))
-    tenant_id = fields.Str(data_key='tenant_id')
     status_id = fields.Int(data_key='status_id')

--- a/api/src/api/services/staff_user_service.py
+++ b/api/src/api/services/staff_user_service.py
@@ -57,12 +57,12 @@ class StaffUserService:
     @classmethod
     def sync_super_admin_membership(cls, token_info: dict, token_roles, tenant_id=None):
         """Sync SUPER_ADMIN tenant membership from keycloak roles at login/request time."""
-        if getattr(g, 'syncing_super_admin_membership', False) or getattr(db.session, '_flushing', False):
+        if getattr(g, '_syncing_super_admin_membership', False):
             return
 
-        g.syncing_super_admin_membership = True
+        g._syncing_super_admin_membership = True
         if not token_info:
-            g.syncing_super_admin_membership = False
+            g._syncing_super_admin_membership = False
             return
 
         try:
@@ -94,7 +94,7 @@ class StaffUserService:
             if not has_super_admin_role:
                 UserGroupMembershipService.remove_group_memberships_by_group_name(external_id, 'SUPER_ADMIN')
         finally:
-            g.syncing_super_admin_membership = False
+            g._syncing_super_admin_membership = False
 
     @staticmethod
     def _send_access_request_email(user: StaffUserModel, tenant_id: Optional[int] = None) -> None:

--- a/api/src/api/services/staff_user_service.py
+++ b/api/src/api/services/staff_user_service.py
@@ -9,6 +9,7 @@ from api.models.db import db
 from api.models.membership import Membership
 from api.models.pagination_options import PaginationOptions
 from api.models.staff_user import StaffUser as StaffUserModel
+from api.models.tenant import Tenant as TenantModel
 from api.models.user_group_membership import UserGroupMembership
 from api.schemas.staff_user import StaffUserSchema
 from api.services.user_group_membership_service import UserGroupMembershipService
@@ -44,25 +45,32 @@ class StaffUserService:
         self.validate_fields(user)
 
         external_id = user.get('external_id')
+        tenant_id = getattr(g, 'tenant_id', None)
+        has_no_tenant_roles = len(user.get('roles', [])) == 0
         db_user = StaffUserModel.get_user_by_external_id(external_id, include_inactive=True)
 
         if db_user is None:
             new_user = StaffUserModel.create_user(user)
-            if len(user.get('roles', [])) == 0:
+            if has_no_tenant_roles and tenant_id:
+                UserGroupMembershipService.ensure_access_request_membership(external_id, tenant_id)
+            if has_no_tenant_roles:
                 self._send_access_request_email(new_user, getattr(g, 'tenant_id', None))
             return new_user
+
+        if has_no_tenant_roles and tenant_id:
+            UserGroupMembershipService.ensure_access_request_membership(external_id, tenant_id)
 
         return StaffUserModel.update_user(db_user.id, user)
 
     @classmethod
     def sync_super_admin_membership(cls, token_info: dict, token_roles, tenant_id=None):
         """Sync SUPER_ADMIN tenant membership from keycloak roles at login/request time."""
-        if getattr(g, '_syncing_super_admin_membership', False):
+        if getattr(g, 'syncing_super_admin_membership', False):
             return
 
-        g._syncing_super_admin_membership = True
+        g.syncing_super_admin_membership = True
         if not token_info:
-            g._syncing_super_admin_membership = False
+            g.syncing_super_admin_membership = False
             return
 
         try:
@@ -94,23 +102,41 @@ class StaffUserService:
             if not has_super_admin_role:
                 UserGroupMembershipService.remove_group_memberships_by_group_name(external_id, 'SUPER_ADMIN')
         finally:
-            g._syncing_super_admin_membership = False
+            g.syncing_super_admin_membership = False
 
     @staticmethod
     def _send_access_request_email(user: StaffUserModel, tenant_id: Optional[int] = None) -> None:
         """Send a new user email.Throws error if fails."""
         templates = current_app.config['EMAIL_TEMPLATES']
-        to_email_address = templates['ACCESS_REQUEST']['DEST_EMAIL_ADDRESS']
-        if to_email_address is None:
-            return
         template_id = templates['ACCESS_REQUEST']['ID']
         subject, body, args = StaffUserService._render_email_template(user, tenant_id)
+
+        resolved_tenant_id = tenant_id if tenant_id is not None else getattr(g, 'tenant_id', None)
+        recipient_emails = []
+
+        global_contact_email = templates['ACCESS_REQUEST']['DEST_EMAIL_ADDRESS']
+        if global_contact_email:
+            recipient_emails.append(global_contact_email)
+
+        if resolved_tenant_id:
+            tenant = TenantModel.find_by_id(resolved_tenant_id)
+            if tenant and tenant.contact_email:
+                recipient_emails.append(tenant.contact_email)
+
+        # Preserve order and avoid duplicate sends when contacts are the same.
+        recipient_emails = list(dict.fromkeys(recipient_emails))
+        if not recipient_emails:
+            return
+
         try:
-            notification.send_email(subject=subject,
-                                    email=to_email_address,
-                                    html_body=body,
-                                    args=args,
-                                    template_id=template_id)
+            for email in recipient_emails:
+                notification.send_email(
+                    subject=subject,
+                    email=email,
+                    html_body=body,
+                    args=args,
+                    template_id=template_id,
+                )
         except Exception as exc:  # noqa: B902
             current_app.logger.error('<Notification for new user registration failed', exc)
             raise BusinessException(
@@ -153,9 +179,11 @@ class StaffUserService:
             composite_role = UserGroupMembershipService.get_user_group_within_tenant(user.get('external_id'),
                                                                                      g.tenant_id)
             user['composite_roles'] = ''
+            user['main_role'] = ''
             if composite_role:
                 user['composite_roles'] = composite_role
-                user['main_role'] = CompositeRoles[composite_role].value
+                if composite_role in CompositeRoles.__members__:
+                    user['main_role'] = CompositeRoles[composite_role].value
 
     @classmethod
     def find_users(
@@ -221,7 +249,12 @@ class StaffUserService:
 
     @classmethod
     def delete_deactivated_user(cls, user_id, actor_external_id: Optional[str] = None):
-        """Permanently delete a user after required safeguards are satisfied."""
+        """Delete a deactivated user or only remove current tenant membership.
+
+        Behavior is tenant-aware:
+        - If the user has memberships in other tenants, only remove membership in the current tenant.
+        - If the user only belongs to the current tenant, fully delete the user.
+        """
         db_user = StaffUserModel.get_by_id(user_id, include_inactive=True)
         if db_user is None:
             raise BusinessException(error='User not found.', status_code=HTTPStatus.NOT_FOUND)
@@ -238,9 +271,48 @@ class StaffUserService:
                 status_code=HTTPStatus.CONFLICT,
             )
 
+        current_tenant_id = getattr(g, 'tenant_id', None)
+        if not current_tenant_id:
+            raise BusinessException(
+                error='Tenant context is required for this operation.',
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
+
+        user_group_memberships = UserGroupMembership.query.filter(
+            UserGroupMembership.staff_user_external_id == db_user.external_id,
+        ).all()
+
+        has_current_tenant_membership = any(
+            membership.tenant_id == current_tenant_id for membership in user_group_memberships
+        )
+        if not has_current_tenant_membership:
+            raise BusinessException(
+                error='User does not have membership in the current tenant.',
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
+
+        has_other_tenant_memberships = any(
+            membership.tenant_id != current_tenant_id for membership in user_group_memberships
+        )
+
+        if has_other_tenant_memberships:
+            UserGroupMembership.query.filter(
+                UserGroupMembership.staff_user_external_id == db_user.external_id,
+                UserGroupMembership.tenant_id == current_tenant_id,
+            ).delete(synchronize_session=False)
+            db.session.commit()
+            return {
+                'message': 'User removed from current tenant successfully.',
+                'action': 'removed_current_tenant_membership',
+            }
+
         Membership.query.filter(Membership.user_id == db_user.id).delete(synchronize_session=False)
         UserGroupMembership.query.filter(
             UserGroupMembership.staff_user_external_id == db_user.external_id,
         ).delete(synchronize_session=False)
         db.session.delete(db_user)
         db.session.commit()
+        return {
+            'message': 'User deleted successfully.',
+            'action': 'deleted_user',
+        }

--- a/api/src/api/services/staff_user_service.py
+++ b/api/src/api/services/staff_user_service.py
@@ -15,6 +15,7 @@ from api.services.user_group_membership_service import UserGroupMembershipServic
 from api.utils import notification
 from api.utils.constants import CompositeRoles
 from api.utils.enums import CompositeRoleId, CompositeRoleNames, UserStatus
+from api.utils.roles import Role
 from api.utils.template import Template
 
 
@@ -48,20 +49,62 @@ class StaffUserService:
         if db_user is None:
             new_user = StaffUserModel.create_user(user)
             if len(user.get('roles', [])) == 0:
-                self._send_access_request_email(new_user)
+                self._send_access_request_email(new_user, getattr(g, 'tenant_id', None))
             return new_user
 
         return StaffUserModel.update_user(db_user.id, user)
 
+    @classmethod
+    def sync_super_admin_membership(cls, token_info: dict, token_roles, tenant_id=None):
+        """Sync SUPER_ADMIN tenant membership from keycloak roles at login/request time."""
+        if getattr(g, 'syncing_super_admin_membership', False) or getattr(db.session, '_flushing', False):
+            return
+
+        g.syncing_super_admin_membership = True
+        if not token_info:
+            g.syncing_super_admin_membership = False
+            return
+
+        try:
+            external_id = token_info.get('sub')
+            if not external_id:
+                return
+
+            has_super_admin_role = Role.SUPER_ADMIN.value in set(token_roles or [])
+
+            db_user = StaffUserModel.get_user_by_external_id(external_id, include_inactive=True)
+            if db_user is None:
+                user_data = {
+                    'external_id': external_id,
+                    'first_name': token_info.get('given_name'),
+                    'last_name': token_info.get('family_name'),
+                    'email_address': token_info.get('email'),
+                    'username': token_info.get('preferred_username'),
+                    'identity_provider': token_info.get('identity_provider', ''),
+                    'roles': set(token_roles or []),
+                }
+                required = ['external_id', 'first_name', 'last_name', 'email_address']
+                if all(user_data.get(field) for field in required):
+                    cls().create_or_update_user(user_data)
+
+            if has_super_admin_role and tenant_id:
+                UserGroupMembershipService.ensure_group_membership(external_id, tenant_id, 'SUPER_ADMIN')
+                return
+
+            if not has_super_admin_role:
+                UserGroupMembershipService.remove_group_memberships_by_group_name(external_id, 'SUPER_ADMIN')
+        finally:
+            g.syncing_super_admin_membership = False
+
     @staticmethod
-    def _send_access_request_email(user: StaffUserModel) -> None:
+    def _send_access_request_email(user: StaffUserModel, tenant_id: Optional[int] = None) -> None:
         """Send a new user email.Throws error if fails."""
         templates = current_app.config['EMAIL_TEMPLATES']
         to_email_address = templates['ACCESS_REQUEST']['DEST_EMAIL_ADDRESS']
         if to_email_address is None:
             return
         template_id = templates['ACCESS_REQUEST']['ID']
-        subject, body, args = StaffUserService._render_email_template(user)
+        subject, body, args = StaffUserService._render_email_template(user, tenant_id)
         try:
             notification.send_email(subject=subject,
                                     email=to_email_address,
@@ -75,13 +118,14 @@ class StaffUserService:
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR) from exc
 
     @staticmethod
-    def _render_email_template(user: StaffUserModel):
+    def _render_email_template(user: StaffUserModel, tenant_id: Optional[int] = None):
         template = Template.get_template('email_access_request.html')
         templates = current_app.config['EMAIL_TEMPLATES']
         paths = current_app.config['PATHS']
         subject = templates['ACCESS_REQUEST']['SUBJECT']
+        tenant_id = tenant_id if tenant_id is not None else getattr(g, 'tenant_id', None)
         grant_access_url = notification.get_tenant_site_url(
-            user.tenant_id, paths['USER_MANAGEMENT']
+            tenant_id, paths['USER_MANAGEMENT']
         ).replace('{id}', str(user.id))
         email_environment = templates['ENVIRONMENT']
         args = {

--- a/api/src/api/services/user_group_membership_service.py
+++ b/api/src/api/services/user_group_membership_service.py
@@ -1,6 +1,8 @@
 """Service for user group membership management."""
 from typing import List, Tuple
 
+from api.models.db import db
+from api.models.user_group import UserGroup
 from api.models.user_group_membership import UserGroupMembership
 from api.models.user_role import UserRole
 
@@ -52,3 +54,57 @@ class UserGroupMembershipService:
     def reassign_composite_role_to_user(membership_data):
         """Update user_group_membership."""
         return UserGroupMembership.update_user_group_membership(membership_data)
+
+    @staticmethod
+    def ensure_group_membership(external_id: str, tenant_id: int, group_name: str):
+        """Ensure the user has a membership for the given tenant and group name."""
+        if not external_id or not tenant_id or not group_name:
+            return None
+
+        group = UserGroup.query.filter(UserGroup.name == group_name).first()
+        if not group:
+            return None
+
+        membership = UserGroupMembership.query.filter(
+            UserGroupMembership.staff_user_external_id == external_id,
+            UserGroupMembership.tenant_id == tenant_id,
+        ).first()
+
+        if membership:
+            if membership.group_id != group.id or not membership.is_active:
+                membership.group_id = group.id
+                membership.is_active = True
+                db.session.commit()
+            return membership
+
+        membership = UserGroupMembership(
+            staff_user_external_id=external_id,
+            group_id=group.id,
+            tenant_id=tenant_id,
+            is_active=True,
+        )
+        membership.save()
+        return membership
+
+    @staticmethod
+    def remove_group_memberships_by_group_name(external_id: str, group_name: str) -> int:
+        """Remove all memberships for a user that belong to the given group name."""
+        if not external_id or not group_name:
+            return 0
+
+        memberships = UserGroupMembership.query.join(
+            UserGroup,
+            UserGroupMembership.group_id == UserGroup.id,
+        ).filter(
+            UserGroupMembership.staff_user_external_id == external_id,
+            UserGroup.name == group_name,
+        ).all()
+
+        if not memberships:
+            return 0
+
+        for membership in memberships:
+            db.session.delete(membership)
+
+        db.session.commit()
+        return len(memberships)

--- a/api/src/api/services/user_group_membership_service.py
+++ b/api/src/api/services/user_group_membership_service.py
@@ -1,10 +1,15 @@
 """Service for user group membership management."""
 from typing import List, Tuple
 
+from sqlalchemy import func
+
 from api.models.db import db
 from api.models.user_group import UserGroup
 from api.models.user_group_membership import UserGroupMembership
 from api.models.user_role import UserRole
+
+
+ACCESS_REQUEST_GROUP_NAME = 'ACCESS_REQUEST'
 
 
 class UserGroupMembershipService:
@@ -76,6 +81,39 @@ class UserGroupMembershipService:
                 membership.is_active = True
                 db.session.commit()
             return membership
+
+        membership = UserGroupMembership(
+            staff_user_external_id=external_id,
+            group_id=group.id,
+            tenant_id=tenant_id,
+            is_active=True,
+        )
+        membership.save()
+        return membership
+
+    @staticmethod
+    def ensure_access_request_membership(external_id: str, tenant_id: int):
+        """Ensure a tenant-scoped access-request membership exists for a user.
+
+        The access-request group intentionally has no role mappings, so users
+        become visible in tenant user management without receiving permissions.
+        """
+        if not external_id or not tenant_id:
+            return None
+
+        existing_membership = UserGroupMembership.query.filter(
+            UserGroupMembership.staff_user_external_id == external_id,
+            UserGroupMembership.tenant_id == tenant_id,
+        ).first()
+        if existing_membership:
+            return existing_membership
+
+        group = UserGroup.query.filter(UserGroup.name == ACCESS_REQUEST_GROUP_NAME).first()
+        if not group:
+            next_group_id = (db.session.query(func.max(UserGroup.id)).scalar() or 0) + 1
+            group = UserGroup(name=ACCESS_REQUEST_GROUP_NAME)
+            group.id = next_group_id
+            group.save()
 
         membership = UserGroupMembership(
             staff_user_external_id=external_id,

--- a/api/src/api/utils/constants.py
+++ b/api/src/api/utils/constants.py
@@ -20,6 +20,7 @@ class CompositeRoles(Enum):
     """Enumeration representing user roles."""
 
     ADMIN = 'Administrator'
+    SUPER_ADMIN = 'Super Admin'
     TEAM_MEMBER = 'Team Member'
     REVIEWER = 'Reviewer'
     VIEWER = 'Viewer'

--- a/api/src/api/utils/enums.py
+++ b/api/src/api/utils/enums.py
@@ -63,6 +63,7 @@ class CompositeRoleNames(Enum):
     """Composite role names."""
 
     ADMIN = 'ADMIN'
+    SUPER_ADMIN = 'SUPER_ADMIN'
     VIEWER = 'VIEWER'
     TEAM_MEMBER = 'TEAM_MEMBER'
     REVIEWER = 'REVIEWER'
@@ -75,6 +76,7 @@ class CompositeRoleId(IntEnum):
     TEAM_MEMBER = 2
     REVIEWER = 3
     VIEWER = 4
+    SUPER_ADMIN = 5
 
 
 class MembershipType(IntEnum):

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -181,7 +181,7 @@ def setup_super_admin_user_and_claims(jwt):
     """Set up a user with the super-admin role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     claims = copy.deepcopy(TestJwtClaims.system_admin_role.value)
     claims['sub'] = str(user.external_id)
 
@@ -194,7 +194,7 @@ def setup_admin_user_and_claims(jwt):
     """Set up a user with the staff admin role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
     claims['sub'] = str(user.external_id)
 
@@ -207,7 +207,7 @@ def setup_reviewer_and_claims(jwt):
     """Set up a user with the reviewer role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.REVIEWER.value)
+    factory_user_group_membership_model(str(user.external_id), group_id=CompositeRoleId.REVIEWER.value)
     claims = copy.deepcopy(TestJwtClaims.reviewer_role.value)
     claims['sub'] = str(user.external_id)
 
@@ -220,7 +220,7 @@ def setup_team_member_and_claims(jwt):
     """Set up a user with the team member role."""
     staff_info = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_info)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.TEAM_MEMBER.value)
+    factory_user_group_membership_model(str(user.external_id), group_id=CompositeRoleId.TEAM_MEMBER.value)
     claims = copy.deepcopy(TestJwtClaims.team_member_role.value)
     claims['sub'] = str(user.external_id)
 

--- a/api/tests/unit/api/test_engagement.py
+++ b/api/tests/unit/api/test_engagement.py
@@ -139,8 +139,8 @@ def test_creating_engagments_cross_tenant(client, jwt, session, setup_admin_user
     By extension, this tests the superuser's general ability to perform actions across tenants,
     where this would be disallowed for any other user.
     """
-    adm_user, adm_claims = setup_admin_user_and_claims
-    sup_user, sup_claims = setup_super_admin_user_and_claims
+    _, adm_claims = setup_admin_user_and_claims
+    _, sup_claims = setup_super_admin_user_and_claims
     tenant_short_name = current_app.config.get('DEFAULT_TENANT_SHORT_NAME')
     tenant_1 = TenantModel.find_by_short_name(tenant_short_name)
     assert tenant_1 is not None

--- a/api/tests/unit/api/test_engagement.py
+++ b/api/tests/unit/api/test_engagement.py
@@ -107,7 +107,7 @@ def test_tenant_id_in_create_engagements(client, jwt, session,
     # set user's tenant id to be same as engagement's tenant id
     staff_2 = dict(TestUserInfo.user_staff_2)
     user = factory_staff_user_model(user_info=staff_2)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id), tenant_2.id)
     claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
     claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -145,9 +145,6 @@ def test_creating_engagments_cross_tenant(client, jwt, session, setup_admin_user
     tenant_1 = TenantModel.find_by_short_name(tenant_short_name)
     assert tenant_1 is not None
     tenant_2 = factory_tenant_model(TestTenantInfo.tenant2)
-
-    adm_user.tenant_id = tenant_1.id
-    sup_user.tenant_id = tenant_1.id
 
     engagement_info = TestEngagementInfo.engagement1
 
@@ -218,7 +215,7 @@ def test_get_engagements_reviewer(client, jwt, session, engagement_info,
     eng_id = created_eng.get('id')
     staff_2 = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_2)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.REVIEWER.value)
+    factory_user_group_membership_model(str(user.external_id), group_id=CompositeRoleId.REVIEWER.value)
     claims = copy.deepcopy(TestJwtClaims.reviewer_role.value)
     claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -462,7 +459,7 @@ def test_patch_engagement_by_member(client, jwt, session):  # pylint:disable=unu
 
     staff_1 = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_1)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.TEAM_MEMBER.value)
+    factory_user_group_membership_model(str(user.external_id), group_id=CompositeRoleId.TEAM_MEMBER.value)
     claims = copy.deepcopy(TestJwtClaims.reviewer_role.value)
     claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)

--- a/api/tests/unit/api/test_engagement_membership.py
+++ b/api/tests/unit/api/test_engagement_membership.py
@@ -24,8 +24,7 @@ def test_create_engagement_membership_team_member(client, jwt, session, setup_ad
     user, claims = setup_admin_user_and_claims
     engagement = factory_engagement_model()
     staff_user = factory_staff_user_model()
-    factory_user_group_membership_model(str(staff_user.external_id), staff_user.tenant_id,
-                                        CompositeRoleId.TEAM_MEMBER.value)
+    factory_user_group_membership_model(str(staff_user.external_id), group_id=CompositeRoleId.TEAM_MEMBER.value)
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     mock_add_user_to_role_keycloak_response = MagicMock()
@@ -61,8 +60,7 @@ def test_create_engagement_membership_reviewer(client, jwt, session, setup_admin
     user, claims = setup_admin_user_and_claims
     engagement = factory_engagement_model()
     staff_user = factory_staff_user_model()
-    factory_user_group_membership_model(str(staff_user.external_id), staff_user.tenant_id,
-                                        CompositeRoleId.REVIEWER.value)
+    factory_user_group_membership_model(str(staff_user.external_id), group_id=CompositeRoleId.REVIEWER.value)
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     mock_add_user_to_role_keycloak_response = MagicMock()
@@ -252,8 +250,7 @@ def test_get_all_engagements_by_user(client, jwt, session, setup_admin_user_and_
     user, claims = setup_admin_user_and_claims
     engagement = factory_engagement_model()
     staff_user = factory_staff_user_model()
-    factory_user_group_membership_model(str(staff_user.external_id), staff_user.tenant_id,
-                                        CompositeRoleId.TEAM_MEMBER.value)
+    factory_user_group_membership_model(str(staff_user.external_id), group_id=CompositeRoleId.TEAM_MEMBER.value)
     headers = factory_auth_header(jwt=jwt, claims=claims)
 
     mock_add_user_to_role_keycloak_response = MagicMock()

--- a/api/tests/unit/api/test_submission.py
+++ b/api/tests/unit/api/test_submission.py
@@ -197,7 +197,7 @@ def test_get_comment_filtering(client, jwt, session,
     user = factory_staff_user_model()
     factory_membership_model(
         user_id=user.id, engagement_id=eng.id, member_type=MembershipType.TEAM_MEMBER.name)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.TEAM_MEMBER.value)
+    factory_user_group_membership_model(str(user.external_id), group_id=CompositeRoleId.TEAM_MEMBER.value)
     claims = copy.deepcopy(TestJwtClaims.team_member_role.value)
     claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)

--- a/api/tests/unit/api/test_survey.py
+++ b/api/tests/unit/api/test_survey.py
@@ -107,8 +107,8 @@ def test_create_survey_with_tenant(client, jwt, session,
     staff_info = dict(TestUserInfo.user_staff_3)
     staff_info['tenant_id'] = tenant_2.id
     user = factory_staff_user_model(user_info=staff_info)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
-    set_global_tenant(tenant_id=user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id), tenant_2.id)
+    set_global_tenant(tenant_id=tenant_2.id)
     claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
     claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -249,7 +249,7 @@ def test_get_survey_for_reviewer(client, jwt, session):  # pylint:disable=unused
     set_global_tenant()
     staff_1 = dict(TestUserInfo.user_staff_1)
     user = factory_staff_user_model(user_info=staff_1)
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id, CompositeRoleId.REVIEWER.value)
+    factory_user_group_membership_model(str(user.external_id), group_id=CompositeRoleId.REVIEWER.value)
     claims = copy.deepcopy(TestJwtClaims.reviewer_role.value)
     claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -298,9 +298,12 @@ def test_get_survey_for_reviewer(client, jwt, session):  # pylint:disable=unused
     assert rv.status_code == HTTPStatus.OK.value
 
 
-def test_get_hidden_survey_for_team_member(client, jwt, session):  # pylint:disable=unused-argument
+def test_get_hidden_survey_for_team_member(
+    client, jwt, session, setup_team_member_and_claims
+):  # pylint:disable=unused-argument
     """Assert that a hidden survey cannot be fetched by team members."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.team_member_role)
+    _, claims = setup_team_member_and_claims
+    headers = factory_auth_header(jwt=jwt, claims=claims)
     set_global_tenant()
     factory_survey_model(TestSurveyInfo.hidden_survey)
 
@@ -350,9 +353,12 @@ def test_edit_template_survey_for_admins(client, jwt, session,
     assert rv.status_code == HTTPStatus.OK.value, 'Admins are able to edit template surveys'
 
 
-def test_edit_template_survey_for_team_member(client, jwt, session):  # pylint:disable=unused-argument
+def test_edit_template_survey_for_team_member(
+    client, jwt, session, setup_team_member_and_claims
+):  # pylint:disable=unused-argument
     """Assert that a hidden survey cannot be fetched by team members."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.team_member_role)
+    _, claims = setup_team_member_and_claims
+    headers = factory_auth_header(jwt=jwt, claims=claims)
     survey = factory_survey_model(TestSurveyInfo.survey_template)
     survey_id = str(survey.id)
     new_survey_name = 'new_survey_name'

--- a/api/tests/unit/api/test_user.py
+++ b/api/tests/unit/api/test_user.py
@@ -81,6 +81,56 @@ def test_create_staff_user(client, jwt, session, side_effect, expected_status,
     assert rv.status_code == expected_status
 
 
+def test_no_role_login_creates_access_request_membership_for_new_user(client, jwt, session, notify_mock):
+    """Assert no-role login creates a tenant-scoped ACCESS_REQUEST membership for new users."""
+    set_global_tenant(tenant_id=1)
+    claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
+    claims['sub'] = 'b2f9b95e-3e6d-4b25-9b58-611201fce100'
+    claims['email'] = 'new-requester@gov.bc.ca'
+    claims['client_roles'] = []
+
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+
+    access_request_group = UserGroup.query.filter_by(name='ACCESS_REQUEST').first()
+    assert access_request_group is not None
+
+    membership = UserGroupMembership.get_group_by_user_and_tenant_id(claims['sub'], 1)
+    assert membership is not None
+    assert membership.group_id == access_request_group.id
+
+
+def test_no_role_login_creates_access_request_membership_for_existing_user_in_new_tenant(client, jwt, session):
+    """Assert no-role login adds ACCESS_REQUEST membership when an existing user enters a new tenant."""
+    set_global_tenant(tenant_id=1)
+    existing_user = factory_staff_user_model(external_id='6fdde698-238f-4d65-8a4d-b71715ea99ab')
+    factory_user_group_membership_model(str(existing_user.external_id), tenant_id=1)
+
+    tenant_data = dict(TestTenantInfo.tenant2)
+    tenant_data['short_name'] = 'GDXT'
+    tenant_2 = factory_tenant_model(tenant_data)
+
+    claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
+    claims['sub'] = str(existing_user.external_id)
+    claims['email'] = existing_user.email_address
+    claims['client_roles'] = []
+
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    headers[TENANT_ID_HEADER] = tenant_2.short_name
+    rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+
+    access_request_group = UserGroup.query.filter_by(name='ACCESS_REQUEST').first()
+    assert access_request_group is not None
+
+    membership = UserGroupMembership.get_group_by_user_and_tenant_id(str(existing_user.external_id), tenant_2.id)
+    assert membership is not None
+    assert membership.group_id == access_request_group.id
+
+
 def test_super_admin_login_assigns_super_admin_group_in_tenant(client, jwt, session):
     """Assert super admin users are persisted in tenant membership on login."""
     set_global_tenant()

--- a/api/tests/unit/api/test_user.py
+++ b/api/tests/unit/api/test_user.py
@@ -22,18 +22,41 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
-from flask import current_app
 
 from api.exceptions.business_exception import BusinessException
-from api.models import Tenant as TenantModel
+from api.models.group_role_mapping import GroupRoleMapping
+from api.models.staff_user import StaffUser as StaffUserModel
+from api.models.user_group import UserGroup
+from api.models.user_group_membership import UserGroupMembership
+from api.models.user_role import UserRole
 from api.services.staff_user_membership_service import StaffUserMembershipService
 from api.services.staff_user_service import StaffUserService
-from api.utils.constants import CompositeRoles
+from api.utils.constants import TENANT_ID_HEADER, CompositeRoles
 from api.utils.enums import CompositeRoleNames, ContentType, UserStatus
 from tests.utilities.factory_scenarios import TestJwtClaims, TestTenantInfo, TestUserInfo
 from tests.utilities.factory_utils import (
     factory_auth_header, factory_staff_user_model, factory_tenant_model, factory_user_group_membership_model,
     set_global_tenant)
+
+
+def _ensure_super_admin_role_setup():
+    """Ensure SUPER_ADMIN group/role/mapping exists for tests."""
+    group = UserGroup.query.filter_by(name='SUPER_ADMIN').first()
+    if not group:
+        group = UserGroup(name='SUPER_ADMIN')
+        group.save()
+
+    role = UserRole.query.filter_by(name='super_admin').first()
+    if not role:
+        role = UserRole(name='super_admin', description='Role for system-wide super administrator access')
+        role.save()
+
+    mapping = GroupRoleMapping.query.filter_by(group_id=group.id, role_id=role.id).first()
+    if not mapping:
+        mapping = GroupRoleMapping(group_id=group.id, role_id=role.id)
+        mapping.save()
+
+    return group
 
 
 @pytest.mark.parametrize(
@@ -51,13 +74,66 @@ def test_create_staff_user(client, jwt, session, side_effect, expected_status,
     rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == HTTPStatus.OK
     assert rv.json.get('email_address') == claims.get('email')
-    tenant_short_name = current_app.config.get('DEFAULT_TENANT_SHORT_NAME')
-    tenant = TenantModel.find_by_short_name(tenant_short_name)
-    assert rv.json.get('tenant_id') == str(tenant.id)
+    assert 'tenant_id' not in rv.json
 
     with patch.object(StaffUserService, 'create_or_update_user', side_effect=side_effect):
         rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == expected_status
+
+
+def test_super_admin_login_assigns_super_admin_group_in_tenant(client, jwt, session):
+    """Assert super admin users are persisted in tenant membership on login."""
+    set_global_tenant()
+    _ensure_super_admin_role_setup()
+
+    claims = copy.deepcopy(TestJwtClaims.system_admin_role.value)
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('main_role') == CompositeRoles.SUPER_ADMIN.value
+
+    membership = UserGroupMembership.query.join(
+        UserGroup,
+        UserGroupMembership.group_id == UserGroup.id,
+    ).filter(
+        UserGroupMembership.staff_user_external_id == claims['sub'],
+        UserGroupMembership.tenant_id == 1,
+        UserGroup.name == 'SUPER_ADMIN',
+    ).first()
+
+    assert membership is not None
+
+
+def test_super_admin_binding_removed_when_keycloak_role_removed(client, jwt, session):
+    """Assert SUPER_ADMIN DB binding is removed when keycloak role is no longer present."""
+    set_global_tenant()
+    super_admin_group = _ensure_super_admin_role_setup()
+
+    claims = copy.deepcopy(TestJwtClaims.system_admin_role.value)
+    user = factory_staff_user_model(external_id=claims['sub'])
+    factory_user_group_membership_model(str(user.external_id), 1, super_admin_group.id)
+    factory_user_group_membership_model(str(user.external_id), 1)
+
+    non_super_claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
+    non_super_claims['sub'] = claims['sub']
+    headers = factory_auth_header(jwt=jwt, claims=non_super_claims)
+
+    rv = client.put('/api/user/', headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+
+    super_admin_membership = UserGroupMembership.query.join(
+        UserGroup,
+        UserGroupMembership.group_id == UserGroup.id,
+    ).filter(
+        UserGroupMembership.staff_user_external_id == claims['sub'],
+        UserGroup.name == 'SUPER_ADMIN',
+    ).first()
+
+    assert super_admin_membership is None
+    assert StaffUserModel.get_user_by_external_id(claims['sub'], include_inactive=True) is not None
 
 
 def test_get_staff_users(client, jwt, session, setup_admin_user_and_claims, setup_super_admin_user_and_claims):
@@ -66,17 +142,15 @@ def test_get_staff_users(client, jwt, session, setup_admin_user_and_claims, setu
     staff_1 = dict(TestUserInfo.user_staff_1)
     staff_2 = dict(TestUserInfo.user_staff_1)
     staff_other_tenant = dict(TestUserInfo.user_staff_2)
-    staff_other_tenant['tenant_id'] = factory_tenant_model(TestTenantInfo.tenant2).id
+    other_tenant_id = factory_tenant_model(TestTenantInfo.tenant2).id
     user1 = factory_staff_user_model(user_info=staff_1)
-    # Mapping user1 to its tenant via user group membership
-    factory_user_group_membership_model(str(user1.external_id), user1.tenant_id)
+    factory_user_group_membership_model(str(user1.external_id))
     user2 = factory_staff_user_model(user_info=staff_2)
-    # Mapping user2 to its tenant via user group membership
-    factory_user_group_membership_model(str(user2.external_id), user2.tenant_id)
+    factory_user_group_membership_model(str(user2.external_id))
+    unassigned_user = factory_staff_user_model(user_info=staff_1)
 
     user3 = factory_staff_user_model(user_info=staff_other_tenant)
-    # Mapping user3 to its tenant via user group membership
-    factory_user_group_membership_model(str(user3.external_id), user3.tenant_id)
+    factory_user_group_membership_model(str(user3.external_id), other_tenant_id)
 
     # Check that staff admins can see users within the same tenant
     _, claims = setup_admin_user_and_claims
@@ -85,6 +159,8 @@ def test_get_staff_users(client, jwt, session, setup_admin_user_and_claims, setu
     assert rv.status_code == HTTPStatus.OK
     assert rv.json.get('total') == 5
     assert len(rv.json.get('items')) == 5
+    assert all(item.get('id') != unassigned_user.id for item in rv.json.get('items'))
+    assert all(item.get('id') != user3.id for item in rv.json.get('items'))
 
     # Check that super admins only see users from their currently selected tenant
     _, claims = setup_super_admin_user_and_claims
@@ -92,8 +168,9 @@ def test_get_staff_users(client, jwt, session, setup_admin_user_and_claims, setu
     rv = client.get('/api/user/', headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == HTTPStatus.OK
     assert rv.json.get('total') == 5
-    # Users from other tenants should not be included
     assert len(rv.json.get('items')) == 5
+    assert all(item.get('id') != unassigned_user.id for item in rv.json.get('items'))
+    assert all(item.get('id') != user3.id for item in rv.json.get('items'))
 
 
 @pytest.mark.parametrize(
@@ -190,12 +267,15 @@ def test_add_user_to_team_member_role_across_tenants(client, jwt, session):
     user = factory_staff_user_model()
     # users can't modify their own roles, so we need a second user
     other_user = factory_staff_user_model()
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
+    tenant_data = dict(TestTenantInfo.tenant2)
+    tenant_data['short_name'] = f'TEST{other_user.id}'
+    tenant_2 = factory_tenant_model(tenant_data)
 
     claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
-    # sets a different tenant id in the request
-    claims['tenant_id'] = 2
+    claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
+    headers[TENANT_ID_HEADER] = tenant_2.short_name
     rv = client.post(
         f'/api/user/{other_user.external_id}/roles?role={CompositeRoleNames.TEAM_MEMBER.value}',
         headers=headers,
@@ -205,9 +285,9 @@ def test_add_user_to_team_member_role_across_tenants(client, jwt, session):
     assert rv.status_code == HTTPStatus.UNAUTHORIZED
 
     claims = copy.deepcopy(TestJwtClaims.system_admin_role.value)
-    # sets a different tenant id in the request
-    claims['tenant_id'] = 2
+    claims['sub'] = str(user.external_id)
     headers = factory_auth_header(jwt=jwt, claims=claims)
+    headers[TENANT_ID_HEADER] = tenant_2.short_name
     rv = client.post(
         f'/api/user/{other_user.external_id}/roles?role={CompositeRoleNames.TEAM_MEMBER.value}',
         headers=headers,

--- a/api/tests/unit/api/test_user_membership.py
+++ b/api/tests/unit/api/test_user_membership.py
@@ -41,7 +41,7 @@ def test_reassign_user_reviewer_team_member(mocker, client, jwt, session, setup_
     """Assert that returns bad request if bad request body."""
     user = factory_staff_user_model()
     eng = factory_engagement_model()
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     current_membership = factory_membership_model(user_id=user.id, engagement_id=eng.id)  # noqa: E501
     assert current_membership.status == MembershipStatus.ACTIVE.value
 

--- a/api/tests/unit/models/test_staff_user.py
+++ b/api/tests/unit/models/test_staff_user.py
@@ -1,0 +1,13 @@
+"""Tests for the StaffUser model schema."""
+
+from sqlalchemy import inspect
+
+from api.models.db import db
+
+
+def test_staff_users_table_does_not_include_tenant_id(session):  # pylint:disable=unused-argument
+    """Assert the migrated staff_users table no longer includes tenant_id."""
+    inspector = inspect(db.engine)
+    columns = {column['name'] for column in inspector.get_columns('staff_users')}
+
+    assert 'tenant_id' not in columns

--- a/api/tests/unit/schemas/test_widget_image_schema.py
+++ b/api/tests/unit/schemas/test_widget_image_schema.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from api.schemas.widget_image import WidgetImageSchema
 
 
-FULL_URL = 'https://objects.example.com/met-public-files/uploads/banner.png'
+FULL_URL = 'https://objects.example.com/dep-public-files/uploads/banner.png'
 
 
 def _schema_with_mock_storage(url_return_value=FULL_URL):

--- a/api/tests/unit/services/test_engagement.py
+++ b/api/tests/unit/services/test_engagement.py
@@ -41,7 +41,7 @@ def test_create_engagement(session, monkeypatch):  # pylint:disable=unused-argum
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     engagement_data = TestEngagementInfo.engagement1
     saved_engagament = EngagementService().create_engagement(engagement_data)
     # fetch the engagement with id and assert
@@ -58,7 +58,7 @@ def test_create_engagement_with_survey_block(session, monkeypatch):  # pylint:di
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     engagement_data = TestEngagementInfo.engagement2
     saved_engagament = EngagementService().create_engagement(engagement_data)
     # fetch the engagement with id and assert

--- a/api/tests/unit/services/test_engagement_details_tab_translation_service.py
+++ b/api/tests/unit/services/test_engagement_details_tab_translation_service.py
@@ -44,7 +44,7 @@ def test_bulk_create_engagement_details_tab_translations(session, monkeypatch):
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     engagement = factory_engagement_model(
         {
             **TestEngagementInfo.engagement1.value,
@@ -74,7 +74,7 @@ def test_sync_engagement_details_tab_translation_with_authorization(session, mon
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     engagement = factory_engagement_model(
         {
             **TestEngagementInfo.engagement1.value,
@@ -114,7 +114,7 @@ def test_delete_engagement_details_tab_translation_with_authorization(session, m
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     engagement = factory_engagement_model(
         {
             **TestEngagementInfo.engagement1.value,

--- a/api/tests/unit/services/test_event_item_translation_service.py
+++ b/api/tests/unit/services/test_event_item_translation_service.py
@@ -52,7 +52,7 @@ def test_create_event_item_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     event_item, event = event_item_model_with_language()
     data = {
         ** TestEventItemTranslationInfo.event_item_info1.value,
@@ -78,7 +78,7 @@ def test_create_event_item_translation_with_authorization_pre_populate(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     event_item, event = event_item_model_with_language()
     data = {
         ** TestEventItemTranslationInfo.event_item_info1.value,
@@ -104,7 +104,7 @@ def test_update_event_item_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     event_item, event = event_item_model_with_language()
     translation = factory_event_item_translation_model(
         {
@@ -133,7 +133,7 @@ def test_delete_event_item_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     event_item, event = event_item_model_with_language()
     translation = factory_event_item_translation_model(
         {

--- a/api/tests/unit/services/test_poll_answer_translation_service.py
+++ b/api/tests/unit/services/test_poll_answer_translation_service.py
@@ -56,7 +56,7 @@ def test_create_poll_answer_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     answer, poll = poll_answer_model_with_poll_enagement()
     data = {
         'poll_answer_id': answer.id,
@@ -81,7 +81,7 @@ def test_create_poll_answer_translation_with_authorization_with_prepopulate(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     answer, poll = poll_answer_model_with_poll_enagement()
 
     data = {
@@ -107,7 +107,7 @@ def test_update_poll_answer_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     answer, poll = poll_answer_model_with_poll_enagement()
     translation = factory_poll_answer_translation_model(
         {
@@ -135,7 +135,7 @@ def test_delete_poll_answer_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     answer, poll = poll_answer_model_with_poll_enagement()
     translation = factory_poll_answer_translation_model(
         {

--- a/api/tests/unit/services/test_survey.py
+++ b/api/tests/unit/services/test_survey.py
@@ -41,7 +41,7 @@ def test_create_survey(session, monkeypatch,):  # pylint:disable=unused-argument
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     saved_survey = SurveyService().create(survey_data)
     # fetch the survey with id and assert
     fetched_survey = SurveyService().get(saved_survey.id)

--- a/api/tests/unit/services/test_survey_translation_service.py
+++ b/api/tests/unit/services/test_survey_translation_service.py
@@ -29,7 +29,7 @@ def test_create_survey_translation(session, monkeypatch):
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     survey, _ = factory_survey_and_eng_model()
 
     # Create translation with Prepoulate true
@@ -63,7 +63,7 @@ def test_update_survey_translation(session, monkeypatch):
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
 
     translation, _ = factory_survey_translation_and_engagement_model()
 
@@ -80,7 +80,7 @@ def test_delete_survey_translation(session, monkeypatch):
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     translation, _ = factory_survey_translation_and_engagement_model()
     session.add(translation)
     session.commit()

--- a/api/tests/unit/services/test_timeline_event_translation_service.py
+++ b/api/tests/unit/services/test_timeline_event_translation_service.py
@@ -53,7 +53,7 @@ def test_create_timeline_event_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     timeline_event, widget_timeline = timeline_event_model_with_language()
     data = {
         **TestTimelineEventTranslationInfo.timeline_event_info1.value,
@@ -79,7 +79,7 @@ def test_create_timeline_event_translation_with_authorization_with_prepopulate(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     timeline_event, widget_timeline = timeline_event_model_with_language()
     data = {
         'timeline_event_id': timeline_event.id,
@@ -103,7 +103,7 @@ def test_update_timeline_event_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     timeline_event, widget_timeline = timeline_event_model_with_language()
     translation = factory_timeline_event_translation_model(
         {
@@ -132,7 +132,7 @@ def test_delete_timeline_event_translation_with_authorization(
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     timeline_event, widget_timeline = timeline_event_model_with_language()
     translation = factory_timeline_event_translation_model(
         {

--- a/api/tests/unit/services/test_user.py
+++ b/api/tests/unit/services/test_user.py
@@ -171,7 +171,7 @@ def test_existing_user_login_to_new_tenant_without_roles_creates_access_request_
     assert membership.group_id == access_request_group.id
 
 
-def test_access_request_email_sent_to_global_and_tenant_contacts(client, jwt, session):
+def test_access_request_email_sent_to_global_and_tenant_contacts(client, jwt, session, monkeypatch):
     """Assert access request sends notification to global and tenant primary contacts."""
     tenant_data = dict(TestTenantInfo.tenant1)
     tenant_data['short_name'] = 'GDXE'
@@ -180,11 +180,17 @@ def test_access_request_email_sent_to_global_and_tenant_contacts(client, jwt, se
 
     user = factory_staff_user_model()
 
+    expected_global_contact = 'global.access@gov.bc.ca'
+    monkeypatch.setitem(
+        current_app.config['EMAIL_TEMPLATES']['ACCESS_REQUEST'],
+        'DEST_EMAIL_ADDRESS',
+        expected_global_contact,
+    )
+
     with patch.object(notification, 'send_email') as mocked_send_email:
         StaffUserService._send_access_request_email(user, tenant_id=tenant.id)
 
     sent_to = [call.kwargs.get('email') for call in mocked_send_email.call_args_list]
-    expected_global_contact = current_app.config['EMAIL_TEMPLATES']['ACCESS_REQUEST']['DEST_EMAIL_ADDRESS']
 
     assert expected_global_contact in sent_to
     assert tenant.contact_email in sent_to

--- a/api/tests/unit/services/test_user.py
+++ b/api/tests/unit/services/test_user.py
@@ -18,11 +18,20 @@ Test-Suite to ensure that the UserService is working as expected.
 """
 import pytest
 from faker import Faker
+from unittest.mock import patch
+from flask import current_app
 
+from api.models.staff_user import StaffUser as StaffUserModel
+from api.models.user_group import UserGroup
+from api.models.user_group_membership import UserGroupMembership
 from api.schemas.staff_user import StaffUserSchema
 from api.services.staff_user_service import StaffUserService
-from tests.utilities.factory_scenarios import TestUserInfo
-from tests.utilities.factory_utils import factory_staff_user_model, set_global_tenant
+from api.utils import notification
+from api.utils.enums import UserStatus
+from tests.utilities.factory_scenarios import TestTenantInfo, TestUserInfo
+from tests.utilities.factory_utils import (
+    factory_staff_user_model, factory_tenant_model, factory_user_group_membership_model, set_global_tenant)
+
 
 fake = Faker()
 
@@ -46,19 +55,20 @@ def test_create_user_invalid_without_external_id(client, jwt, session, ):  # pyl
 
 
 def test_create_user(client, jwt, session, notify_mock, ):  # pylint:disable=unused-argument
-    """Assert that an user can be Created."""
+    """Assert that a user can be Created."""
     set_global_tenant()
     user_data: dict = TestUserInfo.user_staff_1
     external_id = str(fake.random_number(digits=5))
     user_data['external_id'] = external_id
     user_schema = StaffUserSchema().load(user_data)
     new_user = StaffUserService().create_or_update_user(user_schema)
+    assert new_user is not None
     assert new_user.external_id == external_id
     assert new_user.first_name == user_data['first_name']
 
 
 def test_update_user_email(client, jwt, session, ):  # pylint:disable=unused-argument
-    """Assert that an user can be Created."""
+    """Assert that a user can be updated."""
     user_details = factory_staff_user_model()
     old_email = user_details.email_address
     user_id = user_details.id
@@ -75,9 +85,107 @@ def test_update_user_email(client, jwt, session, ):  # pylint:disable=unused-arg
     }
     user_schema = StaffUserSchema().load(new_user_data)
     new_user = StaffUserService().create_or_update_user(user_schema)
+    assert new_user is not None
 
     # verify same user , but different email id
     assert new_user.external_id == user_details.external_id
     assert new_user.first_name == user_details.first_name
     assert new_user.id == user_details.id
     assert new_user.email_address == new_user_data.get('email_address')
+
+
+def test_delete_deactivated_user_removes_only_current_tenant_membership(client, jwt, session):
+    """Assert tenant-aware delete only removes current tenant membership when user belongs elsewhere."""
+    set_global_tenant(tenant_id=1)
+    other_tenant = factory_tenant_model(TestTenantInfo.tenant2)
+    user = factory_staff_user_model()
+    user.status_id = UserStatus.INACTIVE.value
+    user.save()
+
+    factory_user_group_membership_model(str(user.external_id), tenant_id=1)
+    factory_user_group_membership_model(str(user.external_id), tenant_id=other_tenant.id)
+
+    response = StaffUserService.delete_deactivated_user(user.id, actor_external_id='different-actor')
+
+    assert response.get('action') == 'removed_current_tenant_membership'
+    assert StaffUserModel.get_by_id(user.id, include_inactive=True) is not None
+    assert UserGroupMembership.get_group_by_user_and_tenant_id(str(user.external_id), 1) is None
+    assert UserGroupMembership.get_group_by_user_and_tenant_id(str(user.external_id), other_tenant.id) is not None
+
+
+def test_delete_deactivated_user_fully_deletes_single_tenant_user(client, jwt, session):
+    """Assert tenant-aware delete fully deletes user when no other tenant memberships exist."""
+    set_global_tenant(tenant_id=1)
+    user = factory_staff_user_model()
+    user.status_id = UserStatus.INACTIVE.value
+    user.save()
+
+    factory_user_group_membership_model(str(user.external_id), tenant_id=1)
+
+    response = StaffUserService.delete_deactivated_user(user.id, actor_external_id='different-actor')
+
+    assert response.get('action') == 'deleted_user'
+    assert StaffUserModel.get_by_id(user.id, include_inactive=True) is None
+    assert UserGroupMembership.get_group_by_user_and_tenant_id(str(user.external_id), 1) is None
+
+
+def test_create_user_without_roles_creates_access_request_membership(client, jwt, session, notify_mock):
+    """Assert first login with no roles creates a no-permissions tenant association."""
+    set_global_tenant(tenant_id=1)
+    user_data = dict(TestUserInfo.user_staff_1)
+    user_data['external_id'] = str(fake.uuid4())
+    user_data['roles'] = []
+
+    created_user = StaffUserService().create_or_update_user(user_data)
+    assert created_user is not None
+
+    access_request_group = UserGroup.query.filter(UserGroup.name == 'ACCESS_REQUEST').first()
+    assert access_request_group is not None
+
+    membership = UserGroupMembership.get_group_by_user_and_tenant_id(str(created_user.external_id), 1)
+    assert membership is not None
+    assert membership.group_id == access_request_group.id
+
+
+def test_existing_user_login_to_new_tenant_without_roles_creates_access_request_membership(client, jwt, session):
+    """Assert no-role login to another tenant creates tenant-specific pending association."""
+    set_global_tenant(tenant_id=1)
+    existing_user = factory_staff_user_model()
+    user_data = {
+        'external_id': str(existing_user.external_id),
+        'first_name': existing_user.first_name,
+        'last_name': existing_user.last_name,
+        'email_address': existing_user.email_address,
+        'roles': [],
+    }
+
+    other_tenant = factory_tenant_model(TestTenantInfo.tenant2)
+    set_global_tenant(tenant_id=other_tenant.id)
+
+    StaffUserService().create_or_update_user(user_data)
+
+    access_request_group = UserGroup.query.filter(UserGroup.name == 'ACCESS_REQUEST').first()
+    membership = UserGroupMembership.get_group_by_user_and_tenant_id(str(existing_user.external_id), other_tenant.id)
+    assert access_request_group is not None
+    assert membership is not None
+    assert membership.group_id == access_request_group.id
+
+
+def test_access_request_email_sent_to_global_and_tenant_contacts(client, jwt, session):
+    """Assert access request sends notification to global and tenant primary contacts."""
+    tenant_data = dict(TestTenantInfo.tenant1)
+    tenant_data['short_name'] = 'GDXE'
+    tenant_data['contact_email'] = 'tenant.contact@gov.bc.ca'
+    tenant = factory_tenant_model(tenant_data)
+
+    user = factory_staff_user_model()
+
+    with patch.object(notification, 'send_email') as mocked_send_email:
+        StaffUserService._send_access_request_email(user, tenant_id=tenant.id)
+
+    sent_to = [call.kwargs.get('email') for call in mocked_send_email.call_args_list]
+    expected_global_contact = current_app.config['EMAIL_TEMPLATES']['ACCESS_REQUEST']['DEST_EMAIL_ADDRESS']
+
+    assert expected_global_contact in sent_to
+    assert tenant.contact_email in sent_to
+    assert len(sent_to) == 2

--- a/api/tests/unit/services/test_widget.py
+++ b/api/tests/unit/services/test_widget.py
@@ -43,7 +43,7 @@ def test_create_widget(session, monkeypatch):  # pylint:disable=unused-argument
     patch_token_info(TestJwtClaims.staff_admin_role, monkeypatch)
     set_global_tenant()
     user = factory_staff_user_model(external_id=TestJwtClaims.staff_admin_role['sub'])
-    factory_user_group_membership_model(str(user.external_id), user.tenant_id)
+    factory_user_group_membership_model(str(user.external_id))
     widget_record = WidgetService().create_widget(widget_to_create, engagement.id)
 
     # Assert that was created

--- a/api/tests/utilities/factory_utils.py
+++ b/api/tests/utilities/factory_utils.py
@@ -278,7 +278,6 @@ def factory_staff_user_model(external_id=None, user_info: dict = TestUserInfo.us
         middle_name=user_info['middle_name'],
         email_address=user_info['email_address'],
         status_id=user_info['status_id'],
-        tenant_id=user_info['tenant_id'],
     )
     user.save()
     return user
@@ -292,7 +291,7 @@ def factory_user_group_membership_model(external_id=None, tenant_id=None, group_
     group_id = group_id or CompositeRoleId.ADMIN.value
     # Check if tenant_id is provided, otherwise use a default value
     if tenant_id is None:
-        tenant_id = '1'
+        tenant_id = getattr(g, 'tenant_id', None) or '1'
     membership = UserGroupMembershipModel(
         staff_user_external_id=str(external_id),
         group_id=group_id,

--- a/web/src/components/userManagement/listing/UserManagementContext.tsx
+++ b/web/src/components/userManagement/listing/UserManagementContext.tsx
@@ -81,8 +81,8 @@ export const UserManagementContextProvider = ({ children }: { children: JSX.Elem
     const [paginationOptions, setPaginationOptions] = useState<PaginationOptions<User>>({
         page: Number(pageFromURL) || 1,
         size: Number(sizeFromURL) || 10,
-        sort_key: 'first_name',
-        nested_sort_key: 'first_name',
+        sort_key: 'last_name',
+        nested_sort_key: 'last_name',
         sort_order: 'asc',
     });
 

--- a/web/src/components/userManagement/listing/UserManagementListing.tsx
+++ b/web/src/components/userManagement/listing/UserManagementListing.tsx
@@ -29,7 +29,7 @@ const UserManagementListing = () => {
 
     const headCells: HeadCell<User>[] = [
         {
-            key: 'first_name',
+            key: 'last_name',
             numeric: false,
             disablePadding: true,
             label: 'User Name',

--- a/web/src/components/userManagement/userDetails/UserDetails.tsx
+++ b/web/src/components/userManagement/userDetails/UserDetails.tsx
@@ -89,7 +89,10 @@ export const UserDetails = () => {
     const isInactive = savedUser?.status_id === USER_STATUS.INACTIVE.value;
     const canAssignToEngagement = !isInactive && !isSelf;
     const canReassignRole = roles.includes(USER_ROLES.UPDATE_USER_GROUP);
-    const isAdminUser = savedUser?.main_role === USER_COMPOSITE_ROLE.ADMIN.label;
+    const isAdminUser = [USER_COMPOSITE_ROLE.ADMIN.label, USER_COMPOSITE_ROLE.SUPER_ADMIN.label].includes(
+        savedUser?.main_role ?? '',
+    );
+    const toggleUserStatusRole = roles.includes(USER_ROLES.TOGGLE_USER_STATUS);
 
     const { canEditRole, canEditRoleMessage } = useMemo(() => {
         if (!savedUser) return { canEditRole: false, canEditRoleMessage: '' };
@@ -103,6 +106,14 @@ export const UserDetails = () => {
 
         return { canEditRole: true, canEditRoleMessage: '' };
     }, [savedUser, isSelf, isInactive, isAdminUser, isSuperAdmin, canReassignRole]);
+
+    const canToggleUserStatusMessage = useMemo(() => {
+        if (!savedUser) return '';
+        if (isSelf) return 'You cannot change your own status.';
+        if (isAdminUser) return 'Administrators cannot be deactivated.';
+        if (!toggleUserStatusRole) return "You do not have permission to change this user's status.";
+        return '';
+    }, [savedUser, isSelf, isAdminUser, toggleUserStatusRole]);
 
     const canDeleteUser = savedUser?.status_id === USER_STATUS.INACTIVE.value && !isSelf;
     const currentStatusLabel =
@@ -239,7 +250,7 @@ export const UserDetails = () => {
                                             describeChild
                                             placement="bottom"
                                             arrow
-                                            title={isAdminUser ? 'Administrators cannot be deactivated.' : ''}
+                                            title={canToggleUserStatusMessage}
                                         >
                                             {/* wrap the button so the tooltip applies when the button is disabled */}
                                             <div>

--- a/web/src/components/userManagement/userDetails/UserDetails.tsx
+++ b/web/src/components/userManagement/userDetails/UserDetails.tsx
@@ -144,18 +144,21 @@ export const UserDetails = () => {
                     subText: [
                         { text: 'This action removes the user from the database and cannot be undone.' },
                         { text: 'Only proceed if you understand the operational and audit implications.' },
-                        { text: 'Do you want to permanently delete this user?' },
+                        { text: 'Do you want to delete this user?' },
                     ],
                     confirmButtonText: 'Delete User',
                     cancelButtonText: 'Cancel',
                     handleConfirm: async () => {
                         try {
                             setIsDeletingUser(true);
-                            await deleteUser(savedUser.id);
+                            const deleteResponse = await deleteUser(savedUser.id);
                             dispatch(
                                 openNotification({
                                     severity: 'success',
-                                    text: `${savedUser.first_name} ${savedUser.last_name} was deleted successfully.`,
+                                    text:
+                                        deleteResponse?.action === 'removed_current_tenant_membership'
+                                            ? `${savedUser.first_name} ${savedUser.last_name} was removed from the current tenant.`
+                                            : `${savedUser.first_name} ${savedUser.last_name} was deleted successfully.`,
                                 }),
                             );
                             navigate(getPath(ROUTES.USER_MANAGEMENT));

--- a/web/src/components/userManagement/userDetails/UserStatusButton.tsx
+++ b/web/src/components/userManagement/userDetails/UserStatusButton.tsx
@@ -19,8 +19,11 @@ const UserStatusButton = ({ size = 'medium' }: { size?: 'small' | 'medium' | 'la
     const dispatch = useAppDispatch();
 
     const isActive = savedUser?.status_id === 1;
-
-    const disabled = savedUser?.main_role === USER_COMPOSITE_ROLE.ADMIN.label || savedUser?.id === userDetail?.user?.id;
+    const isSelf = savedUser?.id === userDetail?.user?.id;
+    const isAdminUser = [USER_COMPOSITE_ROLE.ADMIN.label, USER_COMPOSITE_ROLE.SUPER_ADMIN.label].includes(
+        savedUser?.main_role ?? '',
+    );
+    const canToggle = roles.includes(USER_ROLES.TOGGLE_USER_STATUS);
 
     useEffect(() => {
         setUserStatus(isActive);
@@ -123,7 +126,7 @@ const UserStatusButton = ({ size = 'medium' }: { size?: 'small' | 'medium' | 'la
             data-testid="user-status-toggle"
             loading={togglingUserStatus}
             onClick={() => handleToggleUserStatus(!userStatus)}
-            disabled={disabled}
+            disabled={isAdminUser || isSelf || !canToggle}
             icon={<FontAwesomeIcon icon={userStatus ? faUserXmark : faUserCheck} />}
         >
             {userStatus ? 'Deactivate User' : 'Reactivate User'}

--- a/web/src/models/user.ts
+++ b/web/src/models/user.ts
@@ -1,6 +1,10 @@
-export type UserCompositeRole = 'ADMIN' | 'VIEWER' | 'TEAM_MEMBER' | 'REVIEWER';
+export type UserCompositeRole = 'SUPER_ADMIN' | 'ADMIN' | 'VIEWER' | 'TEAM_MEMBER' | 'REVIEWER';
 
 export const USER_COMPOSITE_ROLE: { [x: string]: { value: UserCompositeRole; label: string } } = {
+    SUPER_ADMIN: {
+        value: 'SUPER_ADMIN',
+        label: 'Super Admin',
+    },
     ADMIN: {
         value: 'ADMIN',
         label: 'Administrator',

--- a/web/src/services/userService/api/index.tsx
+++ b/web/src/services/userService/api/index.tsx
@@ -81,7 +81,13 @@ export const toggleUserStatus = async (user_id: string, active: boolean): Promis
     return responseData.data;
 };
 
-export const deleteUser = async (user_id: number): Promise<void> => {
+export interface DeleteUserResponse {
+    message: string;
+    action: 'deleted_user' | 'removed_current_tenant_membership';
+}
+
+export const deleteUser = async (user_id: number): Promise<DeleteUserResponse> => {
     const url = replaceUrl(Endpoints.User.DELETE, 'user_id', String(user_id));
-    await http.DeleteRequest<void>(url);
+    const responseData = await http.DeleteRequest<DeleteUserResponse>(url);
+    return responseData.data;
 };


### PR DESCRIPTION
Issue #: [🎟️ DEP-262](https://citz-gdx.atlassian.net/browse/DEP-262)

**Description of changes:**

**User Guide update ticket (if applicable):**
- **Feature** Sync SUPER_ADMIN tenant membership and protect super admins in user management
  - Added a migration to create the `SUPER_ADMIN` group, the `super_admin` role, and their mapping so super admins can be represented in tenant memberships.
  - Updated the API to add or remove `SUPER_ADMIN` group membership based on the user's Keycloak roles during login/request processing, including unit tests for assignment and removal.
  - Updated the user management UI to recognize Super Admin as a composite role and prevent administrators and super admins from being deactivated, while showing the correct permission messaging.
  - Removed the tenant_id column from staff_user table, as tenant membership is determined by group memberships rather than a direct column on the user model, making the column redundant.

- - [ ] Yes, a user guide update ticket has been created. _(Link to ticket)_
- - [x] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
