### PR TITLE
DEP-263: Add dynamic page titles based on route handles

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,13 @@
+## June 22, 2026
+
+- **Feature** Added dynamic tab titles based on the current chain of route matches [🎟️ DEP-263](https://citz-gdx.atlassian.net/browse/DEP-263)
+  - Updated the DocumentTitle component to dynamically generate the browser tab title based on the current route matches and their associated handles, similar to the automatic breadcrumb system. This ensures that the page title reflects the current context of the application, including engagement titles, page names, or other relevant data.
+    - Minor reorganization to some routes to ensure they display correctly in all situations
+  - Added documentation for hooking into the `handle` / `useMatches` ecosystem as it is used in DEP.
+
 ## June 16, 2026
 
-- **Feature** Merged engagement slug into engagement requests [🎟️ DEP-265](https://citz-gdx.atlassian.net/browse/DEP-265)
+- **Feature** Merged engagement slug into engagement requests [ DEP-265](https://citz-gdx.atlassian.net/browse/DEP-265)
   - Removed the EngagementSlug model, schema, and resource from the API, as they are no longer needed.
   - Updated the Engagement model to include a `slug` field, which is now used to store the engagement slug directly in the engagement record.
   - Engagements can now be fetched by slug, rather than fetching the slug then fetching the engagement by ID. This hastens the process of retrieving engagement data based on the slug.

--- a/docs/React_Route_Handles.md
+++ b/docs/React_Route_Handles.md
@@ -1,0 +1,83 @@
+## Route Handles in DEP
+
+In our React Router setup, we utilize the `handle` property on route definitions to provide additional metadata that can be used throughout our application. This is particularly useful for features like breadcrumb generation and dynamic document titles.
+
+### Setting up a route handle
+
+When defining a route, you can include a `handle` property that returns an object with a `crumb` function. This function should return an object containing at least a `name` property, which will be used for breadcrumb display and document title generation. You can also include an optional `link` property for breadcrumb navigation and an `isIndex` property to indicate if the route is an index page. You can return a separate `title` property if you want to use a different string inside the document title than the breadcrumb name.
+
+```tsx
+{
+    handle: {
+        crumb: () => ({ name: 'Engagements', title: 'All Engagements', link: getPath(ROUTES.ENGAGEMENT_LISTING)}),
+    },
+}
+
+// Result:
+//   - Page title: "All Engagements | DEP"
+//   - Breadcrumb: "Home > Engagements" (clickable link to the listing page)
+```
+
+### Using loader data in route handles
+
+If your breadcrumb name needs to be dynamic based on loader data, your crumb function can expect a `data` parameter, which will be the RESOLVED data returned from the route's loader. This allows you to generate breadcrumb names that reflect the specific content being viewed. This data will never be a promise, as it is processed by the page before the crumb function is called.
+
+```tsx
+{
+    handle: {
+        crumb: (data) => ({ name: data?.engagement?.title || 'Engagement Details' }),
+    },
+}
+// Result:
+//   - Page title: "<engagement title> | DEP"
+//   - Breadcrumb: "Home > Engagements > <engagement title>"
+```
+
+### Excluding index pages from document titles
+
+If you want to exclude a route from being included in the document title, you can set the `isIndex` property to `true` in the crumb object. This is useful for routes that serve as index pages for their parent routes, such as a listing page that should not appear in the document title when viewing an individual item.
+
+For example, if you had a page `/products/:productId` that shows details for a specific product, you might have a parent route `/products` that lists all products. You would want the breadcrumb to show "Products > Product Name", but the document title should just be "Product Name". In this case, you would set `isIndex: true` on the crumb for the `/products` route.
+
+```tsx
+return (
+    <LazyRoute
+        path="products"
+        handle={{
+            allowedRoles: [USER_ROLES.EDIT_ENGAGEMENT],
+            crumb: (data?: { engagement?: { id?: number } }) => ({
+                name: 'Products',
+                isIndex: true,
+            }),
+        }}
+    >
+        <LazyRoute
+            index
+            ComponentLazy={...}
+            handle={{
+                crumb: (data) => ({ name: data?.product?.name || 'Product Details' }),
+            }}
+        />
+    </LazyRoute>
+)
+
+// Result:
+//   - Breadcrumb: "Home > Products > Product Name"
+//   - Page title: "Product Name | DEP"
+```
+
+### Hooking into the crumb system
+
+If you want to design a component that can leverage the crumb system for consistent breadcrumb and title generation, you can use the `useMatches` hook from React Router to access the current route matches and their associated handles. This allows you to dynamically pull route tree information and generate breadcrumbs or titles based on the current route context.
+
+```tsx
+import { useMatches } from "react-router";
+
+const matches = useMatches();
+const crumbs = matches
+  .map((match) => match.handle?.crumb?.(match.data))
+  .filter((crumb) => crumb?.name && !crumb?.isIndex);
+
+// Example of generating a breadcrumb-style path from the current page:
+const my_generated_path = crumbs.map((crumb) => crumb.name).join(" > ");
+```

--- a/web/src/DocumentTitle.tsx
+++ b/web/src/DocumentTitle.tsx
@@ -44,12 +44,16 @@ const DocumentTitle = () => {
                 // Exclude crumbs that are marked as index pages UNLESS they are the current page
                 .filter((crumb, index) => (crumb?.title ?? crumb?.name) && (index == 0 || !crumb?.isIndex))
                 .map((crumb) => truncate(crumb.title ?? crumb.name, 40)); // Limit individual crumb length to prevent excessively long titles
-            const title = filteredCrumbs.length > 0 ? filteredCrumbs.join(' | ') : tenant.title;
+            if (filteredCrumbs.length < 1) {
+                setPageTitle(tenant.title);
+                return;
+            }
+            const title = filteredCrumbs.join(' | ');
             const truncatedTitle = truncate(title, 65); // Limit total title length to prevent browser truncation
             if (truncatedTitle == title) {
-                setPageTitle(title + ' | ' + 'Digital Engagement Platform');
+                setPageTitle(title + ' | ' + tenant.title);
             } else {
-                setPageTitle(truncatedTitle + ' | ' + 'DEP');
+                setPageTitle(truncatedTitle + ' | ' + tenant.short_name.toUpperCase());
             }
         };
 
@@ -58,7 +62,7 @@ const DocumentTitle = () => {
         return () => {
             cancelled = true;
         };
-    }, [matches, tenant.title]);
+    }, [matches, tenant.title, tenant.short_name]);
 
     return (
         <Helmet>

--- a/web/src/DocumentTitle.tsx
+++ b/web/src/DocumentTitle.tsx
@@ -1,12 +1,68 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { TenantState } from 'reduxSlices/tenantSlice';
 import { useAppSelector } from './hooks';
+import { useMatches } from 'react-router';
+import { BreadcrumbProps, UIMatchWithCrumb } from 'components/common/Navigation/Breadcrumb';
+
+const truncate = (str: string, maxLength: number) => {
+    if (str.length <= maxLength) return str;
+    return str.slice(0, maxLength - 1) + '…';
+};
+
 const DocumentTitle = () => {
     const tenant: TenantState = useAppSelector((state) => state.tenant);
+    // Reverse list to prioritize the most specific route matches for title
+    const matches = useMatches().reverse() as UIMatchWithCrumb[];
+    const [pageTitle, setPageTitle] = React.useState(tenant.title);
+
+    const getResolvedCrumbs = async (matches: UIMatchWithCrumb[]) => {
+        return await Promise.all(
+            matches.map(async (match) => {
+                if (match.handle?.crumb) {
+                    try {
+                        const data = match.loaderData;
+                        const resolvedCrumb = await match.handle.crumb(data);
+                        return resolvedCrumb;
+                    } catch {
+                        return null;
+                    }
+                }
+                return null;
+            }),
+        ).then((crumbs) => crumbs.filter((crumb): crumb is BreadcrumbProps => crumb !== null));
+    };
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const resolveTitle = async () => {
+            const crumbs = await getResolvedCrumbs(matches);
+            if (cancelled) return;
+            console.log('Resolved crumbs for title:', crumbs);
+            const filteredCrumbs = crumbs
+                // Exclude crumbs that are marked as index pages UNLESS they are the current page
+                .filter((crumb, index) => (crumb?.title ?? crumb?.name) && (index == 0 || !crumb?.isIndex))
+                .map((crumb) => truncate(crumb.title ?? crumb.name, 40)); // Limit individual crumb length to prevent excessively long titles
+            const title = filteredCrumbs.length > 0 ? filteredCrumbs.join(' | ') : tenant.title;
+            const truncatedTitle = truncate(title, 65); // Limit total title length to prevent browser truncation
+            if (truncatedTitle == title) {
+                setPageTitle(title + ' | ' + 'Digital Engagement Platform');
+            } else {
+                setPageTitle(truncatedTitle + ' | ' + 'DEP');
+            }
+        };
+
+        resolveTitle();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [matches, tenant.title]);
+
     return (
         <Helmet>
-            <title>{tenant.title}</title>
+            <title>{pageTitle}</title>
         </Helmet>
     );
 };

