### PR TITLE
DEP-283: Add API-side locking to Surveys

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,10 @@
+## August 5, 2026
+
+- **Feature** Added API-side locking to Surveys [🎟️ DEP-283](https://citz-gdx.atlassian.net/browse/DEP-283)
+  - Updated resource_lock_service to allow locks on Survey resources, including the Survey Builder and other settings sections.
+  - Updated the Survey endpoints to prevent updates if a survey is locked by another user, returning a 423 Locked response.
+  - Added unit tests to ensure correct locking behavior for survey resources.
+
 ## August 4, 2026
 
 - **Feature** Add API-side locking to Engagements and related resources [🎟️ DEP-282](https://citz-gdx.atlassian.net/browse/DEP-282)

--- a/api/sample.env
+++ b/api/sample.env
@@ -21,9 +21,10 @@ USE_TEST_KEYCLOAK_DOCKER=false
 USE_DOCKER_MOCK=false
 LEGISLATIVE_TIMEZONE="America/Vancouver"
 ENGAGEMENT_END_TIME="5 PM"
-# Feature flag: enable lock-token validation for PATCH /engagements.
-# Keep false until admin UI lock acquire/refresh/release UX is fully integrated.
+# Feature flag: enable lock-token validation for engagements and surveys.
+# Keep each false until corresponding admin UI lock acquire/refresh/release UX is fully integrated.
 ENGAGEMENT_LOCK_VALIDATION_ENABLED=false
+SURVEY_LOCK_VALIDATION_ENABLED=false
 # Default name for the tenant. Used to initially populate the database.
 DEFAULT_TENANT_SHORT_NAME="GDX"
 DEFAULT_TENANT_NAME="Government Digital Experience Division"

--- a/api/src/api/config.py
+++ b/api/src/api/config.py
@@ -185,6 +185,10 @@ class Config:  # pylint: disable=too-few-public-methods
     ENGAGEMENT_LOCK_VALIDATION_ENABLED = env_truthy(
         'ENGAGEMENT_LOCK_VALIDATION_ENABLED', default=False)
 
+    # Feature flag: when enabled, survey builder/report-setting writes require lock validation.
+    SURVEY_LOCK_VALIDATION_ENABLED = env_truthy(
+        'SURVEY_LOCK_VALIDATION_ENABLED', default=False)
+
     EPIC_CONFIG = {
         'ENABLED': env_truthy('EPIC_INTEGRATION_ENABLED'),
         'JWT_OIDC_ISSUER': os.getenv('EPIC_JWT_OIDC_ISSUER'),

--- a/api/src/api/resources/lock_validation_decorators.py
+++ b/api/src/api/resources/lock_validation_decorators.py
@@ -221,3 +221,76 @@ def require_widget_translation_lock_by_id(
         return wrapper
 
     return decorator
+
+
+def require_survey_section_lock(
+    *,
+    section_key: str,
+    survey_id_kwarg: str = 'survey_id',
+    error_builder: LockErrorBuilder = lock_error_raw,
+) -> Callable:
+    """Validate a survey section lock for route-scoped operations.
+
+    Reads survey_id from URL kwargs by default; pass survey_id_kwarg to override.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            survey_id = kwargs.get(survey_id_kwarg)
+            user_id = TokenInfo.get_id()
+            try:
+                ResourceLockService.validate_survey_section_lock(
+                    survey_id=survey_id,
+                    section_key=section_key,
+                    lock_token=request.headers.get(
+                        ResourceLockService.LOCK_HEADER_NAME),
+                    owner_user_sub=user_id,
+                )
+            except BusinessException as err:
+                return error_builder(err)
+
+            g.lock_validation_user_id = user_id
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def require_survey_builder_lock(func: Callable) -> Callable:
+    """Validate survey builder lock for PUT /surveys/ before calling the handler.
+
+    Reads survey id from the JSON body since the PUT route has no URL id param.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        request_json = request.get_json()
+        if not isinstance(request_json, dict):
+            return 'Invalid survey payload', HTTPStatus.BAD_REQUEST
+
+        survey_id = request_json.get('id')
+        if isinstance(survey_id, str) and survey_id.isdigit():
+            survey_id = int(survey_id)
+
+        if not isinstance(survey_id, int):
+            return 'Survey id is required', HTTPStatus.BAD_REQUEST
+
+        user_id = TokenInfo.get_id()
+        try:
+            ResourceLockService.validate_survey_section_lock(
+                survey_id=survey_id,
+                section_key=ResourceLockService.SECTION_SURVEY_BUILDER,
+                lock_token=request.headers.get(
+                    ResourceLockService.LOCK_HEADER_NAME),
+                owner_user_sub=user_id,
+            )
+        except BusinessException as err:
+            return err.error, err.status_code
+
+        g.survey_builder_payload = request_json
+        g.lock_validation_user_id = user_id
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/api/src/api/resources/report_setting.py
+++ b/api/src/api/resources/report_setting.py
@@ -22,7 +22,9 @@ from marshmallow import ValidationError
 
 from api.auth import auth
 from api.auth import jwt as _jwt
+from api.resources.lock_validation_decorators import require_survey_section_lock
 from api.services.report_setting_service import ReportSettingService
+from api.services.resource_lock_service import ResourceLockService
 from api.utils.util import allowedorigins, cors_preflight
 
 
@@ -54,9 +56,11 @@ class ReportSetting(Resource):
             return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
 
     @staticmethod
-    # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
     @_jwt.requires_auth
+    @require_survey_section_lock(
+        section_key=ResourceLockService.SECTION_SURVEY_REPORT_SETTINGS,
+    )
     def patch(survey_id):
         """Update saved report setting partially."""
         try:

--- a/api/src/api/resources/survey.py
+++ b/api/src/api/resources/survey.py
@@ -15,7 +15,7 @@
 
 from http import HTTPStatus
 
-from flask import request
+from flask import g, request
 from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
@@ -24,6 +24,7 @@ from api.auth import jwt as _jwt
 from api.exceptions.business_exception import BusinessException
 from api.models.pagination_options import PaginationOptions
 from api.models.survey_search_options import SurveySearchOptions
+from api.resources.lock_validation_decorators import require_survey_builder_lock
 from api.schemas.survey import SurveySchema
 from api.services.survey_service import SurveyService
 from api.utils.roles import Role
@@ -132,12 +133,13 @@ class Surveys(Resource):
     @staticmethod
     @cross_origin(origins=allowedorigins())
     @_jwt.requires_auth
+    @require_survey_builder_lock
     def put():
         """Update a existing survey."""
         try:
-            requestjson = request.get_json()
+            requestjson = dict(g.survey_builder_payload)
             survey_schema = SurveySchema().load(requestjson)
-            user_id = TokenInfo.get_id()
+            user_id = g.lock_validation_user_id
             survey_schema['updated_by'] = user_id
             SurveyService().update(survey_schema)
             return survey_schema, HTTPStatus.OK

--- a/api/src/api/services/resource_lock_service.py
+++ b/api/src/api/services/resource_lock_service.py
@@ -24,9 +24,11 @@ class ResourceLockService:
 
     LOCK_HEADER_NAME = 'X-Resource-Lock-Token'
     ENGAGEMENT_PATCH_VALIDATION_FLAG = 'ENGAGEMENT_LOCK_VALIDATION_ENABLED'
+    SURVEY_LOCK_VALIDATION_FLAG = 'SURVEY_LOCK_VALIDATION_ENABLED'
     DEFAULT_TTL_SECONDS = 90
 
     RESOURCE_TYPE_ENGAGEMENT_SECTION = 'engagement_section'
+    RESOURCE_TYPE_SURVEY = 'survey'
 
     SECTION_AUTHORING_BANNER = 'authoring.banner'
     SECTION_AUTHORING_SUMMARY = 'authoring.summary'
@@ -35,6 +37,9 @@ class ResourceLockService:
     SECTION_AUTHORING_SUBSCRIBE = 'authoring.subscribe'
     SECTION_AUTHORING_MORE = 'authoring.more'
     SECTION_CONFIG_GENERAL = 'config.general'
+
+    SECTION_SURVEY_BUILDER = 'survey.builder'
+    SECTION_SURVEY_REPORT_SETTINGS = 'survey.report_settings'
 
     WIDGET_LOCATION_SUMMARY = 1
     WIDGET_LOCATION_DETAILS = 2
@@ -877,6 +882,38 @@ class ResourceLockService:
             return False
 
         return bool(current_app.config.get(cls.ENGAGEMENT_PATCH_VALIDATION_FLAG, False))
+
+    @classmethod
+    def is_survey_lock_validation_enabled(cls) -> bool:
+        """Feature flag gate for survey lock enforcement."""
+        if not has_app_context():
+            return False
+
+        return bool(current_app.config.get(cls.SURVEY_LOCK_VALIDATION_FLAG, False))
+
+    @classmethod
+    def validate_survey_section_lock(  # pylint: disable=too-many-arguments
+        cls,
+        *,
+        survey_id: int,
+        section_key: str,
+        lock_token: Optional[str],
+        owner_user_sub: str,
+    ) -> Optional[ResourceLock]:
+        """Validate a lock token for a survey section scope."""
+        if not cls.is_survey_lock_validation_enabled():
+            return None
+
+        expected_scope = cls.build_scope_key(
+            cls.RESOURCE_TYPE_SURVEY,
+            survey_id,
+            section_key,
+        )
+        return cls._validate_lock_for_scope(
+            expected_scope=expected_scope,
+            lock_token=lock_token,
+            owner_user_sub=owner_user_sub,
+        )
 
     @classmethod
     def _serialize_lock(cls, lock: ResourceLock, is_mine: bool = False) -> dict[str, Any]:

--- a/api/tests/unit/api/test_lock_validation_decorators.py
+++ b/api/tests/unit/api/test_lock_validation_decorators.py
@@ -312,8 +312,10 @@ def test_require_survey_builder_lock():
     with app.test_request_context(
         '/resource',
         method='POST',
-        headers={ResourceLockService.LOCK_HEADER_NAME: 'lock-token-1',
-                 "Content-Type": "application/json"},
+        headers={
+            ResourceLockService.LOCK_HEADER_NAME: 'lock-token-1',
+            'Content-Type': 'application/json'
+        },
         json={'id': 123}
     ):
         with patch('api.resources.lock_validation_decorators.TokenInfo.get_id', return_value='user-1'):

--- a/api/tests/unit/api/test_lock_validation_decorators.py
+++ b/api/tests/unit/api/test_lock_validation_decorators.py
@@ -23,7 +23,8 @@ from flask import Flask, g
 
 from api.exceptions.business_exception import BusinessException
 from api.resources.lock_validation_decorators import (
-    require_engagement_content_translation_lock, require_widget_translation_lock, require_widget_translation_lock_by_id)
+    require_engagement_content_translation_lock, require_survey_builder_lock, require_survey_section_lock,
+    require_widget_translation_lock, require_widget_translation_lock_by_id)
 from api.services.resource_lock_service import ResourceLockService
 
 
@@ -237,3 +238,123 @@ def test_require_widget_translation_lock_by_id_business_exception():
 
     assert status == HTTPStatus.FORBIDDEN
     assert response == {'code': 'forbidden', 'message': 'not lock owner'}
+
+
+def test_require_survey_section_lock():
+    """Assert decorator validates survey section lock."""
+    app = Flask(__name__)
+
+    @require_survey_section_lock(section_key='survey_section_1')
+    def handler(survey_id):
+        return {
+            'survey_id': survey_id,
+            'user_id': g.lock_validation_user_id,
+        }, HTTPStatus.OK
+
+    with app.test_request_context(
+        '/resource',
+        method='POST',
+        headers={ResourceLockService.LOCK_HEADER_NAME: 'lock-token-1'},
+    ):
+        with patch('api.resources.lock_validation_decorators.TokenInfo.get_id', return_value='user-1'):
+            with patch.object(ResourceLockService, 'validate_survey_section_lock') as validate_mock:
+                response, status = handler(survey_id=123)
+
+    assert status == HTTPStatus.OK
+    assert response['survey_id'] == 123
+    assert response['user_id'] == 'user-1'
+    validate_mock.assert_called_once_with(
+        survey_id=123,
+        section_key='survey_section_1',
+        lock_token='lock-token-1',
+        owner_user_sub='user-1',
+    )
+
+
+def test_require_survey_section_lock_business_exception():
+    """Assert decorator returns raw business error payload for survey section lock errors."""
+    app = Flask(__name__)
+
+    @require_survey_section_lock(section_key='survey_section_1')
+    def handler(survey_id):
+        return {'survey_id': survey_id}, HTTPStatus.OK
+
+    with app.test_request_context(
+        '/resource',
+        method='POST',
+        headers={ResourceLockService.LOCK_HEADER_NAME: 'lock-token-1'},
+    ):
+        with patch('api.resources.lock_validation_decorators.TokenInfo.get_id', return_value='user-1'):
+            with patch.object(
+                ResourceLockService,
+                'validate_survey_section_lock',
+                side_effect=BusinessException(
+                    error={'code': 'lock_conflict', 'message': 'locked'},
+                    status_code=HTTPStatus.CONFLICT,
+                ),
+            ):
+                response, status = handler(survey_id=123)
+
+    assert status == HTTPStatus.CONFLICT
+    assert response == {'code': 'lock_conflict', 'message': 'locked'}
+
+
+def test_require_survey_builder_lock():
+    """Assert decorator validates survey builder lock."""
+    app = Flask(__name__)
+
+    @require_survey_builder_lock
+    def handler(survey_id):
+        return {
+            'survey_id': survey_id,
+            'user_id': g.lock_validation_user_id,
+        }, HTTPStatus.OK
+    with app.test_request_context(
+        '/resource',
+        method='POST',
+        headers={ResourceLockService.LOCK_HEADER_NAME: 'lock-token-1',
+                 "Content-Type": "application/json"},
+        json={'id': 123}
+    ):
+        with patch('api.resources.lock_validation_decorators.TokenInfo.get_id', return_value='user-1'):
+            with patch.object(ResourceLockService, 'validate_survey_section_lock') as validate_mock:
+                response, status = handler(survey_id=123)
+
+    assert status == HTTPStatus.OK
+    assert response['survey_id'] == 123
+    assert response['user_id'] == 'user-1'
+    validate_mock.assert_called_once_with(
+        survey_id=123,
+        section_key=ResourceLockService.SECTION_SURVEY_BUILDER,
+        lock_token='lock-token-1',
+        owner_user_sub='user-1',
+    )
+
+
+def test_require_survey_builder_lock_business_exception():
+    """Assert decorator returns raw business error payload for survey builder lock errors."""
+    app = Flask(__name__)
+
+    @require_survey_builder_lock
+    def handler(survey_id):
+        return {'survey_id': survey_id}, HTTPStatus.OK
+
+    with app.test_request_context(
+        '/resource',
+        method='POST',
+        headers={ResourceLockService.LOCK_HEADER_NAME: 'lock-token-1'},
+        json={'id': 123}
+    ):
+        with patch('api.resources.lock_validation_decorators.TokenInfo.get_id', return_value='user-1'):
+            with patch.object(
+                ResourceLockService,
+                'validate_survey_section_lock',
+                side_effect=BusinessException(
+                    error={'code': 'lock_conflict', 'message': 'locked'},
+                    status_code=HTTPStatus.CONFLICT,
+                ),
+            ):
+                response, status = handler(survey_id=123)
+
+    assert status == HTTPStatus.CONFLICT
+    assert response == {'code': 'lock_conflict', 'message': 'locked'}

--- a/api/tests/unit/api/test_report_setting.py
+++ b/api/tests/unit/api/test_report_setting.py
@@ -35,7 +35,8 @@ from tests.utilities.factory_utils import (
 ])
 def test_get_report_setting(client, jwt, session, side_effect, expected_status):  # pylint:disable=unused-argument
     """Assert that report setting can be fetched."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    headers = factory_auth_header(
+        jwt=jwt, claims=TestJwtClaims.staff_admin_role)
     survey, _ = factory_survey_and_eng_model(TestSurveyInfo.survey3)
 
     report_setting_data = {
@@ -65,9 +66,11 @@ def test_get_report_setting(client, jwt, session, side_effect, expected_status):
     (KeyError('Test error'), HTTPStatus.INTERNAL_SERVER_ERROR),
     (ValueError('Test error'), HTTPStatus.INTERNAL_SERVER_ERROR),
 ])
-def test_patch_report_setting(client, jwt, session, side_effect, expected_status):  # pylint:disable=unused-argument
+def test_patch_report_setting(client, jwt, session, side_effect, expected_status,
+                              setup_admin_user_and_claims):  # pylint:disable=unused-argument
     """Assert that report setting can be PATCHed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    _, claims = setup_admin_user_and_claims
+    headers = factory_auth_header(jwt=jwt, claims=claims)
     survey, _ = factory_survey_and_eng_model(TestSurveyInfo.survey3)
 
     report_setting_data = {


### PR DESCRIPTION
Issue #: [🎟️ DEP-283](https://citz-gdx.atlassian.net/browse/DEP-283)

**Description of changes:**
- **Feature** Added API-side locking to Surveys
  - Updated resource_lock_service to allow locks on Survey resources, including the Survey Builder and other settings sections.
  - Updated the Survey endpoints to prevent updates if a survey is locked by another user, returning a 423 Locked response.
  - Added unit tests to ensure correct locking behavior for survey resources.

**User Guide update ticket (if applicable):**

- - [ ] Yes, a user guide update ticket has been created. _(Link to ticket)_
- - [x] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