--- a/web/src/components/common/Navigation/Breadcrumb.tsx
+++ b/web/src/components/common/Navigation/Breadcrumb.tsx
@@ -6,9 +6,13 @@ import { UIMatch, useMatches } from 'react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/pro-regular-svg-icons';
 
-type BreadcrumbProps = {
+export type BreadcrumbProps = {
     name: string;
     link?: string;
+    // If true, this crumb will be considered an index page for its parent and will not be used
+    // when generating the page title, though the breadcrumb will still render unaffected.
+    title?: string; // Optional custom title for document title generation, if different from the breadcrumb name
+    isIndex?: boolean;
 };
 
 /**
@@ -58,14 +62,15 @@ export const BreadcrumbTrail: React.FC<{ crumbs: BreadcrumbProps[]; smallScreenO
     );
 };
 
-type UICrumbFunction = (data: unknown) => Promise<BreadcrumbProps> | BreadcrumbProps;
+export type UICrumbFunction = (data: unknown) => Promise<BreadcrumbProps> | BreadcrumbProps;
 
-interface UIRouteHandle {
+export interface UIRouteHandle {
     crumb?: UICrumbFunction;
+    excludeFromTitle?: boolean; // If true, this route's crumb will be excluded from the document title generation
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface UIMatchWithCrumb extends UIMatch<unknown, UIRouteHandle> {}
+export interface UIMatchWithCrumb extends UIMatch<unknown, UIRouteHandle> {}
 
 /**
  * Automatically generates breadcrumbs based on the `handle.crumb` function of the current route and its parents.

--- a/web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
+++ b/web/src/components/engagement/dashboard/comment/CommentsBlock.tsx
@@ -1,14 +1,11 @@
 import React, { useContext } from 'react';
 import { Grid2 as Grid, Paper, Skeleton } from '@mui/material';
-import { useNavigate, useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 import { Link } from 'components/common/Navigation';
 import { Button } from 'components/common/Input/Button';
 import { CommentViewContext } from './CommentViewContext';
 import { Heading4 } from 'components/common/Typography/Headings';
 import CommentTable from './CommentTable';
-import { useAppSelector, useAppDispatch } from 'hooks';
-import { SubmissionStatus } from 'constants/engagementStatus';
-import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
 import { useAppTranslation } from 'hooks';
 import { faFileChartPie } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -22,11 +19,9 @@ interface CommentsBlockProps {
 export const CommentsBlock: React.FC<CommentsBlockProps> = ({ dashboardType }) => {
     const { t: translate } = useAppTranslation();
     const { slug, language } = useParams();
+    const location = useLocation();
     const { engagement, isEngagementLoading } = useContext(CommentViewContext);
-    const navigate = useNavigate();
-    const dispatch = useAppDispatch();
-    const canAccessDashboard = useAppSelector((state) => state.user.roles.includes('access_dashboard'));
-    const isLoggedIn = useAppSelector((state) => state.user.authentication.authenticated);
+    const isAdminPath = location.pathname === '/manage' || location.pathname.startsWith('/manage/');
     const publicEngagementLink = getPath(R.PUBLIC_ENGAGEMENT_BY_SLUG, {
         slug: slug ?? '',
         language: language ?? sessionStorage.getItem('languageId') ?? AppConfig.language.defaultLanguageId,
@@ -42,36 +37,7 @@ export const CommentsBlock: React.FC<CommentsBlockProps> = ({ dashboardType }) =
         engagementId: engagementId ?? '',
         dashboardType,
     });
-
-    const handleViewDashboard = () => {
-        /* check to ensure that users with role access_dashboard can access the dashboard while engagement not closed*/
-        if (canAccessDashboard) {
-            if (!engagementId && isLoggedIn) return;
-            navigate(isLoggedIn ? engagementDashboardLink : publicEngagementDashboardLink);
-            return;
-        }
-
-        /* check to ensure that all other users can access the dashboard only after the engagement is closed*/
-        if (engagement?.submission_status !== SubmissionStatus.Closed) {
-            dispatch(
-                openNotificationModal({
-                    open: true,
-                    data: {
-                        header: translate('commentDashboard.block.notification.header'),
-                        subText: [{ text: translate('commentDashboard.block.notification.text') }],
-                    },
-                    type: 'update',
-                }),
-            );
-            return;
-        }
-
-        if (isLoggedIn) {
-            if (!engagementId) return;
-            navigate(engagementDashboardLink);
-        }
-        navigate(publicEngagementDashboardLink);
-    };
+    const dashboardURL = isAdminPath ? engagementDashboardLink : publicEngagementDashboardLink;
 
     if (isEngagementLoading || !engagement) {
         return <Skeleton width="100%" height="40em" />;
@@ -80,7 +46,7 @@ export const CommentsBlock: React.FC<CommentsBlockProps> = ({ dashboardType }) =
     return (
         <>
             <Grid size={12} container direction="row" justifyContent="flex-end" paddingBottom={'8px'}>
-                <Link to={isLoggedIn ? adminEngagementViewLink : publicEngagementLink} style={{ color: '#1A5A96' }}>
+                <Link to={isAdminPath ? adminEngagementViewLink : publicEngagementLink} sx={{ color: 'text.link' }}>
                     {translate('commentDashboard.block.engagementLink')}
                 </Link>
             </Grid>
@@ -100,7 +66,7 @@ export const CommentsBlock: React.FC<CommentsBlockProps> = ({ dashboardType }) =
                                 icon={<FontAwesomeIcon icon={faFileChartPie} />}
                                 variant="primary"
                                 size="small"
-                                onClick={handleViewDashboard}
+                                href={dashboardURL}
                             >
                                 {translate('commentDashboard.block.buttonText')}
                             </Button>

--- a/web/src/components/engagement/preview/EngagementPreview.tsx
+++ b/web/src/components/engagement/preview/EngagementPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
-import { useBlocker, useLoaderData, useParams, useRevalidator } from 'react-router';
+import { useBlocker, useRouteLoaderData, useParams, useRevalidator } from 'react-router';
 import { Box, Modal } from '@mui/material';
 import PreviewControlBar from './PreviewControlBar';
 import PreviewContent from './PreviewContent';
@@ -186,7 +186,7 @@ const MeasurementBar: React.FC = () => {
  * modifying the actual engagement.
  */
 export const EngagementPreview: React.FC = () => {
-    const loaderData = useLoaderData() as EngagementLoaderPublicData;
+    const loaderData = useRouteLoaderData('public-single-engagement') as EngagementLoaderPublicData;
     const { engagementId, languageCode } = useParams();
     const revalidator = useRevalidator();
     const [previewState, setPreviewState] = useState<SubmissionStatusTypes>('Upcoming');

--- a/web/src/components/engagement/preview/PreviewLoaderDataContext.tsx
+++ b/web/src/components/engagement/preview/PreviewLoaderDataContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import { useLoaderData } from 'react-router';
+import { useRouteLoaderData } from 'react-router';
 import { EngagementLoaderPublicData } from 'components/engagement/public/view/EngagementLoaderPublic';
 
 const PreviewLoaderDataContext = createContext<EngagementLoaderPublicData | null>(null);
@@ -15,7 +15,7 @@ export const PreviewLoaderDataProvider: React.FC<PreviewLoaderDataProviderProps>
 
 export const useEngagementLoaderData = (): EngagementLoaderPublicData => {
     const previewLoaderData = useContext(PreviewLoaderDataContext);
-    const routeLoaderData = useLoaderData() as EngagementLoaderPublicData;
+    const routeLoaderData = useRouteLoaderData('public-single-engagement') as EngagementLoaderPublicData;
     return previewLoaderData ?? routeLoaderData;
 };
 

--- a/web/src/components/engagement/public/view/EngagementLoaderPublic.tsx
+++ b/web/src/components/engagement/public/view/EngagementLoaderPublic.tsx
@@ -24,6 +24,18 @@ export type EngagementLoaderPublicData = {
     translationBundle: Promise<TranslationBundle>;
 };
 
+export type AwaitedEngagementLoaderPublicData = {
+    engagement: Engagement;
+    widgets: Widget[];
+    details: EngagementDetailsTab[];
+    metadata: EngagementMetadata[];
+    taxa: MetadataTaxon[];
+    languages: Language[];
+    translationLanguages?: Language[];
+    suggestions: SuggestedEngagementWithAttachment[];
+    translationBundle: TranslationBundle;
+};
+
 export const engagementLoaderPublic = async ({ params }: { params: Params<string> }) => {
     const { slug: slugParam, engagementId, language } = params;
     const defaultLanguageCode = AppConfig.language.defaultLanguageId.toLowerCase();

--- a/web/src/components/engagement/public/view/SuggestedEngagements.tsx
+++ b/web/src/components/engagement/public/view/SuggestedEngagements.tsx
@@ -6,7 +6,7 @@ import { Heading2 } from 'components/common/Typography';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowLeftLong } from '@fortawesome/pro-regular-svg-icons';
 import { Link } from 'components/common/Navigation';
-import { Await, useLoaderData } from 'react-router';
+import { Await, useRouteLoaderData } from 'react-router';
 
 import { EngagementLoaderPublicData } from './EngagementLoaderPublic';
 import { EngagementViewSections } from '.';
@@ -19,7 +19,9 @@ import { getPath, ROUTES } from 'routes/routes';
 import { TranslationBundle, resolveTranslationValue } from './engagementTranslationResolution';
 
 export const SuggestedEngagements = () => {
-    const { suggestions, engagement, translationBundle } = useLoaderData() as EngagementLoaderPublicData;
+    const { suggestions, engagement, translationBundle } = useRouteLoaderData(
+        'public-single-engagement',
+    ) as EngagementLoaderPublicData;
     const engagementSlots = Array.from({ length: 3 });
     const { isPreviewMode } = usePreview();
 

--- a/web/src/components/publicDashboard/Dashboard.tsx
+++ b/web/src/components/publicDashboard/Dashboard.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect } from 'react';
 import { Grid2 as Grid, useMediaQuery, Stack, Theme, Box, Backdrop, Paper, CircularProgress } from '@mui/material';
 import { Link } from 'components/common/Navigation';
 import { Button } from 'components/common/Input/Button';
-import { useNavigate, useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 import { BodyText, Heading1 } from 'components/common/Typography';
 import { ReportBanner } from './ReportBanner';
 import SurveysCompleted from './KPI/SurveysCompleted';
@@ -15,7 +15,7 @@ import SurveyBarPrintable from './SurveyBarPrintable';
 import { generateDashboardPdf } from './util';
 import { Map } from 'models/analytics/map';
 import { When } from 'react-if';
-import { useAppSelector, useAppTranslation } from 'hooks';
+import { useAppTranslation } from 'hooks';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faComments, faFileArrowDown } from '@fortawesome/pro-regular-svg-icons';
 import { ROUTES, getPath } from 'routes/routes';
@@ -23,14 +23,14 @@ import { AppConfig } from 'config';
 
 const Dashboard = () => {
     const { language, slug } = useParams();
+    const location = useLocation();
     const { t: translate } = useAppTranslation();
     const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-    const navigate = useNavigate();
     const { engagement, isEngagementLoading, dashboardType } = useContext(DashboardContext);
     const [isPrinting, setIsPrinting] = React.useState(false);
     const [projectMapData, setProjectMapData] = React.useState<Map | null>(null);
     const [pdfExportProgress, setPdfExportProgress] = React.useState(0);
-    const isLoggedIn = useAppSelector((state) => state.user.authentication.authenticated);
+    const isAdminPath = location.pathname === '/manage' || location.pathname.startsWith('/manage/');
     const engagementId = engagement?.id;
     const engagementAuthoringLink = getPath(ROUTES.ENGAGEMENT_DETAILS_AUTHORING, { engagementId: engagementId ?? '' });
     const languageID = language ?? sessionStorage.getItem('languageId') ?? AppConfig.language.defaultLanguageId;
@@ -53,14 +53,7 @@ const Dashboard = () => {
         setProjectMapData(data);
     };
 
-    const handleReadComments = () => {
-        if (isLoggedIn) {
-            if (!engagementId) return;
-            navigate(commentViewPath);
-        } else {
-            navigate(commentViewPublicPath);
-        }
-    };
+    const commentsUrl = isAdminPath ? commentViewPath : commentViewPublicPath;
 
     const handlePdfExportProgress = (progress: number) => {
         setPdfExportProgress(progress);
@@ -101,7 +94,7 @@ const Dashboard = () => {
                     <Grid container size={12} flexDirection="column">
                         <Grid size={12} container justifyContent="flex-end" paddingBottom={'8px'}>
                             <Link
-                                to={isLoggedIn ? engagementAuthoringLink : publicEngagementLink}
+                                to={isAdminPath ? engagementAuthoringLink : publicEngagementLink}
                                 data-testid="link-container"
                             >
                                 {translate('dashboard.engagementLink')}
@@ -133,7 +126,7 @@ const Dashboard = () => {
                                                 variant="primary"
                                                 size="small"
                                                 data-testid="SurveyBlock/take-me-to-survey-button"
-                                                onClick={handleReadComments}
+                                                href={commentsUrl}
                                                 sx={{ minWidth: 'max-content' }}
                                             >
                                                 {translate('dashboard.buttonText.readComments')}
@@ -232,7 +225,7 @@ const Dashboard = () => {
                                             />
                                         </Box>
                                         <SurveyBar
-                                            readComments={handleReadComments}
+                                            commentsUrl={commentsUrl}
                                             engagement={engagement}
                                             engagementIsLoading={isEngagementLoading}
                                             dashboardType={dashboardType}

--- a/web/src/components/publicDashboard/SurveyBar/index.tsx
+++ b/web/src/components/publicDashboard/SurveyBar/index.tsx
@@ -23,11 +23,11 @@ const HEIGHT = 400;
 interface SurveyQuestionProps {
     engagement: Engagement;
     engagementIsLoading: boolean;
-    readComments?: () => void;
+    commentsUrl?: string;
     dashboardType: string;
 }
 
-export const SurveyBar = ({ readComments, engagement, engagementIsLoading, dashboardType }: SurveyQuestionProps) => {
+export const SurveyBar = ({ commentsUrl, engagement, engagementIsLoading, dashboardType }: SurveyQuestionProps) => {
     const { t: translate } = useAppTranslation();
     const isTablet = useMediaQuery((theme) => theme.breakpoints.down('md'));
     const [data, setData] = useState<SurveyResultData | null>(null);
@@ -177,7 +177,7 @@ export const SurveyBar = ({ readComments, engagement, engagementIsLoading, dashb
                                 variant="primary"
                                 sx={{ mt: 3, width: '80%' }}
                                 data-testid="SurveyBlock/take-me-to-survey-button-mobile"
-                                onClick={readComments}
+                                href={commentsUrl}
                             >
                                 {translate('dashboard.barBlock.button')}
                             </Button>

--- a/web/src/routes/AuthenticatedRoutes.tsx
+++ b/web/src/routes/AuthenticatedRoutes.tsx
@@ -31,14 +31,22 @@ const AuthenticatedRoutes = resolveLazyRouteTree(
             ComponentLazy={() => import('components/appLayouts/AuthenticatedLayout')}
             ErrorBoundaryLazy={() => import('./NotFound')}
             loaderLazy={() => import('routes/AuthenticatedRootRouteLoader')}
-            handle={{ crumb: () => ({ name: 'Home', link: getPath(ROUTES.HOME) }) }}
+            // Don't show "Home" at the end of every page title - treat as an index page for the app
+            handle={{ crumb: () => ({ name: 'Home', isIndex: true, link: getPath(ROUTES.HOME) }) }}
             shouldRevalidate={() => false} // Cache the root loader data for the authenticated area
         >
             <LazyRoute index ComponentLazy={() => import('components/dashboard')} />
             <LazyRoute path="no-access" ComponentLazy={() => import('routes/NoAccess')} />
-            <Route path="surveys" handle={{ crumb: () => ({ name: 'Surveys', link: getPath(ROUTES.SURVEYS) }) }}>
+            <Route
+                path="surveys"
+                handle={{ crumb: () => ({ name: 'Surveys', isIndex: true, link: getPath(ROUTES.SURVEYS) }) }}
+            >
                 <LazyRoute index ComponentLazy={() => import('components/survey/listing')} />
-                <LazyRoute path="create" ComponentLazy={() => import('components/survey/create')} />
+                <LazyRoute
+                    path="create"
+                    ComponentLazy={() => import('components/survey/create')}
+                    handle={{ crumb: () => ({ name: 'New Survey' }) }}
+                />
                 <LazyRoute
                     path=":surveyId"
                     id="survey"
@@ -76,7 +84,8 @@ const AuthenticatedRoutes = resolveLazyRouteTree(
                 path="engagements"
                 id="engagement-listing"
                 ErrorBoundaryLazy={() => import('routes/NotFound')}
-                handle={{ crumb: () => ({ name: 'Engagements' }) }}
+                // Exclude extraneous "Engagements" when viewing an individual engagement by marking as index page
+                handle={{ crumb: () => ({ name: 'Engagements', isIndex: true }) }}
             >
                 <LazyRoute index ComponentLazy={() => import('engagements/listing')} />
                 <LazyRoute
@@ -131,36 +140,49 @@ const AuthenticatedRoutes = resolveLazyRouteTree(
                     }}
                 >
                     <LazyRoute index element={<Navigate to="authoring" />} />
-                    <LazyRoute>
+                    <LazyRoute
+                        path="config/edit"
+                        handle={{ crumb: () => ({ name: 'Configuration', link: '../config' }) }}
+                    >
                         <LazyRoute
-                            path="config/edit"
+                            index
+                            handle={{ crumb: () => ({ name: 'Edit' }) }}
                             ComponentLazy={() => import('engagements/admin/config/wizard/ConfigWizard')}
                             actionLazy={() => import('engagements/admin/config/EngagementUpdateAction')}
-                            handle={{ crumb: () => ({ name: 'Configure' }) }}
                         />
-                        <LazyRoute index element={<Navigate to="config" />} />
-                        {/* Wraps the tabs with the engagement title and TabContext */}
-                        <LazyRoute ComponentLazy={() => import('engagements/admin/view')}>
-                            <LazyRoute
-                                path="config"
-                                ComponentLazy={() => import('engagements/admin/view/ConfigSummary')}
-                            />
-                            <LazyRoute
-                                path="authoring"
-                                ComponentLazy={() => import('engagements/admin/view/AuthoringTab')}
-                            />
-                            <LazyRoute path="activity" ComponentLazy={() => import('routes/UnderConstruction')} />
-                            <LazyRoute path="results" ComponentLazy={() => import('routes/UnderConstruction')} />
-                            <LazyRoute
-                                path="publish"
-                                ComponentLazy={() => import('engagements/admin/view/PublishingTab')}
-                                actionLazy={() => import('engagements/admin/view/publishingAction')}
-                            />
-                            <LazyRoute
-                                path="*"
-                                lazy={() => import('routes/NotFound').then((module) => ({ Component: module.default }))}
-                            />
-                        </LazyRoute>
+                    </LazyRoute>
+                    {/* Wraps the tabs with the engagement title and TabContext */}
+                    <LazyRoute ComponentLazy={() => import('engagements/admin/view')}>
+                        <LazyRoute
+                            path="config"
+                            handle={{ crumb: () => ({ name: 'Configuration' }) }}
+                            ComponentLazy={() => import('engagements/admin/view/ConfigSummary')}
+                        />
+                        <LazyRoute
+                            path="authoring"
+                            handle={{ crumb: () => ({ name: 'Authoring' }) }}
+                            ComponentLazy={() => import('engagements/admin/view/AuthoringTab')}
+                        />
+                        <LazyRoute
+                            path="activity"
+                            handle={{ crumb: () => ({ name: 'Activity' }) }}
+                            ComponentLazy={() => import('routes/UnderConstruction')}
+                        />
+                        <LazyRoute
+                            path="results"
+                            handle={{ crumb: () => ({ name: 'Results' }) }}
+                            ComponentLazy={() => import('routes/UnderConstruction')}
+                        />
+                        <LazyRoute
+                            path="publish"
+                            handle={{ crumb: () => ({ name: 'Publish' }) }}
+                            ComponentLazy={() => import('engagements/admin/view/PublishingTab')}
+                            actionLazy={() => import('engagements/admin/view/publishingAction')}
+                        />
+                        <LazyRoute
+                            path="*"
+                            lazy={() => import('routes/NotFound').then((module) => ({ Component: module.default }))}
+                        />
                     </LazyRoute>
                     {/* Authoring editing pages — /manage/engagements/:engagementId/authoring/:languageCode/:page */}
                     <LazyRoute
@@ -331,14 +353,14 @@ const AuthenticatedRoutes = resolveLazyRouteTree(
                     <LazyRoute
                         path="edit"
                         ComponentLazy={() => import('components/tenantManagement/Edit')}
-                        handle={{ crumb: () => ({ name: 'Edit Instance' }) }}
+                        handle={{ crumb: () => ({ name: 'Edit' }) }}
                     />
                 </LazyRoute>
             </LazyRoute>
             <LazyRoute
                 path="feedback"
                 ComponentLazy={() => import('components/feedback/listing')}
-                handle={{ crumb: () => ({ name: 'Feedback' }) }}
+                handle={{ crumb: () => ({ name: 'Site Feedback' }) }}
             />
             <LazyRoute path="calendar" ComponentLazy={() => import('routes/UnderConstruction')} />
             <LazyRoute path="reporting" ComponentLazy={() => import('routes/UnderConstruction')} />

--- a/web/src/routes/UnauthenticatedRouteHandles.ts
+++ b/web/src/routes/UnauthenticatedRouteHandles.ts
@@ -31,6 +31,26 @@ const publicCommentsViewSwitcher: ViewSwitcherHandle = async (_data, params) => 
     };
 };
 
-export const publicEngagementHandle = { viewSwitcher: publicEngagementViewSwitcher };
-export const publicDashboardHandle = { viewSwitcher: publicDashboardViewSwitcher };
-export const publicCommentsHandle = { viewSwitcher: publicCommentsViewSwitcher };
+export const publicEngagementHandle = {
+    viewSwitcher: publicEngagementViewSwitcher,
+    crumb: async (data: EngagementLoaderPublicData) => {
+        console.log('publicEngagementHandle received data:', data);
+        const translationBundle = await data.translationBundle;
+        const engagement = await data.engagement;
+        return {
+            name:
+                translationBundle.currentTranslation?.name ??
+                translationBundle.defaultTranslation?.name ??
+                engagement.name ??
+                'Engagement',
+        };
+    },
+};
+export const publicDashboardHandle = {
+    viewSwitcher: publicDashboardViewSwitcher,
+    crumb: () => ({ name: 'Dashboard' }),
+};
+export const publicCommentsHandle = {
+    viewSwitcher: publicCommentsViewSwitcher,
+    crumb: () => ({ name: 'Comments' }),
+};

--- a/web/src/routes/UnauthenticatedRoutes.tsx
+++ b/web/src/routes/UnauthenticatedRoutes.tsx
@@ -16,35 +16,35 @@ const UnauthenticatedRoutes = resolveLazyRouteTree(
             <LazyRoute
                 path=":language"
                 id="public-single-engagement"
-                ComponentLazy={() =>
-                    import('engagements/public/view').then((module) => withLanguageParam(module.default))
-                }
                 loaderLazy={() => import('engagements/public/view/EngagementLoaderPublic')}
-                handleLazy={() =>
-                    import('routes/UnauthenticatedViewSwitcherHandles').then((m) => m.publicEngagementHandle)
-                }
-            />
-            <LazyRoute
-                path="dashboard/:dashboardType/:language"
-                ComponentLazy={() => import('components/publicDashboard').then((m) => withLanguageParam(m.default))}
-                handleLazy={() =>
-                    import('routes/UnauthenticatedViewSwitcherHandles').then((m) => m.publicDashboardHandle)
-                }
-            />
-            <LazyRoute
-                path="comments/:dashboardType/:language"
-                ComponentLazy={() => import('engagements/dashboard/comment').then((m) => withLanguageParam(m.default))}
-                handleLazy={() =>
-                    import('routes/UnauthenticatedViewSwitcherHandles').then((m) => m.publicCommentsHandle)
-                }
-            />
-            <LazyRoute
-                path="edit/:token/:language"
-                ComponentLazy={() =>
-                    import('components/survey/edit').then((module) => withLanguageParam(module.default))
-                }
-                loaderLazy={() => import('components/survey/building/SurveyLoader')}
-            />
+                handleLazy={() => import('routes/UnauthenticatedRouteHandles').then((m) => m.publicEngagementHandle)}
+            >
+                <LazyRoute
+                    index
+                    ComponentLazy={() =>
+                        import('engagements/public/view').then((module) => withLanguageParam(module.default))
+                    }
+                />
+                <LazyRoute
+                    path="dashboard/:dashboardType"
+                    ComponentLazy={() => import('components/publicDashboard').then((m) => withLanguageParam(m.default))}
+                    handleLazy={() => import('routes/UnauthenticatedRouteHandles').then((m) => m.publicDashboardHandle)}
+                />
+                <LazyRoute
+                    path="comments/:dashboardType"
+                    ComponentLazy={() =>
+                        import('engagements/dashboard/comment').then((m) => withLanguageParam(m.default))
+                    }
+                    handleLazy={() => import('routes/UnauthenticatedRouteHandles').then((m) => m.publicCommentsHandle)}
+                />
+                <LazyRoute
+                    path="edit/:token/:language"
+                    ComponentLazy={() =>
+                        import('components/survey/edit').then((module) => withLanguageParam(module.default))
+                    }
+                    loaderLazy={() => import('components/survey/building/SurveyLoader')}
+                />
+            </LazyRoute>
             <LazyRoute
                 path=":scriptionAction/:scriptionKey/:language"
                 ComponentLazy={() =>

--- a/web/src/routes/UnauthenticatedRoutes.tsx
+++ b/web/src/routes/UnauthenticatedRoutes.tsx
@@ -10,7 +10,11 @@ const UnauthenticatedRoutes = resolveLazyRouteTree(
         ErrorBoundaryLazy={() => import('routes/NotFound')}
         id="public-root"
     >
-        <LazyRoute index ComponentLazy={() => import('components/landing')} />
+        <LazyRoute
+            index
+            ComponentLazy={() => import('components/landing')}
+            handle={{ crumb: () => ({ title: 'Home' }) }}
+        />
         <Route path=":slug">
             <LazyRoute index ComponentLazy={() => import('routes/SlugLanguageRedirect')} />
             <LazyRoute

--- a/web/src/routes/routes.ts
+++ b/web/src/routes/routes.ts
@@ -4,8 +4,8 @@ export const ROUTES = {
     // Public routes
     PUBLIC_LANDING: '/',
     PUBLIC_ENGAGEMENT_BY_SLUG: '/:slug/:language',
-    PUBLIC_DASHBOARD_BY_SLUG: '/:slug/dashboard/:dashboardType/:language',
-    PUBLIC_COMMENTS_BY_SLUG: '/:slug/comments/:dashboardType/:language',
+    PUBLIC_DASHBOARD_BY_SLUG: '/:slug/:language/dashboard/:dashboardType',
+    PUBLIC_COMMENTS_BY_SLUG: '/:slug/:language/comments/:dashboardType',
     PUBLIC_SURVEY_EDIT_BY_SLUG: '/:slug/edit/:token/:language',
     PUBLIC_MANAGE_SUBSCRIPTION: '/engagements/:engagementId/:subscriptionStatus/:scriptionKey/:language',
     PUBLIC_SURVEY_SUBMIT: '/surveys/submit/:surveyId/:token/:language',

--- a/web/tests/unit/components/publicDashboard/PublicDashboard.test.tsx
+++ b/web/tests/unit/components/publicDashboard/PublicDashboard.test.tsx
@@ -5,7 +5,6 @@ import Dashboard from 'components/publicDashboard/Dashboard';
 import { setupEnv } from '../setEnvVars';
 import { DashboardContext } from 'components/publicDashboard/DashboardContext';
 import { closedEngagement } from '../factory';
-import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router';
 import { ROUTES, getPath } from 'routes/routes';
 
@@ -17,7 +16,7 @@ jest.mock('jspdf', () => ({
 
 jest.mock('react-router', () => ({
     ...jest.requireActual('react-router'),
-    useLocation: jest.fn(() => ({ search: '' })),
+    useLocation: jest.fn(() => ({ pathname: '/manage/', search: '' })),
     useParams: jest.fn(() => {
         return { slug: '' };
     }),
@@ -118,13 +117,9 @@ describe('Public Dashboard page tests', () => {
     test('Navigation links work correctly', async () => {
         const returnLink = screen.getByText('dashboard.engagementLink');
         expect(returnLink).toBeInTheDocument();
-        const user = userEvent.setup();
-        await user.click(returnLink);
-        await waitFor(() => {
-            expect(globalThis.location.pathname).toBe(
-                getPath(ROUTES.ENGAGEMENT_DETAILS_AUTHORING, { engagementId: closedEngagement.id }),
-            );
-        });
+        expect(returnLink.getAttribute('href')).toBe(
+            getPath(ROUTES.ENGAGEMENT_DETAILS_AUTHORING, { engagementId: closedEngagement.id ?? '' }),
+        );
     });
 
     test('Public Dashboard has sub components', async () => {


### PR DESCRIPTION
Issue #: [🎟️ DEP-263](https://citz-gdx.atlassian.net/browse/DEP-263)

**Description of changes:**
- **Feature** Added dynamic tab titles based on the current chain of route matches
  - Updated the DocumentTitle component to dynamically generate the browser tab title based on the current route matches and their associated handles, similar to the automatic breadcrumb system. This ensures that the page title reflects the current context of the application, including engagement titles, page names, or other relevant data.
    - Minor reorganization to some routes to ensure they display correctly in all situations
  - Added documentation for hooking into the `handle` / `useMatches` ecosystem as it is used in DEP.

**User Guide update ticket (if applicable):**

- - [ ] Yes, a user guide update ticket has been created. _(Link to ticket)_
- - [x] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
