### PR TITLE
DEP-284: Add engagement locking to web app

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,10 +1,16 @@
+## August 8, 2026
+
+- **Feature** Added engagement locking UX for Engagements [🎟️ DEP-284](https://citz-gdx.atlassian.net/browse/DEP-284)
+  - Implemented resource lock related routes, types, and services for components in the DEP web app to consume
+  - Updated navigation in the engagement config and authoring pages to check for active locks on the engagement resource before allowing navigation to other sections. If a lock is detected, the user is shown a modal informing them that the engagement is locked by another user and cannot be edited.
+
 ## August 7, 2026
 
 - **Feature** Added some fixes to prepare for the new search/filter system [🎟️ DEP-316](https://citz-gdx.atlassian.net/browse/DEP-316)
-    - Fixed metadata and engagement parsing logic in landing loader
-    - Removed unneeded revalidation hook that was causing double engagement results loading
-    - Fixed API logic for engagement status filter in engagement model
-    - Moved EngagementSearch components to a separate subfolder within landing folder for better organization
+  - Fixed metadata and engagement parsing logic in landing loader
+  - Removed unneeded revalidation hook that was causing double engagement results loading
+  - Fixed API logic for engagement status filter in engagement model
+  - Moved EngagementSearch components to a separate subfolder within landing folder for better organization
 
 ## August 5, 2026
 

--- a/api/src/api/models/resource_lock.py
+++ b/api/src/api/models/resource_lock.py
@@ -112,6 +112,21 @@ class ResourceLock(BaseModel):
         ).all()
 
     @classmethod
+    def find_active_by_section(
+        cls,
+        resource_type: str,
+        resource_id: int,
+        section_key: str,
+    ) -> list['ResourceLock']:
+        """Return active locks for a section, across all languages including unscoped locks."""
+        return cls.query.filter_by(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            section_key=section_key,
+            released_at=None,
+        ).all()
+
+    @classmethod
     def find_unexpired_by_token(cls, lock_token: str) -> Optional['ResourceLock']:
         """Return an unexpired lock row by lock token, if still active."""
         return cls.query.filter(

--- a/api/src/api/services/resource_lock_service.py
+++ b/api/src/api/services/resource_lock_service.py
@@ -1,4 +1,5 @@
 """Service for resource lock management."""
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 
@@ -8,12 +9,13 @@ from typing import Any, NoReturn, Optional
 from uuid import UUID, uuid4
 
 from flask import current_app, has_app_context
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, ResourceClosedError
 
 from api.exceptions.business_exception import BusinessException
 from api.models.db import db
 from api.models.engagement_translation import EngagementTranslation as EngagementTranslationModel
 from api.models.resource_lock import ResourceLock
+from api.models.staff_user import StaffUser
 from api.models.widget import Widget as WidgetModel
 from api.models.widget_translation import WidgetTranslation as WidgetTranslationModel
 from api.utils.datetime import utc_now
@@ -26,6 +28,7 @@ class ResourceLockService:
     ENGAGEMENT_PATCH_VALIDATION_FLAG = 'ENGAGEMENT_LOCK_VALIDATION_ENABLED'
     SURVEY_LOCK_VALIDATION_FLAG = 'SURVEY_LOCK_VALIDATION_ENABLED'
     DEFAULT_TTL_SECONDS = 90
+    RESOURCE_LOCK_CONFLICT_MESSAGE = 'Resource section is locked by another editor'
 
     RESOURCE_TYPE_ENGAGEMENT_SECTION = 'engagement_section'
     RESOURCE_TYPE_SURVEY = 'survey'
@@ -34,6 +37,7 @@ class ResourceLockService:
     SECTION_AUTHORING_SUMMARY = 'authoring.summary'
     SECTION_AUTHORING_DETAILS = 'authoring.details'
     SECTION_AUTHORING_FEEDBACK = 'authoring.feedback'
+    SECTION_AUTHORING_RESULTS = 'authoring.results'
     SECTION_AUTHORING_SUBSCRIBE = 'authoring.subscribe'
     SECTION_AUTHORING_MORE = 'authoring.more'
     SECTION_CONFIG_GENERAL = 'config.general'
@@ -63,6 +67,7 @@ class ResourceLockService:
     PATCH_SECTION_FIELDS = {
         SECTION_AUTHORING_BANNER: {
             'status_block',
+            'sponsor_name',
             'banner_filename',
         },
         SECTION_AUTHORING_FEEDBACK: {
@@ -111,6 +116,8 @@ class ResourceLockService:
             'feedback_heading',
             'feedback_body',
         },
+        SECTION_AUTHORING_RESULTS: {
+        },
         SECTION_AUTHORING_SUBSCRIBE: {
             'subscribe_section_heading',
             'subscribe_section_description',
@@ -158,13 +165,52 @@ class ResourceLockService:
         if lock_scope:
             error['lock_scope'] = lock_scope
         if lock:
-            error['owner'] = {
-                'user_sub': lock.owner_user_sub,
-                'display_name': lock.owner_display_name,
-            }
+            error['owner'] = cls._serialize_owner(
+                user_sub=lock.owner_user_sub,
+                owner_display_name=lock.owner_display_name,
+            )
             error['expires_at'] = lock.expires_at.isoformat(
             ) if lock.expires_at else None
         raise BusinessException(error=error, status_code=status_code)
+
+    @classmethod
+    def _resolve_owner_name_parts(
+        cls,
+        *,
+        user_sub: Optional[str],
+    ) -> tuple[Optional[str], Optional[str]]:
+        if not user_sub:
+            return None, None
+        try:
+            staff_user = StaffUser.get_user_by_external_id(
+                user_sub,
+                include_inactive=True,
+            )
+        except ResourceClosedError:
+            return None, None
+        if not staff_user:
+            return None, None
+        return staff_user.first_name, staff_user.last_name
+
+    @classmethod
+    def _serialize_owner(
+        cls,
+        *,
+        user_sub: Optional[str],
+        owner_display_name: Optional[str],
+    ) -> dict[str, Optional[str]]:
+        first, last = cls._resolve_owner_name_parts(user_sub=user_sub)
+        resolved_display_name = owner_display_name
+        if not resolved_display_name:
+            full_name = ' '.join(part for part in [first, last] if part)
+            resolved_display_name = full_name or None
+
+        return {
+            'user_sub': user_sub,
+            'display_name': resolved_display_name,
+            'first_name': first,
+            'last_name': last,
+        }
 
     @classmethod
     def _business_error(
@@ -599,6 +645,34 @@ class ResourceLockService:
         )
 
     @classmethod
+    def _find_cross_scope_conflict(  # pylint: disable=too-many-arguments
+        cls,
+        *,
+        resource_type: str,
+        resource_id: int,
+        section_key: Optional[str],
+        language_id: Optional[int],
+        owner_user_sub: str,
+    ) -> Optional[ResourceLock]:
+        """Find another editor's lock on the same section that should block this acquisition.
+
+        An unscoped (whole-section) lock and a per-language lock have distinct scope keys, so they
+        would not otherwise conflict. An unscoped lock must still be mutually exclusive with every
+        per-language lock for that section (and vice versa), since it represents structural changes
+        that affect all languages.
+        """
+        if not section_key:
+            return None
+
+        for lock in ResourceLock.find_active_by_section(resource_type, resource_id, section_key):
+            if lock.owner_user_sub == owner_user_sub:
+                continue
+            if language_id is None or lock.language_id is None:
+                return lock
+
+        return None
+
+    @classmethod
     def acquire_lock(  # pylint: disable=too-many-arguments,too-many-locals
         cls,
         *,
@@ -627,6 +701,21 @@ class ResourceLockService:
         expires_at = now + timedelta(seconds=ttl)
         lock_scope = cls.build_scope_key(
             resource_type, resource_id, section_key, language_id)
+
+        cross_scope_conflict = cls._find_cross_scope_conflict(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            section_key=section_key,
+            language_id=language_id,
+            owner_user_sub=owner_user_sub,
+        )
+        if cross_scope_conflict:
+            cls._lock_error(
+                code='lock_conflict',
+                message=cls.RESOURCE_LOCK_CONFLICT_MESSAGE,
+                lock_scope=lock_scope,
+                lock=cross_scope_conflict,
+            )
 
         active = ResourceLock.find_active_by_scope(lock_scope)
         existing_lock_response = cls._handle_existing_lock_on_acquire(
@@ -667,7 +756,7 @@ class ResourceLockService:
                 return cls._serialize_lock(conflict, is_mine=True)
             cls._lock_error(
                 code='lock_conflict',
-                message='Resource section is locked by another editor',
+                message=cls.RESOURCE_LOCK_CONFLICT_MESSAGE,
                 lock_scope=lock_scope,
                 lock=conflict,
             )
@@ -697,7 +786,7 @@ class ResourceLockService:
 
             cls._lock_error(
                 code='lock_conflict',
-                message='Resource section is locked by another editor',
+                message=cls.RESOURCE_LOCK_CONFLICT_MESSAGE,
                 lock_scope=lock_scope,
                 lock=active,
             )
@@ -924,10 +1013,10 @@ class ResourceLockService:
             'resource_id': lock.resource_id,
             'section_key': lock.section_key,
             'language_id': lock.language_id,
-            'owner': {
-                'user_sub': lock.owner_user_sub,
-                'display_name': lock.owner_display_name,
-            },
+            'owner': cls._serialize_owner(
+                user_sub=lock.owner_user_sub,
+                owner_display_name=lock.owner_display_name,
+            ),
             'owner_session_id': str(lock.owner_session_id),
             'acquired_at': lock.acquired_at.isoformat() if lock.acquired_at else None,
             'heartbeat_at': lock.heartbeat_at.isoformat() if lock.heartbeat_at else None,

--- a/docs/Engagement_and_Survey_Locking_Design.md
+++ b/docs/Engagement_and_Survey_Locking_Design.md
@@ -22,16 +22,16 @@ This design is intended to support locking Engagements by section, non-authoring
 
 ## Current implementation state
 
-- [-] API updates
+- [x] API updates
   - [x] resource_lock table
   - [x] LockService for acquire/refresh/release and validation
   - [x] Validation on write for Engagement endpoints
-  - [ ] Validation on write for Survey endpoints
-- [ ] Frontend updates
-  - [ ] Engagement
-    - [ ] Authoring sections
-    - [ ] Display in authoring tab overview cards
-    - [ ] Non-authoring config
+  - [x] Validation on write for Survey endpoints
+- [-] Frontend updates
+  - [x] Engagement
+    - [x] Authoring sections
+    - [x] Display in authoring tab overview cards
+    - [x] Non-authoring config
   - [ ] Survey builder
   - [ ] Survey report settings
 

--- a/web/src/apiManager/endpoints/index.ts
+++ b/web/src/apiManager/endpoints/index.ts
@@ -6,8 +6,14 @@ const Endpoints = {
         CREATE: `${AppConfig.apiUrl}/engagements/`,
         UPDATE: `${AppConfig.apiUrl}/engagements/`,
         GET: `${AppConfig.apiUrl}/engagements/engagement_id`,
+        GET_LOCKS: `${AppConfig.apiUrl}/engagements/engagement_id/locks`,
         GET_BY_SLUG: `${AppConfig.apiUrl}/engagements/slug/eng_slug`,
         DELETE: `${AppConfig.apiUrl}/engagements/engagement_id/delete`,
+    },
+    ResourceLocks: {
+        ACQUIRE: `${AppConfig.apiUrl}/locks/acquire`,
+        REFRESH: `${AppConfig.apiUrl}/locks/refresh`,
+        RELEASE: `${AppConfig.apiUrl}/locks/release`,
     },
     EngagementTranslations: {
         GET_TRANSLATION_LANGUAGES: `${AppConfig.apiUrl}/engagement/engagement_id/translations/languages`,

--- a/web/src/apiManager/httpRequestHandler/index.ts
+++ b/web/src/apiManager/httpRequestHandler/index.ts
@@ -38,34 +38,37 @@ const PostRequest = <T>(url: string, data = {}, params = {}, headers = {}) => {
     });
 };
 
-const PutRequest = <T>(url: string, data = {}, params = {}) => {
+const PutRequest = <T>(url: string, data = {}, params = {}, headers = {}) => {
     return axios.put<T>(url, data, {
         params,
         headers: {
             'Content-type': 'application/json',
             Authorization: `Bearer ${UserService.getToken()}`,
             'tenant-id': `${sessionStorage.getItem('tenantId')}`,
+            ...headers,
         },
     });
 };
 
-const PatchRequest = <T>(url: string, data = {}) => {
+const PatchRequest = <T>(url: string, data = {}, headers = {}) => {
     return axios.patch<T>(url, data, {
         headers: {
             'Content-type': 'application/json',
             Authorization: `Bearer ${UserService.getToken()}`,
             'tenant-id': `${sessionStorage.getItem('tenantId')}`,
+            ...headers,
         },
     });
 };
 
-const DeleteRequest = <T>(url: string, params = {}) => {
+const DeleteRequest = <T>(url: string, params = {}, headers = {}) => {
     return axios.delete<T>(url, {
         params: params,
         headers: {
             'Content-type': 'application/json',
             Authorization: `Bearer ${UserService.getToken()}`,
             'tenant-id': `${sessionStorage.getItem('tenantId')}`,
+            ...headers,
         },
     });
 };

--- a/web/src/components/common/dateHelper.tsx
+++ b/web/src/components/common/dateHelper.tsx
@@ -29,3 +29,31 @@ export const formatToUTC = (date: Dayjs | string, formatString = 'YYYY-MM-DD HH:
         return '';
     }
 };
+
+export const formatRelative = (date: Dayjs | string) => {
+    const intervals = [
+        { label: 'year', seconds: 31536000 },
+        { label: 'month', seconds: 2592000 },
+        { label: 'day', seconds: 86400 },
+        { label: 'hour', seconds: 3600 },
+        { label: 'minute', seconds: 60 },
+        { label: 'second', seconds: 1 },
+    ];
+
+    const now = convertToPacific(dayjs().toString());
+    const targetDate = convertToPacific(date.toString());
+    const secondsElapsed = now.diff(targetDate, 'second');
+    const isFuture = secondsElapsed < 0;
+
+    const absSecondsElapsed = Math.abs(secondsElapsed);
+
+    for (const interval of intervals) {
+        const count = Math.floor(absSecondsElapsed / interval.seconds);
+        const pluralS = count > 1 ? 's' : '';
+        if (count >= 1) {
+            return isFuture ? `in ${count} ${interval.label}${pluralS}` : `${count} ${interval.label}${pluralS} ago`;
+        }
+    }
+
+    return 'just now';
+};

--- a/web/src/components/engagement/admin/EngagementLoaderAdmin.tsx
+++ b/web/src/components/engagement/admin/EngagementLoaderAdmin.tsx
@@ -11,9 +11,11 @@ import { getDetailsTabs } from 'services/engagementDetailsTabService';
 import { Language } from 'models/language';
 import { AppConfig } from 'config';
 import { ROUTES, getPath } from 'routes/routes';
+import { getEngagementLocks, ResourceLocksForEngagement } from 'services/resourceLockService';
 
 export type EngagementLoaderAdminData = {
     engagement: Promise<Engagement>;
+    locks: Promise<ResourceLocksForEngagement>;
     widgets: Promise<Widget[]>;
     details: Promise<EngagementDetailsTab[]>;
     metadata: Promise<EngagementMetadata[]>;
@@ -57,6 +59,7 @@ export const engagementLoaderAdmin = async ({ params }: LoaderFunctionArgs) => {
     });
     const widgets = engagement.then((response) => getWidgets(Number(response.id)));
     const details = engagement.then((response) => getDetailsTabs(response.id));
+    const locks = engagement.then((response) => getEngagementLocks(response.id));
     const engagementMetadata = engagement.then((response) => getEngagementMetadata(Number(response.id)));
     const taxaData = getMetadataTaxa();
     const teamMembers = engagement.then((response) => getTeamMembers({ engagement_id: response.id }).catch(() => []));
@@ -77,6 +80,7 @@ export const engagementLoaderAdmin = async ({ params }: LoaderFunctionArgs) => {
 
     return {
         engagement,
+        locks,
         widgets,
         details,
         metadata,

--- a/web/src/components/engagement/admin/config/EngagementUpdateAction.tsx
+++ b/web/src/components/engagement/admin/config/EngagementUpdateAction.tsx
@@ -3,6 +3,7 @@ import { ENGAGEMENT_MEMBERSHIP_STATUS } from 'models/engagementTeamMember';
 import { ActionFunction, redirect } from 'react-router';
 import { ApiErrorBody, patchEngagement } from 'services/engagementService';
 import { openNotification } from 'services/notificationService/notificationSlice';
+import { LOCK_TOKEN_HEADER } from 'services/resourceLockService';
 import {
     addTeamMemberToEngagement,
     revokeMembership,
@@ -35,16 +36,22 @@ const getLanguageCodes = (formData: FormData): string[] => {
 export const engagementUpdateAction: ActionFunction = async ({ request, params }) => {
     const formData = await request.formData();
     const engagementId = Number(params.engagementId);
+    const lockToken = formData.get('lock_token');
+    const requestHeaders: Record<string, string> | undefined =
+        typeof lockToken === 'string' && lockToken ? { [LOCK_TOKEN_HEADER]: lockToken } : undefined;
     try {
-        await patchEngagement({
-            id: engagementId,
-            slug: formData.get('slug') as string,
-            name: formData.get('name') as string,
-            start_date: formData.get('start_date') as string,
-            end_date: formData.get('end_date') as string,
-            is_internal: formData.get('is_internal') === 'true',
-            languages: getLanguageCodes(formData),
-        });
+        await patchEngagement(
+            {
+                id: engagementId,
+                slug: formData.get('slug') as string,
+                name: formData.get('name') as string,
+                start_date: formData.get('start_date') as string,
+                end_date: formData.get('end_date') as string,
+                is_internal: formData.get('is_internal') === 'true',
+                languages: getLanguageCodes(formData),
+            },
+            requestHeaders,
+        );
     } catch (e) {
         const message = getUpdateFailureMessage(e);
         console.error('Error updating engagement:', e);
@@ -57,6 +64,7 @@ export const engagementUpdateAction: ActionFunction = async ({ request, params }
     const usersSet = new Set(users);
 
     try {
+        const membershipUpdates: Promise<unknown>[] = [];
         // Process deactivated users for reinstatement (and active users for revocation)
         // Caution - headaches ahead! There is a big difference between user_id and user.external_id
         for (const member of currentTeamMembers) {
@@ -64,11 +72,11 @@ export const engagementUpdateAction: ActionFunction = async ({ request, params }
             if (member.status !== ENGAGEMENT_MEMBERSHIP_STATUS.Active) {
                 if (isUserInForm) {
                     // If the user was previously deactivated, reinstate them
-                    reinstateMembership(engagementId, member.user_id);
+                    membershipUpdates.push(reinstateMembership(engagementId, member.user_id));
                 }
             } else if (!isUserInForm) {
                 // If the user was previously active but is not in the form, revoke their membership
-                revokeMembership(engagementId, member.user_id);
+                membershipUpdates.push(revokeMembership(engagementId, member.user_id));
             }
 
             // Remove all known users from the set so we can add new members in the next step
@@ -76,8 +84,10 @@ export const engagementUpdateAction: ActionFunction = async ({ request, params }
         }
         // Add new members that weren't in the current team members list
         for (const user of usersSet) {
-            addTeamMemberToEngagement({ user_id: user, engagement_id: engagementId });
+            membershipUpdates.push(addTeamMemberToEngagement({ user_id: user, engagement_id: engagementId }));
         }
+
+        await Promise.all(membershipUpdates);
     } catch (e) {
         console.error('Error updating team members', e);
     }

--- a/web/src/components/engagement/admin/config/wizard/ConfigWizard.tsx
+++ b/web/src/components/engagement/admin/config/wizard/ConfigWizard.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect } from 'react';
-import { useFetcher, createSearchParams, useRouteLoaderData, Await } from 'react-router';
+import { useFetcher, createSearchParams, useNavigate, useRouteLoaderData, Await } from 'react-router';
 import { FormProvider, useForm } from 'react-hook-form';
 import EngagementForm, { EngagementConfigurationData } from '.';
 import { EngagementLoaderAdminData } from 'engagements/admin/EngagementLoaderAdmin';
@@ -10,6 +10,12 @@ import { Language } from 'models/language';
 import { Grid2 as Grid, Skeleton } from '@mui/material';
 import { ROUTES, getPath } from 'routes/routes';
 import { formatToUTC, convertToPacific } from 'components/common/dateHelper';
+import { useAppDispatch } from 'hooks';
+import { openNotification } from 'services/notificationService/notificationSlice';
+import { SECTION_CONFIG_GENERAL, findScopedSectionLock, getLockConflictPayload } from 'services/resourceLockService';
+import useEngagementSectionEditLock from 'services/resourceLockService/useEngagementSectionEditLock';
+import { useEngagementLocks } from 'services/resourceLockService/useEngagementLocks';
+import useAuthoringSectionLockNavigation from 'components/engagement/admin/create/authoring/useAuthoringSectionLockNavigation';
 
 const EngagementConfigurationWizard = () => {
     const loaderData = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
@@ -53,6 +59,8 @@ const ConfigForm = ({
     languages: Language[];
 }) => {
     const fetcher = useFetcher();
+    const navigate = useNavigate();
+    const dispatch = useAppDispatch();
     const start = convertToPacific(engagement.start_date);
     const end = convertToPacific(engagement.end_date);
     const engagementConfigForm = useForm<EngagementConfigurationData>({
@@ -88,6 +96,7 @@ const ConfigForm = ({
                 is_internal: data.is_internal ? 'true' : 'false',
                 slug: data.slug,
                 users: data.users.map((u) => u.external_id),
+                lock_token: activeLockToken ?? '',
             }),
             {
                 method: 'patch',
@@ -97,20 +106,80 @@ const ConfigForm = ({
     };
 
     const {
-        getValues,
         reset,
-        formState: { defaultValues },
+        formState: { defaultValues, isDirty, isSubmitting },
     } = engagementConfigForm;
+    const { locks, refreshLocks } = useEngagementLocks({
+        engagementId: engagement.id,
+        initialLocksPromise: (useRouteLoaderData('single-engagement') as EngagementLoaderAdminData).locks,
+    });
+    const conflictingConfigLock = React.useMemo(() => {
+        const configLock = findScopedSectionLock({
+            locks,
+            sectionKey: SECTION_CONFIG_GENERAL,
+            languageScoped: false,
+        });
+
+        if (!configLock || configLock.is_mine) {
+            return null;
+        }
+
+        return configLock;
+    }, [locks]);
+
+    const { activeLockToken } = useEngagementSectionEditLock({
+        engagementId: engagement.id,
+        scope: { sectionKey: SECTION_CONFIG_GENERAL },
+        enabled: true,
+        isDirty,
+        isSubmitting,
+        blockedByLock: conflictingConfigLock,
+        onConflict: async (error) => {
+            const conflictPayload = getLockConflictPayload(error);
+            if (conflictPayload) {
+                await refreshLocks();
+                return;
+            }
+
+            const message = error instanceof Error ? error.message : 'Unable to acquire edit lock for configuration.';
+            dispatch(
+                openNotification({
+                    severity: 'error',
+                    text: message,
+                }),
+            );
+        },
+    });
+
+    const handleBackToConfigSummary = React.useCallback(() => {
+        navigate(getPath(ROUTES.ENGAGEMENT_DETAILS_CONFIG, { engagementId: engagement.id }));
+    }, [engagement.id, navigate]);
+
+    const refreshConflictState = React.useCallback(async () => {
+        await refreshLocks();
+    }, [refreshLocks]);
+
+    const { conflictLockModal } = useAuthoringSectionLockNavigation({
+        conflictModal: {
+            lock: conflictingConfigLock,
+            sectionName: 'Configuration',
+            backButtonText: 'Back to Configuration Summary',
+            onBack: handleBackToConfigSummary,
+            onRetry: refreshConflictState,
+            onAfterBreakLock: refreshConflictState,
+        },
+    });
 
     useEffect(() => {
         if (fetcher.state === 'idle' && fetcher.data?.status === 'failure') {
             // Keep entered field values but clear submit state so the modal can close.
             reset(defaultValues, { keepValues: true, keepDirty: false, keepSubmitCount: false });
         }
-    }, [fetcher.state, fetcher.data, getValues, reset]);
+    }, [fetcher.state, fetcher.data, reset, defaultValues]);
 
     return (
         <FormProvider {...engagementConfigForm}>
+            {conflictLockModal}
             <EngagementForm engagement={engagement} onSubmit={onSubmit} />
         </FormProvider>
     );

--- a/web/src/components/engagement/admin/create/authoring/AuthoringBanner.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringBanner.tsx
@@ -18,17 +18,18 @@ import { defaultValuesObject, EngagementUpdateData } from './AuthoringContext';
 import { Engagement } from 'models/engagement';
 import { getEngagementTranslationByCode } from 'services/engagementService';
 import { AppConfig } from 'config';
+import { AUTHORING_SECTION } from './useAuthoringSectionCompletion';
 
 const ENGAGEMENT_UPLOADER_HEIGHT = '360px';
 const ENGAGEMENT_CROPPER_ASPECT_RATIO = 1920 / 700;
 const DEFAULT_LANGUAGE_CODE = AppConfig.language.defaultLanguageId.toLowerCase();
 
 const sectionOptions = [
-    ['Summary', Sections.DESCRIPTION],
-    ['Details', Sections.DETAILS_TABS],
-    ['Provide Feedback', Sections.PROVIDE_FEEDBACK],
-    ['Results', Sections.VIEW_RESULTS],
-    ['Subscribe', Sections.SUBSCRIBE],
+    [AUTHORING_SECTION.SUMMARY, Sections.DESCRIPTION],
+    [AUTHORING_SECTION.DETAILS, Sections.DETAILS_TABS],
+    [AUTHORING_SECTION.PROVIDE_FEEDBACK, Sections.PROVIDE_FEEDBACK],
+    [AUTHORING_SECTION.VIEW_RESULTS, Sections.VIEW_RESULTS],
+    [AUTHORING_SECTION.SUBSCRIBE, Sections.SUBSCRIBE],
 ].map((section) => (
     <MenuItem value={section[1]} key={section[1]}>
         {section[0]} Section

--- a/web/src/components/engagement/admin/create/authoring/AuthoringBottomNav.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringBottomNav.tsx
@@ -20,10 +20,10 @@ import { elevations } from 'components/common';
 import { Button } from 'components/common/Input/Button';
 import { StatusCircle } from '../../view/AuthoringTab';
 import { ReactComponent as PagePreviewIcon } from 'assets/images/pagePreview.svg';
-import { AuthoringBottomNavProps, LanguageSelectorProps } from './types';
+import { AuthoringBottomNavProps, AuthoringContextType, LanguageSelectorProps } from './types';
 import { useFormContext } from 'react-hook-form';
 import { EngagementUpdateData } from './AuthoringContext';
-import { Await, useMatch, useNavigate, useParams } from 'react-router';
+import { Await, useMatch, useNavigate, useParams, useRouteLoaderData } from 'react-router';
 import ConfirmModal from 'components/common/Modals/ConfirmModal';
 import { Language } from 'models/language';
 import { RouterLinkRenderer } from 'components/common/Navigation/Link';
@@ -31,28 +31,45 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { EngagementViewSections } from 'components/engagement/public/view';
 import { useAuthoringPreviewWindow } from './AuthoringPreviewWindowContext';
 import { getPath, ROUTES } from 'routes/routes';
-import { useAppDispatch } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { createEngagementTranslation, getEngagementTranslationByLanguage } from 'services/engagementService';
 import axios from 'axios';
 import { AppConfig } from 'config';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { EngagementLoaderAdminData } from 'engagements/admin/EngagementLoaderAdmin';
+import { AuthoringFormContext, useAuthoringFormContext } from './AuthoringFormContext';
+import { findSectionLock, getAuthoringSectionNameByPage } from './useAuthoringSectionLocks';
+import { AUTHORING_SECTION } from './useAuthoringSectionCompletion';
+import useAuthoringSectionLockNavigation, { useSectionLockState } from './useAuthoringSectionLockNavigation';
+import LockOwnerAvatar from './LockOwnerAvatar';
 const PREVIEW_CLOSE_GRACE_MS = 800;
 
+const useCurrentSectionLock = (pageName?: string) => {
+    const { languageId, locks } = React.useContext(AuthoringFormContext as React.Context<AuthoringContextType>);
+    const currentSectionName = getAuthoringSectionNameByPage(pageName) ?? AUTHORING_SECTION.HERO_BANNER;
+
+    return findSectionLock({
+        locks,
+        sectionName: currentSectionName,
+        languageId,
+    });
+};
+
 const AuthoringBottomNav = ({
-    currentLanguage,
-    languages,
     pageTitle,
     pageName,
     currentSectionIncompleteLanguageCodes,
     isSectionCompletionLoading,
-    onSaveSection,
     setUnsavedWorkPromptSuppressed,
-}: Omit<AuthoringBottomNavProps, 'setCurrentLanguage'>) => {
+}: AuthoringBottomNavProps) => {
     const {
         setValue,
         formState: { isDirty, isSubmitting },
     } = useFormContext<EngagementUpdateData>();
+    const { handleSubmit } = useFormContext<EngagementUpdateData>();
+    const { onSubmit } = useAuthoringFormContext();
+    const onSaveSection = handleSubmit(onSubmit);
     const { engagementId, languageCode } = useParams();
     const isMediumScreenOrLarger = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
     const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
@@ -65,7 +82,10 @@ const AuthoringBottomNav = ({
         schedulePreviewClose,
         closePreviewWindow,
     } = useAuthoringPreviewWindow();
+    const currentLanguage = useAppSelector((state) => state.language);
     const defaultLanguageCode = AppConfig.language.defaultLanguageId.toLowerCase();
+    const currentSectionLock = useCurrentSectionLock(pageName);
+    const sectionLockState = useSectionLockState({ lock: currentSectionLock });
 
     const getBasePathPrefix = () => {
         const basename = sessionStorage.getItem('basename');
@@ -344,8 +364,6 @@ const AuthoringBottomNav = ({
                         <Grid className="button-container" container flexWrap="nowrap" size={12} gap="1rem">
                             <ThemeProvider theme={AdminTheme}>
                                 <LanguageSelector
-                                    currentLanguage={currentLanguage}
-                                    languages={languages}
                                     isDirty={isDirty}
                                     isSubmitting={isSubmitting}
                                     currentSectionIncompleteLanguageCodes={currentSectionIncompleteLanguageCodes}
@@ -354,7 +372,7 @@ const AuthoringBottomNav = ({
                                 />
                             </ThemeProvider>
                             <Button
-                                disabled={!isDirty || isSubmitting}
+                                disabled={!isDirty || isSubmitting || sectionLockState.isDisabled}
                                 type="button"
                                 onClick={handleSaveSection}
                                 variant="primary"
@@ -380,6 +398,7 @@ const AuthoringBottomNav = ({
                                     variant="primary"
                                     size="small"
                                     type="button"
+                                    disabled={sectionLockState.isDisabled}
                                     href={`${getTargetPreviewBasePath()}${getPreviewSectionHash(pageName)}`}
                                     icon={<PagePreviewIcon aria-hidden="true" />}
                                     onClick={(e) => {
@@ -435,8 +454,6 @@ const AuthoringBottomNav = ({
 };
 
 const LanguageSelector = ({
-    currentLanguage,
-    languages,
     isDirty,
     isSubmitting,
     currentSectionIncompleteLanguageCodes,
@@ -447,14 +464,20 @@ const LanguageSelector = ({
     const { engagementId, languageCode: urlLanguageCode } = useParams();
     const navigate = useNavigate();
     const pageName = useMatch(ROUTES.AUTHORING_PAGE)?.params.page;
+    const currentLanguage = useAppSelector((state) => state.language);
+    const { languages } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
+    const { locks } = React.useContext(AuthoringFormContext as React.Context<AuthoringContextType>);
+    const { breakLockModal, requestNavigation, resolveSectionLockState } = useAuthoringSectionLockNavigation();
     const dispatch = useAppDispatch();
     const [languageModalOpen, setLanguageModalOpen] = useState(false);
     const [newLanguage, setNewLanguage] = useState('');
     const [languageList, setLanguageList] = useState<Language[]>([]);
     const [languagesLoaded, setLanguagesLoaded] = useState(false);
     const [isSwitchingLanguage, setIsSwitchingLanguage] = useState(false);
+    const newLanguageName = languageList.find((language) => language.code === newLanguage)?.name;
 
     const isEnglishOnly = languagesLoaded && languageList.length <= 1;
+    const currentSectionName = getAuthoringSectionNameByPage(pageName) ?? AUTHORING_SECTION.HERO_BANNER;
     const normalizedIncompleteLanguageCodes = React.useMemo(
         () =>
             [...currentSectionIncompleteLanguageCodes]
@@ -553,20 +576,31 @@ const LanguageSelector = ({
         setIsSwitchingLanguage(true);
         const ready = await ensureTranslationResources(languageCode);
         if (ready) {
-            navigate(
-                getPath(ROUTES.AUTHORING_PAGE, {
+            const language = languageList.find((item) => item.code.toLowerCase() === languageCode.toLowerCase());
+            const languageLock = findSectionLock({
+                locks,
+                sectionName: currentSectionName,
+                languageId: language?.id,
+            });
+            const navigationResult = requestNavigation({
+                href: getPath(ROUTES.AUTHORING_PAGE, {
                     engagementId: engagementId ?? '',
                     languageCode,
                     page: pageName ?? 'banner',
                 }),
-                {
+                sectionName: currentSectionName,
+                lock: languageLock,
+                navigationOptions: {
                     state: {
                         preserveScroll: true,
                         authoringScrollY: globalThis.scrollY,
                     },
                 },
-            );
-            return true;
+            });
+            if (navigationResult !== 'blocked') {
+                setIsSwitchingLanguage(false);
+                return true;
+            }
         }
         setUnsavedWorkPromptSuppressed(false);
         setIsSwitchingLanguage(false);
@@ -597,11 +631,12 @@ const LanguageSelector = ({
 
     return (
         <>
+            {breakLockModal}
             {/* confirm that the user wants to switch languages */}
             <Modal open={languageModalOpen} aria-describedby="publish-modal-subtext">
                 <ConfirmModal
                     style="warning"
-                    header={`Are you sure you want to switch to ${currentLanguage.name || 'another language'}?`}
+                    header={`Are you sure you want to switch to ${newLanguageName || 'another language'}?`}
                     subHeader={`You have unsaved changes for the ${currentLanguage.name || 'current'} language.`}
                     subTextId="publish-modal-subtext"
                     subText={[
@@ -686,14 +721,26 @@ const LanguageSelector = ({
                                         const isIncomplete = effectiveIncompleteLanguageCodeSet.has(
                                             language.code.toLowerCase(),
                                         );
+                                        const languageLock = findSectionLock({
+                                            locks,
+                                            sectionName: currentSectionName,
+                                            languageId: language.id,
+                                        });
+                                        const isDisabled = resolveSectionLockState(languageLock).isDisabled;
                                         return (
-                                            <MenuItem value={language.code} key={language.code}>
+                                            <MenuItem value={language.code} key={language.code} disabled={isDisabled}>
                                                 <span style={{ display: 'inline-flex', alignItems: 'center' }}>
                                                     {language.name}
                                                     <When condition={isIncomplete}>
                                                         <span style={{ marginLeft: '0.3rem', display: 'inline-flex' }}>
                                                             <StatusCircle required={true} />
                                                         </span>
+                                                    </When>
+                                                    <When condition={Boolean(languageLock)}>
+                                                        <LockOwnerAvatar
+                                                            sx={{ ml: 1 }}
+                                                            lock={languageLock ?? undefined}
+                                                        />
                                                     </When>
                                                 </span>
                                             </MenuItem>

--- a/web/src/components/engagement/admin/create/authoring/AuthoringContext.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringContext.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import { FormProvider, useForm, Resolver } from 'react-hook-form';
-import { createSearchParams, useFetcher, useMatch, useParams } from 'react-router';
+import { createSearchParams, useFetcher, useMatch, useParams, useRevalidator, useRouteLoaderData } from 'react-router';
 import { convertToRaw, EditorState } from 'draft-js';
 import * as yup from 'yup';
 import { EngagementViewSections } from 'components/engagement/public/view';
@@ -15,6 +15,9 @@ import { ROUTES, getPath } from 'routes/routes';
 import AuthoringTemplate from './AuthoringTemplate';
 import { AuthoringFormContext } from './AuthoringFormContext';
 import { AppConfig } from 'config';
+import { EngagementLoaderAdminData } from 'engagements/admin/EngagementLoaderAdmin';
+import { Language } from 'models/language';
+import { useAuthoringSectionLocks } from './useAuthoringSectionLocks';
 
 const tabSchema = yup.object({
     id: yup.number().required(),
@@ -261,7 +264,12 @@ export const defaultValuesObject = {
 
 export const AuthoringContext = () => {
     const [defaultValues, setDefaultValues] = useState(defaultValuesObject);
+    const [activeLockToken, setActiveLockToken] = useState<string | null>(null);
+    const [activeLockSectionKey, setActiveLockSectionKey] = useState<string | null>(null);
+    const [activeLockLanguageId, setActiveLockLanguageId] = useState<number | undefined>(undefined);
+    const [lockScopeWideningRequested, setLockScopeWideningRequested] = useState(false);
     const fetcher = useFetcher();
+    const revalidator = useRevalidator();
     // Check if the form has succeeded or failed after a submit, and issue a message to the user.
     const dispatch = useAppDispatch();
     useEffect(() => {
@@ -275,12 +283,51 @@ export const AuthoringContext = () => {
                     text: responseText,
                 }),
             );
+            if ('success' === fetcher.data) {
+                revalidator.revalidate();
+            }
+            setLockScopeWideningRequested(false);
             fetcher.data = undefined;
         }
-    }, [fetcher.data]);
-    const { languageCode } = useParams() as { languageCode: string };
+    }, [dispatch, fetcher, fetcher.data, revalidator]);
+    const { engagementId, languageCode } = useParams() as { engagementId?: string; languageCode?: string };
+    const { locks, languages } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
+    const activeLanguageCode = (languageCode ?? AppConfig.language.defaultLanguageId).toLowerCase();
+    const [languageOptions, setLanguageOptions] = useState<Language[]>([]);
+    const [isLoadingLanguageOptions, setIsLoadingLanguageOptions] = useState(true);
     const currentLanguageCode = languageCode || AppConfig.language.defaultLanguageId;
     const pageName = useMatch(ROUTES.AUTHORING_PAGE)?.params.page;
+    useEffect(() => {
+        let isMounted = true;
+        setIsLoadingLanguageOptions(true);
+
+        void languages
+            .then((resolvedLanguages) => {
+                if (!isMounted) {
+                    return;
+                }
+
+                setLanguageOptions(resolvedLanguages);
+            })
+            .finally(() => {
+                if (!isMounted) {
+                    return;
+                }
+
+                setIsLoadingLanguageOptions(false);
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [languages]);
+
+    const lockState = useAuthoringSectionLocks({
+        engagementId: Number(engagementId),
+        languageCode: activeLanguageCode,
+        languageOptions,
+        initialLocksPromise: locks,
+    });
     /* Changes the resolver based on the page name. 
     If you require more complex validation, you can 
     define your own resolver and add a case for it here.
@@ -342,6 +389,9 @@ export const AuthoringContext = () => {
                     send_report: (data.send_report || '').toString(),
                     slug: data.slug,
                     request_type: data.request_type,
+                    lock_token: activeLockToken ?? '',
+                    lock_section_key: activeLockSectionKey ?? '',
+                    lock_language_id: activeLockLanguageId !== undefined ? String(activeLockLanguageId) : '',
                     language_code: currentLanguageCode,
                     text_content: data.text_content,
                     json_content: data.json_content,
@@ -398,12 +448,42 @@ export const AuthoringContext = () => {
                 },
             );
         },
-        [useFetcher, pageName, currentLanguageCode],
+        [activeLockLanguageId, activeLockSectionKey, activeLockToken, currentLanguageCode, fetcher, pageName],
     );
 
     const contextValue = useMemo(
-        () => ({ onSubmit, defaultValues, setDefaultValues, fetcher }),
-        [onSubmit, defaultValues, setDefaultValues, fetcher],
+        () => ({
+            onSubmit,
+            defaultValues,
+            setDefaultValues,
+            fetcher,
+            activeLanguageCode,
+            isLoadingLanguageOptions,
+            languageOptions,
+            activeLockToken,
+            setActiveLockToken,
+            activeLockSectionKey,
+            setActiveLockSectionKey,
+            activeLockLanguageId,
+            setActiveLockLanguageId,
+            lockScopeWideningRequested,
+            setLockScopeWideningRequested,
+            ...lockState,
+        }),
+        [
+            onSubmit,
+            defaultValues,
+            setDefaultValues,
+            fetcher,
+            activeLanguageCode,
+            isLoadingLanguageOptions,
+            languageOptions,
+            activeLockToken,
+            activeLockSectionKey,
+            activeLockLanguageId,
+            lockScopeWideningRequested,
+            lockState,
+        ],
     );
 
     return (

--- a/web/src/components/engagement/admin/create/authoring/AuthoringDetails.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringDetails.tsx
@@ -19,9 +19,11 @@ import ConfirmModal from 'components/common/Modals/ConfirmModal';
 import { AuthoringLoaderData } from './authoringLoader';
 import { defaultValuesObject, EngagementUpdateData } from './AuthoringContext';
 import { getEditorStateFromRaw } from 'components/common/RichTextEditor/utils';
+import { useAuthoringFormContext } from './AuthoringFormContext';
 
 const AuthoringDetails = () => {
     const { setDefaultValues, fetcher, pageName }: AuthoringTemplateOutletContext = useOutletContext();
+    const { setLockScopeWideningRequested } = useAuthoringFormContext();
     const {
         setValue,
         getValues,
@@ -184,6 +186,7 @@ const AuthoringDetails = () => {
         if (newTabs.length > 9) {
             return; // Maximum 10 tabs
         }
+        setLockScopeWideningRequested(true);
         const renumberedTabs = renumberTabs(newTabs);
         const newTab: FormDetailsTab = {
             id: -1,
@@ -250,6 +253,7 @@ const AuthoringDetails = () => {
     };
 
     const deleteConfirm = () => {
+        setLockScopeWideningRequested(true);
         const newTabs = [...getValues('details_tabs')];
         newTabs.splice(delTabIndex, 1);
         const renumberedTabs = renumberTabs(newTabs);
@@ -281,6 +285,7 @@ const AuthoringDetails = () => {
     };
 
     const noTabsConfirm = () => {
+        setLockScopeWideningRequested(true);
         setTabsEnabled(false);
         const newTabs = getValues('details_tabs');
         // Remove subsequent tabs when switching to no-tab mode. This action dirties the form.

--- a/web/src/components/engagement/admin/create/authoring/AuthoringLockConflictModal.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringLockConflictModal.tsx
@@ -10,7 +10,7 @@ import { UserAvatar } from 'components/common/Layout/UserAvatar';
 import { EngagementLoaderAdminData } from 'engagements/admin/EngagementLoaderAdmin';
 import { useRouteLoaderData } from 'react-router';
 import { useAppSelector } from 'hooks';
-import { formatToPacific } from 'components/common/dateHelper';
+import { formatRelative } from 'components/common/dateHelper';
 
 export const AuthoringLockConflictModal = ({
     open,
@@ -42,9 +42,8 @@ export const AuthoringLockConflictModal = ({
     const isCurrentUserLock = Boolean(lock?.owner.user_sub === currentUserSub);
     const { languages } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
     const resolvedLanguages = React.use(languages);
-    const lockHeldSince = lock ? formatToPacific(lock?.acquired_at) : 'unknown';
-    const lockLastRenewed = lock?.heartbeat_at ? formatToPacific(lock?.heartbeat_at) : 'unknown';
-    const lockExpiresAt = lock?.expires_at ? formatToPacific(lock?.expires_at) : 'unknown';
+    const lockLastRenewed = lock?.heartbeat_at ? formatRelative(lock?.heartbeat_at) : 'unknown';
+    const lockExpiresAt = lock?.expires_at ? formatRelative(lock?.expires_at) : 'unknown';
 
     const languageLabel = (() => {
         if (lock?.language_id === null || lock?.language_id === undefined) {
@@ -85,10 +84,10 @@ export const AuthoringLockConflictModal = ({
                                 borderColor: isCurrentUserLock ? 'success.dark' : 'warning.dark',
                             }}
                         />
+
                         <BodyText component="span">
-                            {isCurrentUserLock
-                                ? `This lock belongs to another tab/session you opened.`
-                                : `This lock is currently held by ${ownerName}.`}
+                            This lock belongs to{' '}
+                            <b>{isCurrentUserLock ? 'another tab/session you opened' : ownerName}</b>.
                         </BodyText>
                     </Grid>
                     <Grid container direction="column" spacing={1}>
@@ -103,16 +102,12 @@ export const AuthoringLockConflictModal = ({
                             </Grid>
                         ) : null}
                         <Grid container spacing={1}>
-                            <BodyText bold>Lock held since:</BodyText>
-                            <BodyText>{lockHeldSince}</BodyText>
-                        </Grid>
-                        <Grid container spacing={1}>
-                            <BodyText bold>Last renewed:</BodyText>
+                            <BodyText bold>Lock renewed:</BodyText>
                             <BodyText>{lockLastRenewed}</BodyText>
                         </Grid>
                         <Grid container spacing={1}>
-                            <BodyText bold>Expires at:</BodyText>
-                            <BodyText>{lockExpiresAt}</BodyText>
+                            <BodyText bold>Expires:</BodyText>
+                            <BodyText>{lockExpiresAt} if not renewed</BodyText>
                         </Grid>
                     </Grid>
 

--- a/web/src/components/engagement/admin/create/authoring/AuthoringLockConflictModal.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringLockConflictModal.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { Modal, Grid2 as Grid, Stack } from '@mui/material';
+import { modalStyle } from 'components/common';
+import { Heading2, BodyText } from 'components/common/Typography';
+import { Button } from 'components/common/Input/Button';
+import { faHammerCrash, faLockAlt } from '@fortawesome/pro-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ResourceLockRecord, getLockOwnerDisplayName } from 'services/resourceLockService';
+import { UserAvatar } from 'components/common/Layout/UserAvatar';
+import { EngagementLoaderAdminData } from 'engagements/admin/EngagementLoaderAdmin';
+import { useRouteLoaderData } from 'react-router';
+import { useAppSelector } from 'hooks';
+import { formatToPacific } from 'components/common/dateHelper';
+
+export const AuthoringLockConflictModal = ({
+    open,
+    lock,
+    isBusy,
+    sectionName,
+    backButtonText = 'Back to Authoring Tab',
+    retryButtonText = 'Try Again',
+    breakButtonText = 'Release Lock',
+    showRetry = true,
+    onBack,
+    onRetry,
+    onBreakLock,
+}: {
+    open: boolean;
+    lock?: ResourceLockRecord | null;
+    isBusy?: boolean;
+    sectionName?: string;
+    backButtonText?: string;
+    retryButtonText?: string;
+    breakButtonText?: string;
+    showRetry?: boolean;
+    onBack: () => void;
+    onRetry?: () => void;
+    onBreakLock?: () => void;
+}) => {
+    const currentUserSub = useAppSelector((state) => state.user.userDetail?.sub);
+    const ownerName = getLockOwnerDisplayName(lock?.owner) ?? 'another editor';
+    const isCurrentUserLock = Boolean(lock?.owner.user_sub === currentUserSub);
+    const { languages } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
+    const resolvedLanguages = React.use(languages);
+    const lockHeldSince = lock ? formatToPacific(lock?.acquired_at) : 'unknown';
+    const lockLastRenewed = lock?.heartbeat_at ? formatToPacific(lock?.heartbeat_at) : 'unknown';
+    const lockExpiresAt = lock?.expires_at ? formatToPacific(lock?.expires_at) : 'unknown';
+
+    const languageLabel = (() => {
+        if (lock?.language_id === null || lock?.language_id === undefined) {
+            return 'all';
+        }
+
+        const language = resolvedLanguages.find((item) => item.id === lock?.language_id);
+        return language ? language.name : `Unknown Language - ID ${lock?.language_id}`;
+    })();
+
+    return (
+        <Modal open={open} aria-labelledby="authoring-lock-conflict-title">
+            <Grid
+                container
+                direction="column"
+                spacing={2}
+                sx={{
+                    ...modalStyle,
+                    borderColor: 'warning.main',
+                }}
+            >
+                <Grid container>
+                    <Grid size="grow">
+                        <Heading2 id="authoring-lock-conflict-title" sx={{ mb: 0 }}>
+                            <FontAwesomeIcon icon={faLockAlt} /> This section is currently locked
+                        </Heading2>
+                    </Grid>
+                </Grid>
+                <Grid container direction="column" spacing={1} sx={{ mb: 2 }}>
+                    <Grid container alignItems="center" spacing={1}>
+                        <UserAvatar
+                            displayName={ownerName}
+                            fallbackCharacter="?"
+                            sx={{
+                                bgcolor: isCurrentUserLock ? 'success.main' : 'warning.main',
+                                color: isCurrentUserLock ? 'common.white' : 'grey.900',
+                                border: '1px solid',
+                                borderColor: isCurrentUserLock ? 'success.dark' : 'warning.dark',
+                            }}
+                        />
+                        <BodyText component="span">
+                            {isCurrentUserLock
+                                ? `This lock belongs to another tab/session you opened.`
+                                : `This lock is currently held by ${ownerName}.`}
+                        </BodyText>
+                    </Grid>
+                    <Grid container direction="column" spacing={1}>
+                        <Grid container spacing={1}>
+                            <BodyText bold>Section:</BodyText>
+                            <BodyText>{sectionName ?? 'Unknown'}</BodyText>
+                        </Grid>
+                        {languageLabel ? (
+                            <Grid container spacing={1}>
+                                <BodyText bold>Language:</BodyText>
+                                <BodyText>{languageLabel}</BodyText>
+                            </Grid>
+                        ) : null}
+                        <Grid container spacing={1}>
+                            <BodyText bold>Lock held since:</BodyText>
+                            <BodyText>{lockHeldSince}</BodyText>
+                        </Grid>
+                        <Grid container spacing={1}>
+                            <BodyText bold>Last renewed:</BodyText>
+                            <BodyText>{lockLastRenewed}</BodyText>
+                        </Grid>
+                        <Grid container spacing={1}>
+                            <BodyText bold>Expires at:</BodyText>
+                            <BodyText>{lockExpiresAt}</BodyText>
+                        </Grid>
+                    </Grid>
+
+                    <BodyText>
+                        {isCurrentUserLock
+                            ? 'You can save from that other tab, then try again here. If needed, you can also break that lock from this tab.'
+                            : 'Please return to the authoring overview and try again later.'}
+                    </BodyText>
+                </Grid>
+                <Grid>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="flex-end" spacing={1}>
+                        <Button type="button" onClick={onBack} disabled={isBusy}>
+                            {backButtonText}
+                        </Button>
+                        {isCurrentUserLock && showRetry && onRetry ? (
+                            <Button type="button" onClick={onRetry} disabled={isBusy}>
+                                {retryButtonText}
+                            </Button>
+                        ) : null}
+                        {onBreakLock ? (
+                            <Button
+                                icon={<FontAwesomeIcon icon={faHammerCrash} />}
+                                variant="primary"
+                                color="warning"
+                                type="button"
+                                onClick={onBreakLock}
+                                disabled={isBusy}
+                            >
+                                {breakButtonText}
+                            </Button>
+                        ) : null}
+                    </Stack>
+                </Grid>
+            </Grid>
+        </Modal>
+    );
+};
+
+export default AuthoringLockConflictModal;

--- a/web/src/components/engagement/admin/create/authoring/AuthoringNavElements.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringNavElements.tsx
@@ -1,8 +1,11 @@
 import { USER_ROLES } from 'services/userService/constants';
 import { ROUTES, getPath } from 'routes/routes';
+import { AUTHORING_SECTION, AuthoringSectionName } from './useAuthoringSectionCompletion';
+
+type AuthoringRouteName = 'Engagement Home' | AuthoringSectionName;
 
 export interface AuthoringRoute {
-    name: string;
+    name: AuthoringRouteName;
     path: string;
     base: string;
     authenticated: boolean;
@@ -13,14 +16,14 @@ export interface AuthoringRoute {
 export const getAuthoringRoutes = (engagementId: number, languageCode: string = 'en'): AuthoringRoute[] => [
     {
         name: 'Engagement Home',
-        path: getPath(ROUTES.ENGAGEMENT_DETAILS, { engagementId }),
+        path: getPath(ROUTES.ENGAGEMENT_DETAILS_AUTHORING, { engagementId }),
         base: `/engagements`,
         authenticated: false,
         allowedRoles: [USER_ROLES.EDIT_ENGAGEMENT],
         required: true,
     },
     {
-        name: 'Hero Banner',
+        name: AUTHORING_SECTION.HERO_BANNER,
         path: getPath(ROUTES.AUTHORING_BANNER, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,
@@ -28,7 +31,7 @@ export const getAuthoringRoutes = (engagementId: number, languageCode: string = 
         required: true,
     },
     {
-        name: 'Summary',
+        name: AUTHORING_SECTION.SUMMARY,
         path: getPath(ROUTES.AUTHORING_SUMMARY, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,
@@ -36,7 +39,7 @@ export const getAuthoringRoutes = (engagementId: number, languageCode: string = 
         required: true,
     },
     {
-        name: 'Details',
+        name: AUTHORING_SECTION.DETAILS,
         path: getPath(ROUTES.AUTHORING_DETAILS, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,
@@ -44,7 +47,7 @@ export const getAuthoringRoutes = (engagementId: number, languageCode: string = 
         required: true,
     },
     {
-        name: 'Provide Feedback',
+        name: AUTHORING_SECTION.PROVIDE_FEEDBACK,
         path: getPath(ROUTES.AUTHORING_FEEDBACK, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,
@@ -52,7 +55,7 @@ export const getAuthoringRoutes = (engagementId: number, languageCode: string = 
         required: true,
     },
     {
-        name: 'View Results',
+        name: AUTHORING_SECTION.VIEW_RESULTS,
         path: getPath(ROUTES.AUTHORING_RESULTS, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,
@@ -60,7 +63,7 @@ export const getAuthoringRoutes = (engagementId: number, languageCode: string = 
         required: false,
     },
     {
-        name: 'Subscribe',
+        name: AUTHORING_SECTION.SUBSCRIBE,
         path: getPath(ROUTES.AUTHORING_SUBSCRIBE, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,
@@ -68,7 +71,7 @@ export const getAuthoringRoutes = (engagementId: number, languageCode: string = 
         required: false,
     },
     {
-        name: 'More Engagements',
+        name: AUTHORING_SECTION.MORE_ENGAGEMENTS,
         path: getPath(ROUTES.AUTHORING_MORE, { engagementId, languageCode }),
         base: `/engagements`,
         authenticated: true,

--- a/web/src/components/engagement/admin/create/authoring/AuthoringSideNav.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringSideNav.tsx
@@ -24,16 +24,23 @@ import { USER_ROLES } from 'services/userService/constants';
 import UserService from 'services/userService';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
 import { faArrowLeftLong } from '@fortawesome/pro-light-svg-icons';
-import { faCheck } from '@fortawesome/pro-regular-svg-icons';
+import { faCheck, faLockAlt } from '@fortawesome/pro-regular-svg-icons';
 import { StatusCircle } from '../../view/AuthoringTab';
-import { useFetchers, useLocation, useParams, useRouteLoaderData } from 'react-router';
+import { useFetchers, useParams, useRevalidator, useRouteLoaderData } from 'react-router';
 import {
+    AUTHORING_SECTION,
+    AUTHORING_SECTION_NAMES,
     AuthoringSectionName,
     useAuthoringSectionCompletion,
 } from 'components/engagement/admin/create/authoring/useAuthoringSectionCompletion';
 import { EngagementLoaderAdminData } from 'components/engagement/admin/EngagementLoaderAdmin';
 import { UserAvatar } from 'components/common/Layout/UserAvatar';
 import { AppConfig } from 'config';
+import { Language } from 'models/language';
+import LockOwnerAvatar from './LockOwnerAvatar';
+import { findSectionLock } from './useAuthoringSectionLocks';
+import useAuthoringSectionLockNavigation, { useSectionLockState } from './useAuthoringSectionLockNavigation';
+import { useEngagementLocks } from 'services/resourceLockService/useEngagementLocks';
 
 export const routeItemStyle = {
     padding: 0,
@@ -65,12 +72,21 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
     const permissions = useAppSelector((state) => state.user.roles);
     const { languageCode } = useParams() as { languageCode?: string };
     const defaultLanguageCode = AppConfig.language.defaultLanguageId.toLowerCase();
-    const location = useLocation();
-    const { engagement, languages, details } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
+    const defaultLanguageName = AppConfig.language.defaultLanguageName;
+    const { engagement, languages, details, locks } = useRouteLoaderData(
+        'single-engagement',
+    ) as EngagementLoaderAdminData;
+    const revalidator = useRevalidator();
     const fetchers = useFetchers();
     const inFlightFetcherKeysRef = useRef<Set<string>>(new Set());
-    const [saveRefreshNonce, setSaveRefreshNonce] = useState(0);
-    const [selectedLanguageCodes, setSelectedLanguageCodes] = useState<string[]>([defaultLanguageCode]);
+    const [selectedLanguages, setSelectedLanguages] = useState<Language[]>([]);
+    const selectedLanguageCodes = useMemo(() => {
+        if (selectedLanguages.length > 0) {
+            return selectedLanguages.map((language) => language.code);
+        }
+
+        return [defaultLanguageCode];
+    }, [defaultLanguageCode, selectedLanguages]);
 
     const fetchersByKey = useMemo(() => {
         return fetchers.map((fetcher) => ({
@@ -98,9 +114,9 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
         inFlightFetcherKeysRef.current = currentInFlightKeys;
 
         if (shouldRefreshAfterSave) {
-            setSaveRefreshNonce((value) => value + 1);
+            revalidator.revalidate();
         }
-    }, [fetchersByKey]);
+    }, [fetchersByKey, revalidator]);
 
     useLayoutEffect(() => {
         let isMounted = true;
@@ -110,26 +126,23 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
                 return;
             }
 
-            const nextCodes: string[] = [];
-            if (resolvedLanguages.length > 0) {
-                for (const language of resolvedLanguages) {
-                    nextCodes.push(language.code);
-                }
-            } else {
-                nextCodes.push(defaultLanguageCode);
-            }
+            const normalizedLanguages =
+                resolvedLanguages.length > 0
+                    ? resolvedLanguages
+                    : [{ id: 0, code: defaultLanguageCode, name: defaultLanguageName, right_to_left: false }];
+            const nextCodes = normalizedLanguages.map((language) => language.code);
 
-            if (areLanguageCodesEqual(selectedLanguageCodes, nextCodes)) {
+            if (areLanguageCodesEqual(selectedLanguageCodes, nextCodes) && selectedLanguages.length > 0) {
                 return;
             }
 
-            setSelectedLanguageCodes(nextCodes);
+            setSelectedLanguages(normalizedLanguages);
         });
 
         return () => {
             isMounted = false;
         };
-    }, [defaultLanguageCode, languages, selectedLanguageCodes]);
+    }, [defaultLanguageCode, defaultLanguageName, languages, selectedLanguageCodes, selectedLanguages.length]);
 
     const { completionBySection } = useAuthoringSectionCompletion({
         engagementId: Number(engagementId),
@@ -137,8 +150,28 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
         selectedLanguageCodes,
         engagementPromise: engagement,
         detailsTabsPromise: details,
-        refreshToken: `${location.pathname}|${saveRefreshNonce}`,
     });
+    const { locks: liveLocks } = useEngagementLocks({
+        engagementId: Number(engagementId),
+        initialLocksPromise: locks,
+    });
+    const locksBySection = useMemo(() => {
+        const entries = AUTHORING_SECTION_NAMES.map((sectionName) => {
+            return [
+                sectionName,
+                findSectionLock({
+                    locks: liveLocks,
+                    sectionName,
+                    languageId:
+                        selectedLanguages.find((language) => language.code === (languageCode ?? defaultLanguageCode))
+                            ?.id ?? undefined,
+                }),
+            ] as const;
+        });
+
+        return Object.fromEntries(entries) as Record<AuthoringSectionName, ReturnType<typeof findSectionLock>>;
+    }, [defaultLanguageCode, languageCode, liveLocks, selectedLanguages]);
+    const { breakLockModal, requestNavigation } = useAuthoringSectionLockNavigation();
 
     const authoringRoutes = getRoutes(Number(engagementId), languageCode ?? defaultLanguageCode);
     const matchingRoutePaths: string[] = authoringRoutes
@@ -158,30 +191,30 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
     });
 
     const renderListItem = (route: Route, isSelected: boolean) => {
-        const isCompleted = completionBySection[route.name as AuthoringSectionName] ?? false;
+        if (route.name === 'Engagement Home') {
+            return null;
+        }
+
+        const sectionName: AuthoringSectionName = route.name;
+        const isCompleted = completionBySection[sectionName] ?? false;
         const shouldShowStatusCircle = isCompleted === false;
-        let completionCheckIcon: React.ReactNode = null;
-        if (isCompleted) {
-            completionCheckIcon = (
-                <FontAwesomeIcon
-                    icon={faCheck}
-                    style={{
-                        color: 'inherit',
-                        fontWeight: 'bold',
-                    }}
-                />
-            );
-        }
-        let completionIndicator: React.ReactNode = null;
-        if (shouldShowStatusCircle) {
-            completionIndicator = <StatusCircle required={Boolean(route.required)} />;
-        }
+        const sectionLock = locksBySection[sectionName];
+        const { isDisabled } = useSectionLockState({ lock: sectionLock });
+
+        const fadeWhenDisabled = (color: string) => {
+            if (isDisabled) return color;
+            return `color-mix(in srgb, ${color} 60%, white)`;
+        };
 
         return (
             <React.Fragment key={route.name}>
-                <When condition={'Hero Banner' === route.name || 'View Results' === route.name}>
+                <When
+                    condition={
+                        AUTHORING_SECTION.HERO_BANNER === route.name || AUTHORING_SECTION.VIEW_RESULTS === route.name
+                    }
+                >
                     <BodyText bold size="small" sx={{ textTransform: 'uppercase', mt: '2rem', mb: '1rem' }}>
-                        {'Hero Banner' === route.name ? 'Required' : 'Optional'} Sections
+                        {AUTHORING_SECTION.HERO_BANNER === route.name ? 'Required' : 'Optional'} Sections
                     </BodyText>
                 </When>
                 <ListItem
@@ -194,6 +227,7 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
                     <ListItemButton
                         component={RouterLinkRenderer}
                         disableRipple
+                        disabled={isDisabled}
                         sx={{
                             '&:hover, &:active, &:focus': {
                                 backgroundColor: 'transparent',
@@ -202,11 +236,19 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
                         }}
                         data-testid={`SideNav/${route.name}-button`}
                         href={route.path}
-                        onClick={() => setOpen(false)}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            requestNavigation({
+                                href: route.path,
+                                sectionName,
+                                lock: sectionLock,
+                                onBeforeNavigate: () => setOpen(false),
+                            });
+                        }}
                     >
                         <BodyText
                             sx={{
-                                color: isSelected ? 'primary.main' : 'text.primary',
+                                color: isSelected ? 'primary.main' : fadeWhenDisabled('text.primary'),
                                 fontWeight: isSelected ? 'bold' : '500',
                                 fontSize: '1rem',
                             }}
@@ -216,26 +258,52 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
                                     paddingRight: '0.6rem',
                                 }}
                             >
-                                {completionCheckIcon}
+                                {isCompleted && (
+                                    <FontAwesomeIcon
+                                        icon={faCheck}
+                                        style={{
+                                            color: 'inherit',
+                                            fontWeight: 'bold',
+                                        }}
+                                    />
+                                )}
                             </span>
 
                             {route.name}
                         </BodyText>
-                        {completionIndicator}
+                        {shouldShowStatusCircle && <StatusCircle required={Boolean(route.required)} />}
+                        <span
+                            style={{
+                                marginLeft: 'auto',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: '0.5rem',
+                                paddingRight: '1.9rem',
+                            }}
+                        >
+                            <LockOwnerAvatar size={24} lock={sectionLock ?? undefined} />
+                        </span>
                         <When condition={currentRoutePath === route.path}>
-                            <span
+                            <BodyText
+                                sx={{
+                                    position: 'absolute',
+                                    right: '1.2rem',
+                                    color: isSelected ? 'primary.main' : 'text.primary',
+                                }}
+                            >
+                                <FontAwesomeIcon icon={faPencil} fontSize="1rem" />
+                            </BodyText>
+                        </When>
+                        <When condition={currentRoutePath !== route.path && Boolean(sectionLock)}>
+                            <BodyText
                                 style={{
                                     position: 'absolute',
                                     right: '1.2rem',
+                                    color: 'text.primary',
                                 }}
                             >
-                                <FontAwesomeIcon
-                                    icon={faPencil}
-                                    style={{
-                                        color: isSelected ? 'primary.main' : 'text.primary',
-                                    }}
-                                />
-                            </span>
+                                <FontAwesomeIcon icon={faLockAlt} fontSize="1rem" />
+                            </BodyText>
                         </When>
                     </ListItemButton>
                 </ListItem>
@@ -256,6 +324,7 @@ const DrawerBox = ({ isMediumScreenOrLarger, setOpen, engagementId }: DrawerBoxP
                 borderRadius: '0 8px 8px 0',
             }}
         >
+            {breakLockModal}
             <List sx={{ pt: { xs: 4, md: 0 }, pb: '0' }}>
                 {/* Engagement Home link */}
                 <Link

--- a/web/src/components/engagement/admin/create/authoring/AuthoringTemplate.tsx
+++ b/web/src/components/engagement/admin/create/authoring/AuthoringTemplate.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect, useLayoutEffect } from 'react';
-import { Form, useParams, Await, Outlet, useLocation, useMatch, useRouteLoaderData } from 'react-router';
+import { Form, useParams, Await, Outlet, useLocation, useMatch, useRouteLoaderData, useNavigate } from 'react-router';
 import AuthoringBottomNav from './AuthoringBottomNav';
 import type { EngagementUpdateData } from './AuthoringContext';
 import { useFormContext } from 'react-hook-form';
@@ -15,19 +15,29 @@ import Grid from '@mui/material/Grid2';
 import Collapse from '@mui/material/Collapse';
 import { StatusLabel } from './StatusLabel';
 import AuthoringMorePreform from './AuthoringMorePreform';
-import { ROUTES } from 'routes/routes';
-import { useAuthoringFormContext } from './AuthoringFormContext';
+import { ROUTES, getPath } from 'routes/routes';
+import { AuthoringFormContext, useAuthoringFormContext } from './AuthoringFormContext';
 import UnsavedWorkConfirmation from 'components/common/Navigation/UnsavedWorkConfirmation';
 import {
     AUTHORING_SECTION_NAMES,
+    REQUIRED_AUTHORING_SECTION_NAMES,
     AuthoringSectionName,
     useAuthoringSectionCompletion,
 } from 'components/engagement/admin/create/authoring/useAuthoringSectionCompletion';
 import { SystemMessage } from 'components/common/Layout/SystemMessage';
 import { AppConfig } from 'config';
+import { openNotification } from 'services/notificationService/notificationSlice';
+import useEngagementSectionEditLock from 'services/resourceLockService/useEngagementSectionEditLock';
+import { getLockConflictPayload } from 'services/resourceLockService';
+import { findSectionLock, getLockTargetBySectionName, getAuthoringSectionNameByPage } from './useAuthoringSectionLocks';
+import useAuthoringSectionLockNavigation from './useAuthoringSectionLockNavigation';
+import { AuthoringContextType } from './types';
 
 const DEFAULT_LANGUAGE_CODE = AppConfig.language.defaultLanguageId.toLowerCase();
 const DEFAULT_LANGUAGE_NAME = AppConfig.language.defaultLanguageName;
+const LOCK_HEARTBEAT_INTERVAL_MS = 30000;
+const AUTHORING_UNSAVED_CHANGES_KEY = 'authoring-unsaved-changes';
+const REQUIRED_AUTHORING_SECTION_NAME_SET = new Set<AuthoringSectionName>(REQUIRED_AUTHORING_SECTION_NAMES);
 
 export const getLanguageValue = (languageCode: string, languages: Language[]) => {
     if (languageCode === DEFAULT_LANGUAGE_CODE) {
@@ -41,42 +51,35 @@ const isAuthoringSectionName = (value: string | undefined): value is AuthoringSe
 };
 
 const AuthoringTemplate = () => {
-    const { onSubmit, defaultValues, setDefaultValues, fetcher } = useAuthoringFormContext();
+    const {
+        onSubmit,
+        defaultValues,
+        setDefaultValues,
+        fetcher,
+        setActiveLockLanguageId,
+        setActiveLockSectionKey,
+        setActiveLockToken,
+        lockScopeWideningRequested,
+        setLockScopeWideningRequested,
+    } = useAuthoringFormContext();
     const { engagementId, languageCode } = useParams() as { engagementId: string; languageCode: string };
+    const navigate = useNavigate();
     const activeLanguageCode = (languageCode ?? DEFAULT_LANGUAGE_CODE).toLowerCase();
     const location = useLocation();
     const { engagement, languages, details } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
     const dispatch = useAppDispatch();
     const currentLanguage = useAppSelector((state) => state.language);
-    const [selectedLanguages, setSelectedLanguages] = React.useState<Language[]>([]);
-    const [isLoadingSelectedLanguages, setIsLoadingSelectedLanguages] = React.useState(true);
+    const {
+        languageOptions,
+        isLoadingLanguageOptions: isLoadingSelectedLanguages,
+        locks,
+        languageId,
+        refreshLocks,
+    } = React.useContext(AuthoringFormContext as React.Context<AuthoringContextType>);
     const selectedLanguageCodes = React.useMemo(
-        () => selectedLanguages.map((language) => language.code),
-        [selectedLanguages],
+        () => languageOptions.map((language) => language.code),
+        [languageOptions],
     );
-
-    useEffect(() => {
-        let isMounted = true;
-        setIsLoadingSelectedLanguages(true);
-
-        void languages
-            .then((resolvedLanguages) => {
-                if (!isMounted) {
-                    return;
-                }
-                setSelectedLanguages(resolvedLanguages);
-            })
-            .finally(() => {
-                if (!isMounted) {
-                    return;
-                }
-                setIsLoadingSelectedLanguages(false);
-            });
-
-        return () => {
-            isMounted = false;
-        };
-    }, [languages]);
 
     // Sync Redux language state whenever the URL language code changes.
     useEffect(() => {
@@ -105,11 +108,10 @@ const AuthoringTemplate = () => {
         selectedLanguageCodes,
         engagementPromise: engagement,
         detailsTabsPromise: details,
-        refreshToken: fetcher.data,
     });
     const currentSectionName = isAuthoringSectionName(pageTitle) ? pageTitle : undefined;
     const isCurrentSectionRequired = currentSectionName
-        ? ['Hero Banner', 'Summary', 'Details', 'Provide Feedback'].includes(currentSectionName)
+        ? REQUIRED_AUTHORING_SECTION_NAME_SET.has(currentSectionName)
         : false;
     let currentSectionCompletion: boolean | undefined;
     let incompleteLanguagesForCurrentSection: Language[] = [];
@@ -117,9 +119,7 @@ const AuthoringTemplate = () => {
         currentSectionCompletion = completionBySection[currentSectionName];
 
         const incompleteCodes = new Set(incompleteLanguageCodesBySection[currentSectionName] ?? []);
-        incompleteLanguagesForCurrentSection = selectedLanguages.filter((language) =>
-            incompleteCodes.has(language.code),
-        );
+        incompleteLanguagesForCurrentSection = languageOptions.filter((language) => incompleteCodes.has(language.code));
     }
 
     const isLoadingBadgesAndMessages = isLoadingSectionCompletion || isLoadingSelectedLanguages;
@@ -144,8 +144,60 @@ const AuthoringTemplate = () => {
         formState: { isDirty, isSubmitting },
     } = useFormContext<EngagementUpdateData>();
     const [isUnsavedWorkPromptSuppressed, setUnsavedWorkPromptSuppressed] = React.useState(false);
-    const onSaveSection = handleSubmit(onSubmit);
     const outletKey = pageName ?? 'authoring';
+    const currentSectionFromPage = React.useMemo(() => {
+        return getAuthoringSectionNameByPage(pageName);
+    }, [pageName]);
+    const currentSectionLockContext = React.useMemo(() => {
+        if (!currentSectionFromPage) {
+            return null;
+        }
+
+        const target = getLockTargetBySectionName(currentSectionFromPage);
+        if (!target) {
+            return null;
+        }
+
+        return {
+            sectionKey: target.sectionKey,
+            useLanguageScope: target.languageScoped,
+        };
+    }, [currentSectionFromPage]);
+    const conflictingSectionLock = React.useMemo(() => {
+        if (!currentSectionFromPage) {
+            return null;
+        }
+
+        const sectionLock = findSectionLock({
+            locks,
+            languageId,
+            sectionName: currentSectionFromPage,
+        });
+
+        if (!sectionLock || sectionLock.is_mine) {
+            return null;
+        }
+
+        return sectionLock;
+    }, [currentSectionFromPage, languageId, locks]);
+
+    const handleBackToAuthoringTab = React.useCallback(() => {
+        navigate(getPath(ROUTES.ENGAGEMENT_DETAILS_AUTHORING, { engagementId: Number(engagementId) }));
+    }, [engagementId, navigate]);
+
+    const refreshConflictState = React.useCallback(async () => {
+        await refreshLocks();
+    }, [refreshLocks]);
+
+    const { conflictLockModal } = useAuthoringSectionLockNavigation({
+        conflictModal: {
+            lock: conflictingSectionLock,
+            sectionName: currentSectionFromPage ?? undefined,
+            onBack: handleBackToAuthoringTab,
+            onRetry: refreshConflictState,
+            onAfterBreakLock: refreshConflictState,
+        },
+    });
 
     useLayoutEffect(() => {
         if (typeof location.state !== 'object' || location.state === null || !('authoringScrollY' in location.state)) {
@@ -166,8 +218,74 @@ const AuthoringTemplate = () => {
         };
     }, [location.key, location.state]);
 
+    useEffect(() => {
+        sessionStorage.setItem(AUTHORING_UNSAVED_CHANGES_KEY, isDirty && !isSubmitting ? '1' : '0');
+
+        return () => {
+            sessionStorage.setItem(AUTHORING_UNSAVED_CHANGES_KEY, '0');
+        };
+    }, [isDirty, isSubmitting]);
+
+    // A structural (add/remove) change only applies to the section the user was on when they made it.
+    useEffect(() => {
+        setLockScopeWideningRequested(false);
+    }, [pageName, setLockScopeWideningRequested]);
+
+    const { activeLockScope, activeLockToken } = useEngagementSectionEditLock({
+        engagementId: Number(engagementId),
+        scope: currentSectionLockContext
+            ? {
+                  sectionKey: currentSectionLockContext.sectionKey,
+                  languageId:
+                      currentSectionLockContext.useLanguageScope && !lockScopeWideningRequested
+                          ? languageId
+                          : undefined,
+              }
+            : null,
+        enabled: Boolean(engagementId),
+        isDirty,
+        isSubmitting,
+        blockedByLock: conflictingSectionLock,
+        heartbeatIntervalMs: LOCK_HEARTBEAT_INTERVAL_MS,
+        onConflict: async (error) => {
+            const conflictPayload = getLockConflictPayload(error);
+            if (conflictPayload) {
+                await refreshConflictState();
+                return;
+            }
+
+            const message = error instanceof Error ? error.message : 'Unable to acquire edit lock for this section.';
+            dispatch(
+                openNotification({
+                    severity: 'error',
+                    text: message,
+                }),
+            );
+        },
+    });
+
+    useEffect(() => {
+        setActiveLockToken(activeLockToken);
+        setActiveLockSectionKey(activeLockScope?.sectionKey ?? null);
+        setActiveLockLanguageId(activeLockScope?.languageId);
+
+        return () => {
+            setActiveLockToken(null);
+            setActiveLockSectionKey(null);
+            setActiveLockLanguageId(undefined);
+        };
+    }, [
+        activeLockScope?.languageId,
+        activeLockScope?.sectionKey,
+        activeLockToken,
+        setActiveLockLanguageId,
+        setActiveLockSectionKey,
+        setActiveLockToken,
+    ]);
+
     return (
         <Grid container>
+            {conflictLockModal}
             <Grid container size={12} mt={2} alignItems="center" columnGap="0.5rem" minHeight="24px">
                 <Grid component="span" sx={{ display: 'inline-flex', alignItems: 'center', minHeight: '24px' }}>
                     <Suspense fallback={<StatusLabel isLoading />}>
@@ -240,15 +358,12 @@ const AuthoringTemplate = () => {
                         </Await>
                     </Suspense>
                     <AuthoringBottomNav
-                        currentLanguage={currentLanguage}
-                        languages={languages}
                         pageTitle={pageTitle || 'untitled'} // Full title
                         pageName={pageName || 'untitled'} // Slug
                         currentSectionIncompleteLanguageCodes={incompleteLanguagesForCurrentSection.map(
                             (language) => language.code,
                         )}
                         isSectionCompletionLoading={isLoadingBadgesAndMessages}
-                        onSaveSection={onSaveSection}
                         setUnsavedWorkPromptSuppressed={setUnsavedWorkPromptSuppressed}
                     />
                 </Form>

--- a/web/src/components/engagement/admin/create/authoring/LockOwnerAvatar.tsx
+++ b/web/src/components/engagement/admin/create/authoring/LockOwnerAvatar.tsx
@@ -1,0 +1,71 @@
+import React, { Suspense } from 'react';
+import type { AvatarProps } from '@mui/material/Avatar';
+import { Tooltip, Skeleton } from '@mui/material';
+import { ResourceLockRecord, getLockOwnerDisplayName } from 'services/resourceLockService';
+import { UserAvatar } from 'components/common/Layout/UserAvatar';
+import { useAppSelector } from 'hooks';
+
+const UnsuspendedLockOwnerAvatar = ({
+    lock,
+    size = 22,
+    ...props
+}: AvatarProps & {
+    lock?: ResourceLockRecord | Promise<ResourceLockRecord>;
+    size?: number;
+}) => {
+    const lockRecord = lock instanceof Promise ? React.use(lock) : lock;
+    if (!lockRecord) {
+        return null;
+    }
+    const currentUserSub = useAppSelector((state) => state.user.userDetail.sub);
+    const languageName = useAppSelector((state) => state.language.name);
+    const ownerName = getLockOwnerDisplayName(lockRecord.owner);
+    const languageSuffix = languageName ? ` in ${languageName}` : '';
+    const title = lockRecord.is_mine ? `Locked by you${languageSuffix}` : `Locked by ${ownerName}${languageSuffix}`;
+    const recordIsMine = lockRecord.is_mine || lockRecord.owner?.user_sub === currentUserSub;
+
+    return (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
+            <Tooltip title={title} placement="top" arrow>
+                <UserAvatar
+                    displayName={ownerName}
+                    fallbackCharacter="?"
+                    {...props}
+                    sx={[
+                        {
+                            width: size,
+                            height: size,
+                            fontSize: `${Math.max(10, Math.floor(size * 0.45))}px`,
+                            bgcolor: recordIsMine ? 'success.main' : 'warning.main',
+                            color: recordIsMine ? 'common.white' : 'grey.900',
+                            border: '1px solid',
+                            borderColor: recordIsMine ? 'success.dark' : 'warning.dark',
+                        },
+                        ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
+                    ]}
+                />
+            </Tooltip>
+        </span>
+    );
+};
+
+export const LockOwnerAvatar = ({
+    lock,
+    size = 22,
+    ...props
+}: AvatarProps & {
+    lock?: ResourceLockRecord;
+    size?: number;
+}) => {
+    return (
+        <Suspense fallback={<LockOwnerAvatarSkeleton size={size} />}>
+            <UnsuspendedLockOwnerAvatar lock={lock} size={size} {...props} />
+        </Suspense>
+    );
+};
+
+export const LockOwnerAvatarSkeleton = ({ size = 22 }: { size?: number }) => (
+    <Skeleton variant="circular" width={size} height={size} />
+);
+
+export default LockOwnerAvatar;

--- a/web/src/components/engagement/admin/create/authoring/authoringUpdateAction.tsx
+++ b/web/src/components/engagement/admin/create/authoring/authoringUpdateAction.tsx
@@ -13,9 +13,23 @@ import { EngagementDetailsTab } from 'models/engagementDetailsTab';
 import { getLanguages } from 'services/languageService';
 import {
     getEngagementContentTranslationsByCode,
+    getLanguageIdByCode,
     syncEngagementContentTranslationsByCode,
 } from 'services/engagementContentTranslationService';
 import { AppConfig } from 'config';
+import {
+    acquireEngagementSectionLock,
+    LOCK_TOKEN_HEADER,
+    SECTION_AUTHORING_BANNER,
+    SECTION_AUTHORING_DETAILS,
+    SECTION_AUTHORING_FEEDBACK,
+    SECTION_AUTHORING_MORE,
+    SECTION_AUTHORING_SUBSCRIBE,
+    SECTION_AUTHORING_SUMMARY,
+    SECTION_CONFIG_GENERAL,
+} from 'services/resourceLockService';
+
+type RequestHeaders = Record<string, string>;
 
 const ensureTranslation = async (engagementId: number, languageCode: string) => {
     let translation = await getEngagementTranslationByCode(engagementId, languageCode);
@@ -42,13 +56,15 @@ const patchTranslationForLanguage = async ({
     engagementId,
     languageCode,
     payload,
+    headers = {},
 }: {
     engagementId: number;
     languageCode: string;
     payload: Record<string, unknown>;
+    headers?: RequestHeaders;
 }) => {
     const translation = await ensureTranslation(engagementId, languageCode);
-    await patchEngagementTranslation(engagementId, translation.id, payload);
+    await patchEngagementTranslation(engagementId, translation.id, payload, headers);
 };
 
 const getOptionalFormText = (formData: FormData, key: string): string | undefined => {
@@ -58,6 +74,109 @@ const getOptionalFormText = (formData: FormData, key: string): string | undefine
     }
 
     return value || undefined;
+};
+
+const compactPayload = <T extends Record<string, unknown>>(payload: T): Partial<T> => {
+    return Object.fromEntries(Object.entries(payload).filter(([, value]) => value !== undefined)) as Partial<T>;
+};
+
+const lockHeaders = (lockToken: string): RequestHeaders => ({
+    [LOCK_TOKEN_HEADER]: lockToken,
+});
+
+type SubmittedAuthoringLockState = {
+    token?: string;
+    sectionKey?: string;
+    languageId?: number;
+};
+
+const getSubmittedAuthoringLockState = (formData: FormData): SubmittedAuthoringLockState => {
+    const token = formData.get('lock_token');
+    const sectionKey = formData.get('lock_section_key');
+    const rawLanguageId = formData.get('lock_language_id');
+    const parsedLanguageId = typeof rawLanguageId === 'string' && rawLanguageId ? Number(rawLanguageId) : undefined;
+
+    return {
+        token: typeof token === 'string' && token ? token : undefined,
+        sectionKey: typeof sectionKey === 'string' && sectionKey ? sectionKey : undefined,
+        languageId: Number.isFinite(parsedLanguageId) ? parsedLanguageId : undefined,
+    };
+};
+
+const matchesSubmittedLockScope = ({
+    submittedLock,
+    sectionKey,
+    languageScoped,
+}: {
+    submittedLock?: SubmittedAuthoringLockState;
+    sectionKey: string;
+    languageScoped: boolean;
+}) => {
+    if (!submittedLock?.token || submittedLock.sectionKey !== sectionKey) {
+        return false;
+    }
+
+    if (languageScoped) {
+        return submittedLock.languageId !== undefined;
+    }
+
+    return submittedLock.languageId === undefined;
+};
+
+const withSectionLock = async <T,>({
+    engagementId,
+    sectionKey,
+    languageCode,
+    submittedLock,
+    task,
+}: {
+    engagementId: number;
+    sectionKey: string;
+    languageCode?: string;
+    submittedLock?: SubmittedAuthoringLockState;
+    task: (headers: RequestHeaders) => Promise<T>;
+}): Promise<T> => {
+    const submittedLockToken = submittedLock?.token;
+    if (
+        submittedLockToken &&
+        matchesSubmittedLockScope({
+            submittedLock,
+            sectionKey,
+            languageScoped: languageCode !== undefined,
+        })
+    ) {
+        return await task(lockHeaders(submittedLockToken));
+    }
+
+    const languageId = languageCode ? await getLanguageIdByCode(languageCode) : undefined;
+    const lock = await acquireEngagementSectionLock({
+        engagementId,
+        sectionKey,
+        languageId,
+    });
+    return await task(lockHeaders(lock.lock_token));
+};
+
+// Binds engagementId/submittedLock so call sites only need to specify what varies: the section, task, and language.
+const createSectionLockRunner = (engagementId: number, submittedLock?: SubmittedAuthoringLockState) => {
+    return <T,>(sectionKey: string, task: (headers: RequestHeaders) => Promise<T>, languageCode?: string): Promise<T> =>
+        withSectionLock({ engagementId, sectionKey, languageCode, submittedLock, task });
+};
+
+const resolvePatchSectionForPayload = (payload: Record<string, unknown>): string => {
+    if ('selected_survey_id' in payload) {
+        return SECTION_AUTHORING_FEEDBACK;
+    }
+
+    if ('suggested_engagements' in payload || 'suggested_engagements_input' in payload) {
+        return SECTION_AUTHORING_MORE;
+    }
+
+    if ('status_block' in payload || 'banner_filename' in payload) {
+        return SECTION_AUTHORING_BANNER;
+    }
+
+    return SECTION_CONFIG_GENERAL;
 };
 
 const toBodyString = (body: unknown): string => {
@@ -94,12 +213,15 @@ const updateDetailsTabs = async ({
     languageCode,
     defaultLanguageCode,
     detailsTabsRaw,
+    submittedLock,
 }: {
     engagementId: number;
     languageCode: string;
     defaultLanguageCode: string;
     detailsTabsRaw: string;
+    submittedLock?: SubmittedAuthoringLockState;
 }) => {
+    const runWithLock = createSectionLockRunner(engagementId, submittedLock);
     const parsedTabs = JSON.parse(detailsTabsRaw) as EngagementDetailsTab[];
 
     const existingBaseTabs = await getDetailsTabs(engagementId);
@@ -131,7 +253,9 @@ const updateDetailsTabs = async ({
         };
     }) as unknown as EngagementDetailsTab[];
 
-    await patchDetailsTabs(engagementId, structuralTabs);
+    await runWithLock(SECTION_AUTHORING_DETAILS, async (headers) => {
+        await patchDetailsTabs(engagementId, structuralTabs, headers);
+    });
 
     if (languageCode === defaultLanguageCode) {
         return;
@@ -172,19 +296,30 @@ const updateDetailsTabs = async ({
         };
     });
 
-    await syncEngagementContentTranslationsByCode(engagementId, languageCode, {
-        details_tabs: translatedTabs,
-    });
+    await runWithLock(
+        SECTION_AUTHORING_DETAILS,
+        async (headers) => {
+            await syncEngagementContentTranslationsByCode(
+                engagementId,
+                languageCode,
+                { details_tabs: translatedTabs },
+                headers,
+            );
+        },
+        languageCode,
+    );
 };
 
 export const authoringUpdateAction: ActionFunction = async ({ request }) => {
     const formData = await request.formData();
     const errors: unknown[] = [];
+    const submittedLock = getSubmittedAuthoringLockState(formData);
     const requestType = formData.get('request_type') as string;
     const formSource = formData.get('form_source');
     const engagementId = Number(formData.get('id'));
     const defaultLanguageCode = AppConfig.language.defaultLanguageId.toLowerCase();
     const languageCode = ((formData.get('language_code') as string) || defaultLanguageCode).toLowerCase();
+    const runWithLock = createSectionLockRunner(engagementId, submittedLock);
     const statusBlock = [
         {
             survey_status: 'Open',
@@ -219,23 +354,51 @@ export const authoringUpdateAction: ActionFunction = async ({ request }) => {
             errors,
             task: async () => {
                 const sponsorName = getOptionalFormText(formData, 'eyebrow');
-                await patchTranslationForLanguage({
-                    engagementId,
-                    languageCode,
-                    payload: {
-                        name: getOptionalFormText(formData, 'name'),
-                        sponsor_name: sponsorName,
-                        description: getOptionalFormText(formData, 'description'),
-                        rich_description: getOptionalFormText(formData, 'rich_description'),
-                        description_title: getOptionalFormText(formData, 'description_title'),
-                        upcoming_status_block_text: getOptionalFormText(formData, 'upcoming_message'),
-                        closed_status_block_text: getOptionalFormText(formData, 'closed_message'),
-                        open_status_block_button_text: getOptionalFormText(formData, 'open_cta'),
-                        view_results_status_block_button_text: getOptionalFormText(formData, 'view_results_cta'),
-                    },
+                const bannerTranslationPayload = compactPayload({
+                    name: getOptionalFormText(formData, 'name'),
+                    sponsor_name: sponsorName,
+                    upcoming_status_block_text: getOptionalFormText(formData, 'upcoming_message'),
+                    closed_status_block_text: getOptionalFormText(formData, 'closed_message'),
+                    open_status_block_button_text: getOptionalFormText(formData, 'open_cta'),
+                    view_results_status_block_button_text: getOptionalFormText(formData, 'view_results_cta'),
                 });
+
+                const summaryTranslationPayload = compactPayload({
+                    description: getOptionalFormText(formData, 'description'),
+                    rich_description: getOptionalFormText(formData, 'rich_description'),
+                    description_title: getOptionalFormText(formData, 'description_title'),
+                });
+
+                if (formSource === 'banner' && Object.keys(bannerTranslationPayload).length > 0) {
+                    await runWithLock(
+                        SECTION_AUTHORING_BANNER,
+                        (headers) =>
+                            patchTranslationForLanguage({
+                                engagementId,
+                                languageCode,
+                                payload: bannerTranslationPayload,
+                                headers,
+                            }),
+                        languageCode,
+                    );
+                }
+
+                if (formSource === 'summary' && Object.keys(summaryTranslationPayload).length > 0) {
+                    await runWithLock(
+                        SECTION_AUTHORING_SUMMARY,
+                        (headers) =>
+                            patchTranslationForLanguage({
+                                engagementId,
+                                languageCode,
+                                payload: summaryTranslationPayload,
+                                headers,
+                            }),
+                        languageCode,
+                    );
+                }
+
                 // Structural fields always stay on base engagement.
-                await patchEngagement({
+                const engagementPatchPayload = {
                     id: Number(formData.get('id')),
                     start_date: (formData.get('start_date') as string) || undefined,
                     status_id: Number(formData.get('status_id')) || undefined,
@@ -243,7 +406,12 @@ export const authoringUpdateAction: ActionFunction = async ({ request }) => {
                     banner_filename: (formData.get('banner_filename') as string) || undefined,
                     sponsor_name: languageCode === defaultLanguageCode ? sponsorName : undefined,
                     status_block: statusBlock,
-                });
+                };
+
+                await runWithLock(
+                    resolvePatchSectionForPayload(engagementPatchPayload as Record<string, unknown>),
+                    (headers) => patchEngagement(engagementPatchPayload, headers),
+                );
             },
         });
     }
@@ -259,6 +427,7 @@ export const authoringUpdateAction: ActionFunction = async ({ request }) => {
                     languageCode,
                     defaultLanguageCode,
                     detailsTabsRaw: formData.get('details_tabs') as string,
+                    submittedLock,
                 });
             },
         });
@@ -272,18 +441,29 @@ export const authoringUpdateAction: ActionFunction = async ({ request }) => {
             task: async () => {
                 const selectedSurvey = formData.get('selected_survey_id');
                 const numericSelectedSurvey = selectedSurvey ? Number(selectedSurvey) : undefined;
-                await patchTranslationForLanguage({
-                    engagementId,
+                await runWithLock(
+                    SECTION_AUTHORING_FEEDBACK,
+                    (headers) =>
+                        patchTranslationForLanguage({
+                            engagementId,
+                            languageCode,
+                            payload: {
+                                feedback_heading: getOptionalFormText(formData, 'feedback_heading'),
+                                feedback_body: getOptionalFormText(formData, 'feedback_body'),
+                            },
+                            headers,
+                        }),
                     languageCode,
-                    payload: {
-                        feedback_heading: getOptionalFormText(formData, 'feedback_heading'),
-                        feedback_body: getOptionalFormText(formData, 'feedback_body'),
-                    },
-                });
-                await patchEngagement({
-                    id: engagementId,
-                    selected_survey_id: numericSelectedSurvey || undefined,
-                });
+                );
+                await runWithLock(SECTION_AUTHORING_FEEDBACK, (headers) =>
+                    patchEngagement(
+                        {
+                            id: engagementId,
+                            selected_survey_id: numericSelectedSurvey || undefined,
+                        },
+                        headers,
+                    ),
+                );
             },
         });
     }
@@ -309,17 +489,29 @@ export const authoringUpdateAction: ActionFunction = async ({ request }) => {
                     })
                     .filter((v) => v !== undefined);
 
-                await patchTranslationForLanguage({
-                    engagementId,
-                    languageCode,
-                    payload: {
-                        more_engagements_heading: moreEngagementsHeading || undefined,
+                await runWithLock(
+                    SECTION_AUTHORING_MORE,
+                    async (headers) => {
+                        await patchTranslationForLanguage({
+                            engagementId,
+                            languageCode,
+                            payload: {
+                                more_engagements_heading: moreEngagementsHeading || undefined,
+                            },
+                            headers,
+                        });
                     },
-                });
+                    languageCode,
+                );
                 // suggested_engagements is structural (cross-language), stays on base engagement.
-                await patchEngagement({
-                    id: engagementId,
-                    suggested_engagements: suggestions,
+                await runWithLock(SECTION_AUTHORING_MORE, async (headers) => {
+                    await patchEngagement(
+                        {
+                            id: engagementId,
+                            suggested_engagements: suggestions,
+                        },
+                        headers,
+                    );
                 });
             },
         });
@@ -331,15 +523,24 @@ export const authoringUpdateAction: ActionFunction = async ({ request }) => {
             label: 'Error updating engagement subscribe section',
             errors,
             task: async () => {
-                await patchTranslationForLanguage({
-                    engagementId,
+                await runWithLock(
+                    SECTION_AUTHORING_SUBSCRIBE,
+                    (headers) =>
+                        patchTranslationForLanguage({
+                            engagementId,
+                            languageCode,
+                            payload: {
+                                subscribe_section_heading: getOptionalFormText(formData, 'subscribe_section_heading'),
+                                subscribe_section_description: getOptionalFormText(
+                                    formData,
+                                    'subscribe_section_description',
+                                ),
+                                subscribe_consent_message: getOptionalFormText(formData, 'subscribe_consent_message'),
+                            },
+                            headers,
+                        }),
                     languageCode,
-                    payload: {
-                        subscribe_section_heading: getOptionalFormText(formData, 'subscribe_section_heading'),
-                        subscribe_section_description: getOptionalFormText(formData, 'subscribe_section_description'),
-                        subscribe_consent_message: getOptionalFormText(formData, 'subscribe_consent_message'),
-                    },
-                });
+                );
             },
         });
     }

--- a/web/src/components/engagement/admin/create/authoring/types.ts
+++ b/web/src/components/engagement/admin/create/authoring/types.ts
@@ -6,8 +6,8 @@ import { Engagement } from 'models/engagement';
 import { EditorState } from 'draft-js';
 import { FetcherWithComponents } from 'react-router';
 import { EngagementDetailsTab } from 'models/engagementDetailsTab';
-import { LanguageState } from 'reduxSlices/languageSlice';
 import { EngagementStatus } from 'constants/engagementStatus';
+import { ResourceLockRecord, ResourceLocksForEngagement } from 'services/resourceLockService';
 
 export interface AuthoringNavProps {
     open: boolean;
@@ -27,11 +27,38 @@ export interface AuthoringContextType {
     defaultValues: EngagementUpdateData;
     setDefaultValues: Dispatch<SetStateAction<EngagementUpdateData>>;
     fetcher: FetcherWithComponents<object>;
+    activeLockToken: string | null;
+    setActiveLockToken: Dispatch<SetStateAction<string | null>>;
+    activeLockSectionKey: string | null;
+    setActiveLockSectionKey: Dispatch<SetStateAction<string | null>>;
+    activeLockLanguageId?: number;
+    setActiveLockLanguageId: Dispatch<SetStateAction<number | undefined>>;
+    // Set by a section (e.g. Details tabs) when the user adds/removes a structural, cross-language
+    // resource, so the current section's edit lock escalates to an unscoped (whole-section) lock.
+    lockScopeWideningRequested: boolean;
+    setLockScopeWideningRequested: Dispatch<SetStateAction<boolean>>;
+    activeLanguageCode: string;
+    isLoadingLanguageOptions: boolean;
+    languageOptions: Language[];
+    locks: ResourceLocksForEngagement;
+    isLoading: boolean;
+    languageId?: number;
+    locksBySection: Record<
+        | 'Hero Banner'
+        | 'Summary'
+        | 'Details'
+        | 'Provide Feedback'
+        | 'View Results'
+        | 'Subscribe'
+        | 'More Engagements'
+        | 'Survey'
+        | '3rd Party Feedback Method Link',
+        ResourceLockRecord | null
+    >;
+    refreshLocks: () => Promise<ResourceLocksForEngagement>;
 }
 
 export interface LanguageSelectorProps {
-    currentLanguage: LanguageState;
-    languages: Promise<Language[]>;
     isDirty: boolean;
     isSubmitting: boolean;
     currentSectionIncompleteLanguageCodes: string[];
@@ -44,13 +71,10 @@ export interface AuthoringMorePreformProps {
 }
 
 export interface AuthoringBottomNavProps {
-    currentLanguage: LanguageState;
-    languages: Promise<Language[]>;
     pageTitle: string;
     pageName: string;
     currentSectionIncompleteLanguageCodes: string[];
     isSectionCompletionLoading: boolean;
-    onSaveSection: () => void;
     setUnsavedWorkPromptSuppressed: Dispatch<SetStateAction<boolean>>;
 }
 

--- a/web/src/components/engagement/admin/create/authoring/useAuthoringSectionCompletion.ts
+++ b/web/src/components/engagement/admin/create/authoring/useAuthoringSectionCompletion.ts
@@ -11,14 +11,28 @@ import { EngagementDetailsTab } from 'models/engagementDetailsTab';
 import { AppConfig } from 'config';
 import { useNavigate } from 'react-router';
 
+export const AUTHORING_SECTION = {
+    HERO_BANNER: 'Hero Banner',
+    SUMMARY: 'Summary',
+    DETAILS: 'Details',
+    PROVIDE_FEEDBACK: 'Provide Feedback',
+    VIEW_RESULTS: 'View Results',
+    SUBSCRIBE: 'Subscribe',
+    MORE_ENGAGEMENTS: 'More Engagements',
+    SURVEY: 'Survey',
+    THIRD_PARTY_FEEDBACK_METHOD_LINK: '3rd Party Feedback Method Link',
+} as const;
+
 export const AUTHORING_SECTION_NAMES = [
-    'Hero Banner',
-    'Summary',
-    'Details',
-    'Provide Feedback',
-    'View Results',
-    'Subscribe',
-    'More Engagements',
+    AUTHORING_SECTION.HERO_BANNER,
+    AUTHORING_SECTION.SUMMARY,
+    AUTHORING_SECTION.DETAILS,
+    AUTHORING_SECTION.PROVIDE_FEEDBACK,
+    AUTHORING_SECTION.VIEW_RESULTS,
+    AUTHORING_SECTION.SUBSCRIBE,
+    AUTHORING_SECTION.MORE_ENGAGEMENTS,
+    AUTHORING_SECTION.SURVEY,
+    AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK,
 ] as const;
 
 export type AuthoringSectionName = (typeof AUTHORING_SECTION_NAMES)[number];
@@ -51,37 +65,57 @@ interface CompletionComputationResult {
 
 type PerLanguageCompletion = Record<string, AuthoringSectionCompletion>;
 
-const REQUIRED_SECTION_NAMES: AuthoringSectionName[] = ['Hero Banner', 'Summary', 'Details', 'Provide Feedback'];
-const REQUIRED_SECTION_NAME_SET = new Set<AuthoringSectionName>(REQUIRED_SECTION_NAMES);
+export const REQUIRED_AUTHORING_SECTION_NAMES: readonly AuthoringSectionName[] = [
+    AUTHORING_SECTION.HERO_BANNER,
+    AUTHORING_SECTION.SUMMARY,
+    AUTHORING_SECTION.DETAILS,
+    AUTHORING_SECTION.PROVIDE_FEEDBACK,
+];
+const REQUIRED_SECTION_NAME_SET = new Set<AuthoringSectionName>(REQUIRED_AUTHORING_SECTION_NAMES);
 
 const DEFAULT_SECTION_INCOMPLETE_LANGUAGES: AuthoringSectionIncompleteLanguages = {
-    'Hero Banner': [],
-    Summary: [],
-    Details: [],
-    'Provide Feedback': [],
-    'View Results': [],
-    Subscribe: [],
-    'More Engagements': [],
+    [AUTHORING_SECTION.HERO_BANNER]: [],
+    [AUTHORING_SECTION.SUMMARY]: [],
+    [AUTHORING_SECTION.DETAILS]: [],
+    [AUTHORING_SECTION.PROVIDE_FEEDBACK]: [],
+    [AUTHORING_SECTION.VIEW_RESULTS]: [],
+    [AUTHORING_SECTION.SUBSCRIBE]: [],
+    [AUTHORING_SECTION.MORE_ENGAGEMENTS]: [],
+    [AUTHORING_SECTION.SURVEY]: [],
+    [AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK]: [],
 };
 
 const DEFAULT_SECTION_COMPLETION: AuthoringSectionCompletion = {
-    'Hero Banner': false,
-    Summary: false,
-    Details: false,
-    'Provide Feedback': false,
-    'View Results': false,
-    Subscribe: false,
-    'More Engagements': false,
+    [AUTHORING_SECTION.HERO_BANNER]: false,
+    [AUTHORING_SECTION.SUMMARY]: false,
+    [AUTHORING_SECTION.DETAILS]: false,
+    [AUTHORING_SECTION.PROVIDE_FEEDBACK]: false,
+    [AUTHORING_SECTION.VIEW_RESULTS]: false,
+    [AUTHORING_SECTION.SUBSCRIBE]: false,
+    [AUTHORING_SECTION.MORE_ENGAGEMENTS]: false,
+    [AUTHORING_SECTION.SURVEY]: false,
+    [AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK]: false,
 };
 
 const DEFAULT_EXPECTED_FIELDS: Record<AuthoringSectionName, string[]> = {
-    'Hero Banner': ['name', 'banner_url', 'open_link'],
-    Summary: ['description_title', 'rich_description'],
-    Details: ['details_tabs.length', 'details_tabs[n].label', 'details_tabs[n].heading', 'details_tabs[n].body'],
-    'Provide Feedback': ['feedback_heading', 'feedback_body'],
-    'View Results': ['view_results_status_block_button_text', 'view_results_link'],
-    Subscribe: ['subscribe_section_heading', 'subscribe_section_description', 'subscribe_consent_message'],
-    'More Engagements': ['more_engagements_heading'],
+    [AUTHORING_SECTION.HERO_BANNER]: ['name', 'banner_url', 'open_link'],
+    [AUTHORING_SECTION.SUMMARY]: ['description_title', 'rich_description'],
+    [AUTHORING_SECTION.DETAILS]: [
+        'details_tabs.length',
+        'details_tabs[n].label',
+        'details_tabs[n].heading',
+        'details_tabs[n].body',
+    ],
+    [AUTHORING_SECTION.PROVIDE_FEEDBACK]: ['feedback_heading', 'feedback_body'],
+    [AUTHORING_SECTION.VIEW_RESULTS]: ['view_results_status_block_button_text', 'view_results_link'],
+    [AUTHORING_SECTION.SUBSCRIBE]: [
+        'subscribe_section_heading',
+        'subscribe_section_description',
+        'subscribe_consent_message',
+    ],
+    [AUTHORING_SECTION.MORE_ENGAGEMENTS]: ['more_engagements_heading'],
+    [AUTHORING_SECTION.SURVEY]: ['survey'],
+    [AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK]: ['3rd_party_feedback_method_link'],
 };
 
 const DEFAULT_SECTION_DEBUG = AUTHORING_SECTION_NAMES.reduce((acc, sectionName) => {
@@ -245,8 +279,8 @@ const computeSectionCompletion = async (
 
     const localizedDetails = getDetailsForLanguage(detailsTabs, contentTranslations, normalizedLanguageCode);
 
-    const sectionFields = {
-        'Hero Banner': [
+    const sectionFields: Record<AuthoringSectionName, SectionFieldStatus[]> = {
+        [AUTHORING_SECTION.HERO_BANNER]: [
             {
                 key: 'name',
                 complete: hasText(getLocalizedField(engagement.name, translation, 'name')),
@@ -260,7 +294,7 @@ const computeSectionCompletion = async (
                 complete: isBlockLinkComplete(openBlock?.link_type, openBlock?.internal_link, openBlock?.external_link),
             },
         ],
-        Summary: [
+        [AUTHORING_SECTION.SUMMARY]: [
             {
                 key: 'description_title',
                 complete: hasText(getLocalizedField(engagement.description_title, translation, 'description_title')),
@@ -270,7 +304,7 @@ const computeSectionCompletion = async (
                 complete: hasText(getLocalizedField(engagement.rich_description, translation, 'rich_description')),
             },
         ],
-        Details:
+        [AUTHORING_SECTION.DETAILS]:
             localizedDetails.length > 0
                 ? localizedDetails.flatMap((tab, index) => [
                       {
@@ -292,7 +326,7 @@ const computeSectionCompletion = async (
                           complete: false,
                       },
                   ],
-        'Provide Feedback': [
+        [AUTHORING_SECTION.PROVIDE_FEEDBACK]: [
             {
                 key: 'feedback_heading',
                 complete: hasText(getLocalizedField(engagement.feedback_heading, translation, 'feedback_heading')),
@@ -302,7 +336,7 @@ const computeSectionCompletion = async (
                 complete: hasText(getLocalizedField(engagement.feedback_body, translation, 'feedback_body')),
             },
         ],
-        'View Results': [
+        [AUTHORING_SECTION.VIEW_RESULTS]: [
             {
                 key: 'view_results_status_block_button_text',
                 complete: hasText(
@@ -322,7 +356,7 @@ const computeSectionCompletion = async (
                 ),
             },
         ],
-        Subscribe: [
+        [AUTHORING_SECTION.SUBSCRIBE]: [
             {
                 key: 'subscribe_section_heading',
                 complete: hasText(
@@ -355,7 +389,7 @@ const computeSectionCompletion = async (
                 ),
             },
         ],
-        'More Engagements': [
+        [AUTHORING_SECTION.MORE_ENGAGEMENTS]: [
             {
                 key: 'more_engagements_heading',
                 complete: hasText(
@@ -363,38 +397,37 @@ const computeSectionCompletion = async (
                 ),
             },
         ],
+        [AUTHORING_SECTION.SURVEY]: [
+            {
+                key: 'survey',
+                complete: engagement.surveys.length > 0,
+            },
+        ],
+        [AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK]: [
+            {
+                key: '3rd_party_feedback_method_link',
+                complete: false,
+            },
+        ],
     };
 
-    const sectionComputation: Record<AuthoringSectionName, SectionComputationResult> = {
-        'Hero Banner': {
-            complete: sectionFields['Hero Banner'].every((field) => field.complete),
-            fields: sectionFields['Hero Banner'],
+    const sectionComputation: Record<AuthoringSectionName, SectionComputationResult> = AUTHORING_SECTION_NAMES.reduce(
+        (acc, sectionName) => {
+            const fields = sectionFields[sectionName];
+            const complete =
+                sectionName === AUTHORING_SECTION.DETAILS
+                    ? localizedDetails.length > 0 && fields.every((field) => field.complete)
+                    : fields.every((field) => field.complete);
+
+            acc[sectionName] = {
+                complete,
+                fields,
+            };
+
+            return acc;
         },
-        Summary: {
-            complete: sectionFields['Summary'].every((field) => field.complete),
-            fields: sectionFields['Summary'],
-        },
-        Details: {
-            complete: localizedDetails.length > 0 && sectionFields['Details'].every((field) => field.complete),
-            fields: sectionFields['Details'],
-        },
-        'Provide Feedback': {
-            complete: sectionFields['Provide Feedback'].every((field) => field.complete),
-            fields: sectionFields['Provide Feedback'],
-        },
-        'View Results': {
-            complete: sectionFields['View Results'].every((field) => field.complete),
-            fields: sectionFields['View Results'],
-        },
-        Subscribe: {
-            complete: sectionFields['Subscribe'].every((field) => field.complete),
-            fields: sectionFields['Subscribe'],
-        },
-        'More Engagements': {
-            complete: sectionFields['More Engagements'].every((field) => field.complete),
-            fields: sectionFields['More Engagements'],
-        },
-    };
+        {} as Record<AuthoringSectionName, SectionComputationResult>,
+    );
 
     const completionBySection: AuthoringSectionCompletion = AUTHORING_SECTION_NAMES.reduce((acc, sectionName) => {
         acc[sectionName] = sectionComputation[sectionName].complete;
@@ -537,6 +570,7 @@ export const useAuthoringSectionCompletion = ({
                     error.status === 302 &&
                     error.headers.get('Location') === '/manage/unauthorized'
                 ) {
+                    console.log('Got 302 redirect while processing section completion');
                     navigate('/manage/unauthorized', { replace: true });
                 }
                 console.debug('[AuthoringSectionCompletionDebug] compute failed', {
@@ -569,7 +603,7 @@ export const useAuthoringSectionCompletion = ({
     ]);
 
     const requiredSectionsComplete = useMemo(
-        () => REQUIRED_SECTION_NAMES.every((sectionName) => completionBySection[sectionName]),
+        () => REQUIRED_AUTHORING_SECTION_NAMES.every((sectionName) => completionBySection[sectionName]),
         [completionBySection],
     );
 

--- a/web/src/components/engagement/admin/create/authoring/useAuthoringSectionLockNavigation.tsx
+++ b/web/src/components/engagement/admin/create/authoring/useAuthoringSectionLockNavigation.tsx
@@ -1,0 +1,244 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import type { NavigateOptions } from 'react-router';
+import { useAppDispatch, useAppSelector } from 'hooks';
+import { openNotification } from 'services/notificationService/notificationSlice';
+import { releaseLock, ResourceLockRecord } from 'services/resourceLockService';
+import AuthoringLockConflictModal from './AuthoringLockConflictModal';
+import { USER_ROLES } from 'services/userService/constants';
+
+const AUTHORING_UNSAVED_CHANGES_KEY = 'authoring-unsaved-changes';
+export type NavigationRequestResult = 'navigated' | 'pending' | 'blocked';
+
+const getSectionLockState = (lock: ResourceLockRecord | null | undefined, currentUserRoles?: string[]) => {
+    const canBreakLock = Boolean(lock?.is_mine || currentUserRoles?.includes(USER_ROLES.EDIT_MEMBERS));
+    const isLockedByOther = Boolean(lock && !lock.is_mine);
+
+    return {
+        canBreakLock,
+        isLockedByOther,
+        isDisabled: isLockedByOther && !canBreakLock,
+    };
+};
+
+export const useSectionLockState = ({ lock }: { lock?: ResourceLockRecord | null }) => {
+    const currentUserRoles = useAppSelector((state) => state.user.roles);
+    return getSectionLockState(lock, currentUserRoles);
+};
+
+type PendingNavigation = {
+    href: string;
+    // Plain string (not AuthoringSectionName) so non-authoring consumers (e.g. config) can supply their own label.
+    sectionName: string;
+    lock: ResourceLockRecord;
+    onBeforeNavigate?: () => void;
+    navigationOptions?: NavigateOptions;
+};
+
+type ConflictModalOptions = {
+    lock?: ResourceLockRecord | null;
+    // Plain string (not AuthoringSectionName) so non-authoring consumers (e.g. config) can supply their own label.
+    sectionName?: string;
+    onBack: () => void;
+    onRetry?: () => Promise<void> | void;
+    onAfterBreakLock?: () => Promise<void> | void;
+    backButtonText?: string;
+    retryButtonText?: string;
+    breakButtonText?: string;
+};
+
+export const useAuthoringSectionLockNavigation = ({ conflictModal }: { conflictModal?: ConflictModalOptions } = {}) => {
+    const navigate = useNavigate();
+    const dispatch = useAppDispatch();
+    const [pendingNavigation, setPendingNavigation] = useState<PendingNavigation | null>(null);
+    const [isBreakingLock, setIsBreakingLock] = useState(false);
+    const [isConflictActionRunning, setIsConflictActionRunning] = useState(false);
+    const currentUserRoles = useAppSelector((state) => state.user.roles);
+
+    const resolveSectionLockState = useCallback(
+        (lock?: ResourceLockRecord | null) => {
+            return getSectionLockState(lock, currentUserRoles);
+        },
+        [currentUserRoles],
+    );
+
+    const requestNavigation = useCallback(
+        ({
+            href,
+            sectionName,
+            lock,
+            onBeforeNavigate,
+            navigationOptions,
+        }: {
+            href: string;
+            sectionName: string;
+            lock?: ResourceLockRecord | null;
+            onBeforeNavigate?: () => void;
+            navigationOptions?: NavigateOptions;
+        }): NavigationRequestResult => {
+            const { canBreakLock, isDisabled } = resolveSectionLockState(lock);
+            if (!lock || lock.is_mine) {
+                onBeforeNavigate?.();
+                navigate(href, navigationOptions);
+                return 'navigated';
+            }
+
+            if (isDisabled) {
+                return 'blocked';
+            }
+
+            if (canBreakLock) {
+                const hasUnsavedChanges = sessionStorage.getItem(AUTHORING_UNSAVED_CHANGES_KEY) === '1';
+                if (hasUnsavedChanges) {
+                    onBeforeNavigate?.();
+                    navigate(href, navigationOptions);
+                    return 'navigated';
+                }
+
+                setPendingNavigation({
+                    href,
+                    sectionName,
+                    lock,
+                    onBeforeNavigate,
+                    navigationOptions,
+                });
+                return 'pending';
+            }
+
+            return 'blocked';
+        },
+        [navigate, resolveSectionLockState],
+    );
+
+    const closeBreakLockModal = useCallback(() => {
+        if (isBreakingLock) {
+            return;
+        }
+
+        setPendingNavigation(null);
+    }, [isBreakingLock]);
+
+    const confirmBreakAndNavigate = useCallback(async () => {
+        if (!pendingNavigation) {
+            return;
+        }
+
+        setIsBreakingLock(true);
+        try {
+            const releaseReason =
+                currentUserRoles?.includes(USER_ROLES.SUPER_ADMIN) && !pendingNavigation.lock.is_mine
+                    ? 'force_takeover'
+                    : 'explicit';
+
+            await releaseLock(pendingNavigation.lock.lock_token, releaseReason);
+            pendingNavigation.onBeforeNavigate?.();
+            navigate(pendingNavigation.href, pendingNavigation.navigationOptions);
+            setPendingNavigation(null);
+        } catch (error) {
+            dispatch(
+                openNotification({
+                    severity: 'error',
+                    text: error instanceof Error ? error.message : 'Unable to break the existing lock.',
+                }),
+            );
+        } finally {
+            setIsBreakingLock(false);
+        }
+    }, [currentUserRoles, dispatch, navigate, pendingNavigation]);
+
+    const breakLockModal = useMemo(() => {
+        const pendingLock = pendingNavigation?.lock;
+        return (
+            <AuthoringLockConflictModal
+                open={Boolean(pendingNavigation)}
+                lock={pendingLock}
+                sectionName={pendingNavigation?.sectionName}
+                isBusy={isBreakingLock}
+                backButtonText="Stay Here"
+                showRetry={false}
+                breakButtonText="Break Lock and Continue"
+                onBack={closeBreakLockModal}
+                onBreakLock={() => {
+                    void confirmBreakAndNavigate();
+                }}
+            />
+        );
+    }, [closeBreakLockModal, confirmBreakAndNavigate, isBreakingLock, pendingNavigation]);
+
+    const conflictLockModal = useMemo(() => {
+        const currentLock = conflictModal?.lock;
+        if (!currentLock) {
+            return null;
+        }
+
+        const canBreakLock = Boolean(currentLock?.is_mine || currentUserRoles?.includes(USER_ROLES.EDIT_MEMBERS));
+
+        const handleRetry = conflictModal.onRetry;
+
+        const handleBreak = canBreakLock
+            ? async () => {
+                  setIsConflictActionRunning(true);
+                  try {
+                      await releaseLock(currentLock.lock_token, 'explicit');
+                      await conflictModal.onAfterBreakLock?.();
+                  } catch (error) {
+                      let errorMessage = 'Unable to release lock from the other tab.';
+                      if (error instanceof Error) {
+                          errorMessage = error.message;
+                      }
+                      dispatch(
+                          openNotification({
+                              severity: 'error',
+                              text: errorMessage,
+                          }),
+                      );
+                  } finally {
+                      setIsConflictActionRunning(false);
+                  }
+              }
+            : undefined;
+
+        return (
+            <AuthoringLockConflictModal
+                open={Boolean(currentLock)}
+                lock={currentLock}
+                sectionName={conflictModal.sectionName}
+                isBusy={isConflictActionRunning}
+                backButtonText={conflictModal.backButtonText}
+                retryButtonText={conflictModal.retryButtonText}
+                breakButtonText={conflictModal.breakButtonText}
+                onBack={conflictModal.onBack}
+                onRetry={
+                    handleRetry
+                        ? () => {
+                              void (async () => {
+                                  setIsConflictActionRunning(true);
+                                  try {
+                                      await handleRetry();
+                                  } finally {
+                                      setIsConflictActionRunning(false);
+                                  }
+                              })();
+                          }
+                        : undefined
+                }
+                onBreakLock={
+                    handleBreak
+                        ? () => {
+                              void handleBreak();
+                          }
+                        : undefined
+                }
+            />
+        );
+    }, [conflictModal, currentUserRoles, dispatch, isConflictActionRunning]);
+
+    return {
+        breakLockModal,
+        conflictLockModal,
+        resolveSectionLockState,
+        requestNavigation,
+    };
+};
+
+export default useAuthoringSectionLockNavigation;

--- a/web/src/components/engagement/admin/create/authoring/useAuthoringSectionLocks.ts
+++ b/web/src/components/engagement/admin/create/authoring/useAuthoringSectionLocks.ts
@@ -1,0 +1,174 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    ResourceLockRecord,
+    ResourceLocksForEngagement,
+    findScopedSectionLock,
+    SECTION_AUTHORING_BANNER,
+    SECTION_AUTHORING_DETAILS,
+    SECTION_AUTHORING_FEEDBACK,
+    SECTION_AUTHORING_MORE,
+    SECTION_AUTHORING_SUBSCRIBE,
+    SECTION_AUTHORING_SUMMARY,
+} from 'services/resourceLockService';
+import { useEngagementLocks } from 'services/resourceLockService/useEngagementLocks';
+import { getLanguageIdByCode } from 'services/engagementContentTranslationService';
+import { Language } from 'models/language';
+import { AUTHORING_SECTION, AUTHORING_SECTION_NAMES, AuthoringSectionName } from './useAuthoringSectionCompletion';
+
+const LOCK_POLL_INTERVAL_MS = 15000;
+
+type LockTarget = {
+    sectionKey: string;
+    languageScoped: boolean;
+};
+
+const LOCK_TARGET_BY_SECTION: Record<AuthoringSectionName, LockTarget | null> = {
+    [AUTHORING_SECTION.HERO_BANNER]: { sectionKey: SECTION_AUTHORING_BANNER, languageScoped: true },
+    [AUTHORING_SECTION.SUMMARY]: { sectionKey: SECTION_AUTHORING_SUMMARY, languageScoped: true },
+    [AUTHORING_SECTION.DETAILS]: { sectionKey: SECTION_AUTHORING_DETAILS, languageScoped: true },
+    [AUTHORING_SECTION.PROVIDE_FEEDBACK]: { sectionKey: SECTION_AUTHORING_FEEDBACK, languageScoped: true },
+    // View Results currently has no independently lock-scoped fields.
+    [AUTHORING_SECTION.VIEW_RESULTS]: null,
+    [AUTHORING_SECTION.SUBSCRIBE]: { sectionKey: SECTION_AUTHORING_SUBSCRIBE, languageScoped: true },
+    [AUTHORING_SECTION.MORE_ENGAGEMENTS]: { sectionKey: SECTION_AUTHORING_MORE, languageScoped: true },
+    // Survey and third-party link are configured in the feedback section and share its lock scope.
+    [AUTHORING_SECTION.SURVEY]: { sectionKey: SECTION_AUTHORING_FEEDBACK, languageScoped: true },
+    [AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK]: {
+        sectionKey: SECTION_AUTHORING_FEEDBACK,
+        languageScoped: true,
+    },
+};
+
+const SECTION_BY_PAGE: Record<string, AuthoringSectionName> = {
+    banner: AUTHORING_SECTION.HERO_BANNER,
+    summary: AUTHORING_SECTION.SUMMARY,
+    details: AUTHORING_SECTION.DETAILS,
+    feedback: AUTHORING_SECTION.PROVIDE_FEEDBACK,
+    results: AUTHORING_SECTION.VIEW_RESULTS,
+    subscribe: AUTHORING_SECTION.SUBSCRIBE,
+    more: AUTHORING_SECTION.MORE_ENGAGEMENTS,
+};
+
+export const getAuthoringSectionNameByPage = (pageName?: string): AuthoringSectionName | null => {
+    if (!pageName) {
+        return null;
+    }
+
+    return SECTION_BY_PAGE[pageName] ?? null;
+};
+
+export const getLockTargetBySectionName = (sectionName: AuthoringSectionName): LockTarget | null => {
+    return LOCK_TARGET_BY_SECTION[sectionName];
+};
+
+export const findSectionLock = ({
+    locks,
+    sectionName,
+    languageId,
+}: {
+    locks?: ResourceLocksForEngagement | null;
+    sectionName: AuthoringSectionName;
+    languageId?: number;
+}): ResourceLockRecord | null => {
+    if (!locks?.locks?.length) {
+        return null;
+    }
+
+    const target = getLockTargetBySectionName(sectionName);
+    if (!target) {
+        return null;
+    }
+
+    return findScopedSectionLock({
+        locks,
+        sectionKey: target.sectionKey,
+        languageId,
+        languageScoped: target.languageScoped,
+    });
+};
+
+export const useAuthoringSectionLocks = ({
+    engagementId,
+    languageCode,
+    languageOptions,
+    initialLocksPromise,
+    surveyUsesDedicatedLock = false,
+    pollIntervalMs = LOCK_POLL_INTERVAL_MS,
+}: {
+    engagementId: number;
+    languageCode: string;
+    languageOptions?: Pick<Language, 'id' | 'code'>[];
+    initialLocksPromise?: Promise<ResourceLocksForEngagement>;
+    surveyUsesDedicatedLock?: boolean;
+    pollIntervalMs?: number;
+}) => {
+    const [languageId, setLanguageId] = useState<number | undefined>(undefined);
+    const { locks, isLoading, refreshLocks } = useEngagementLocks({
+        engagementId,
+        initialLocksPromise,
+        pollIntervalMs,
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+
+        if (languageOptions !== undefined) {
+            const normalizedLanguageCode = languageCode.toLowerCase();
+            const selectedLanguage = languageOptions.find(
+                (language) => language.code.toLowerCase() === normalizedLanguageCode,
+            );
+
+            if (selectedLanguage && selectedLanguage.id > 0) {
+                setLanguageId(selectedLanguage.id);
+                return () => {
+                    cancelled = true;
+                };
+            }
+        }
+
+        const resolveLanguageId = async () => {
+            try {
+                const resolvedLanguageId = await getLanguageIdByCode(languageCode);
+                if (!cancelled) {
+                    setLanguageId(resolvedLanguageId);
+                }
+            } catch {
+                if (!cancelled) {
+                    setLanguageId(undefined);
+                }
+            }
+        };
+
+        void resolveLanguageId();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [languageCode, languageOptions]);
+
+    const locksBySection = useMemo(() => {
+        const entries = AUTHORING_SECTION_NAMES.map((sectionName) => {
+            if (sectionName === AUTHORING_SECTION.SURVEY && surveyUsesDedicatedLock) {
+                return [sectionName, null] as const;
+            }
+            return [
+                sectionName,
+                findSectionLock({
+                    locks,
+                    sectionName,
+                    languageId,
+                }),
+            ] as const;
+        });
+
+        return Object.fromEntries(entries) as Record<AuthoringSectionName, ResourceLockRecord | null>;
+    }, [languageId, locks, surveyUsesDedicatedLock]);
+
+    return {
+        locks,
+        isLoading,
+        languageId,
+        locksBySection,
+        refreshLocks,
+    };
+};

--- a/web/src/components/engagement/admin/view/AuthoringTab.tsx
+++ b/web/src/components/engagement/admin/view/AuthoringTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { AuthoringButtonProps, StatusCircleProps } from './types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowRightLong } from '@fortawesome/pro-light-svg-icons';
@@ -10,15 +10,24 @@ import { Collapse, Grid2 as Grid, MenuItem, Select, SelectChangeEvent, Skeleton 
 import { colors } from 'styles/Theme';
 import { Link } from 'components/common/Navigation';
 import { getDefaultAuthoringTabValues } from './AuthoringTabElements';
-import { useAppSelector } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { useParams, useRouteLoaderData } from 'react-router';
 import { EngagementLoaderAdminData } from '../EngagementLoaderAdmin';
 import { Language } from 'models/language';
 import { faGlobe } from '@fortawesome/pro-regular-svg-icons';
 import {
-    AuthoringSectionName,
+    AUTHORING_SECTION,
+    AUTHORING_SECTION_NAMES,
     useAuthoringSectionCompletion,
 } from 'components/engagement/admin/create/authoring/useAuthoringSectionCompletion';
+import { findSectionLock } from 'components/engagement/admin/create/authoring/useAuthoringSectionLocks';
+import LockOwnerAvatar from 'components/engagement/admin/create/authoring/LockOwnerAvatar';
+import { getPath, ROUTES } from 'routes/routes';
+import { saveLanguage } from 'reduxSlices/languageSlice';
+import useAuthoringSectionLockNavigation from 'components/engagement/admin/create/authoring/useAuthoringSectionLockNavigation';
+import { ResourceLockRecord } from 'services/resourceLockService';
+import { AppConfig } from 'config';
+import { useEngagementLocks } from 'services/resourceLockService/useEngagementLocks';
 
 export const StatusCircle = (props: StatusCircleProps) => {
     const statusCircleStyles = {
@@ -34,31 +43,43 @@ export const StatusCircle = (props: StatusCircleProps) => {
     return <span style={statusCircleStyles}> </span>;
 };
 
-const AuthoringButton = (props: AuthoringButtonProps & { isLoading?: boolean }) => {
+const AuthoringButton = (
+    props: AuthoringButtonProps & {
+        isLoading?: boolean;
+        onNavigate: (item: AuthoringButtonProps['item']) => void;
+        isDisabled: boolean;
+    },
+) => {
+    // Mix with white instead of altering opacity - ensure child avatar is not dimmed
+    const fadeWhenDisabled = (color: string) => {
+        if (!props.isDisabled) return color;
+        return `color-mix(in srgb, ${color} 60%, white)`;
+    };
+
+    const bgColor = props.item.required ? colors.surface.blue[10] : colors.surface.gray[10];
+
     const buttonStyles = {
         display: 'flex',
         width: '100%',
         height: '3rem',
-        backgroundColor: props.item.required ? colors.surface.blue[10] : colors.surface.gray[10],
+        backgroundColor: fadeWhenDisabled(bgColor),
         borderRadius: '8px',
         border: 'none',
         padding: '0 1rem 0 2.5rem',
         margin: '0 0 0.5rem',
         alignItems: 'center',
         justifyContent: 'flex-start',
-        cursor: 'pointer',
-    };
-    const textStyles = {
-        fontSize: '1rem',
-        color: colors.type.regular.primary,
+        cursor: props.isDisabled ? 'not-allowed' : 'pointer',
+        color: fadeWhenDisabled(colors.type.regular.primary),
+        position: 'relative' as const,
     };
     const arrowStyles = {
-        color: colors.surface.blue[90],
+        color: fadeWhenDisabled(colors.surface.blue[90]),
         fontSize: '1.3rem',
         marginLeft: 'auto',
     };
     const checkStyles = {
-        color: colors.type.regular.primary,
+        color: 'inherit',
         fontSize: '1rem',
         fontWeight: 'bold',
         paddingRight: '0.4rem',
@@ -68,12 +89,28 @@ const AuthoringButton = (props: AuthoringButtonProps & { isLoading?: boolean }) 
         return <Skeleton variant="rounded" height={48} width="100%" sx={{ mb: '0.5rem', borderRadius: '8px' }} />;
     }
 
+    const lock = props.item.lock;
+
     return (
-        <Link underline="none" style={{ ...buttonStyles }} to={props.item.link}>
+        <Link
+            underline="none"
+            sx={{ ...buttonStyles }}
+            to={props.isDisabled ? '#' : props.item.link}
+            aria-disabled={props.isDisabled}
+            onClick={
+                props.onNavigate
+                    ? (event) => {
+                          event.preventDefault();
+                          props.onNavigate(props.item);
+                      }
+                    : undefined
+            }
+        >
+            <LockOwnerAvatar sx={{ position: 'absolute', left: '0.5rem', cursor: 'default' }} lock={lock} size={20} />
             <When condition={props.item.completed}>
                 <FontAwesomeIcon style={checkStyles} icon={faCheck} />
             </When>
-            <span style={textStyles}>{props.item.title}</span>
+            <BodyText color="inherit">{props.item.title}</BodyText>
             <Unless condition={props.item.completed}>
                 <StatusCircle required={props.item.required} />
             </Unless>
@@ -83,12 +120,36 @@ const AuthoringButton = (props: AuthoringButtonProps & { isLoading?: boolean }) 
 };
 
 export const AuthoringTab = () => {
-    // Set useStates. When data is imported, it will be set with setSectionValues and setFeedbackMethods.
     const { engagementId } = useParams();
-    const { engagement, languages } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
-    const currentLanguageCode = useAppSelector((state) => state.language.id) || 'en';
-    const [selectedLanguageCode, setSelectedLanguageCode] = useState(currentLanguageCode);
-    const [languageOptions, setLanguageOptions] = useState<Language[]>([]);
+    const { engagement, languages, locks } = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
+    const resolvedEngagement = React.use(engagement);
+    const resolvedLanguages = React.use(languages);
+    const defaultLanguage = useMemo(
+        () => ({
+            id: 0,
+            code: AppConfig.language.defaultLanguageId,
+            name: AppConfig.language.defaultLanguageName,
+            right_to_left: AppConfig.language.defaultRightToLeft,
+        }),
+        [],
+    );
+    const selectedLanguage = useAppSelector((state) => state.language);
+    const selectedLanguageCode = selectedLanguage?.id ?? defaultLanguage.code;
+    const dispatch = useAppDispatch();
+    const setSelectedLanguage = (language: Language) => {
+        if (!language?.id) return;
+        dispatch(saveLanguage({ id: language.code, name: language.name }));
+    };
+    const languageOptions = resolvedLanguages;
+    const linkedSurveyId = useMemo(() => {
+        const selectedSurveyId = Number(resolvedEngagement.selected_survey_id);
+        if (Number.isFinite(selectedSurveyId) && selectedSurveyId > 0) {
+            return selectedSurveyId;
+        }
+
+        const firstSurveyId = Number(resolvedEngagement.surveys?.[0]?.id);
+        return Number.isFinite(firstSurveyId) && firstSurveyId > 0 ? firstSurveyId : null;
+    }, [resolvedEngagement]);
     const selectedLanguageCodes = useMemo(() => {
         if (languageOptions.length > 0) {
             return languageOptions.map((language) => language.code);
@@ -107,30 +168,64 @@ export const AuthoringTab = () => {
         selectedLanguageCodes,
         engagementPromise: engagement,
     });
+    const { locks: liveLocks } = useEngagementLocks({
+        engagementId: numericEngagementId,
+        initialLocksPromise: locks,
+    });
+    const selectedLanguageId = languageOptions.find((language) => language.code === selectedLanguageCode)?.id;
+    const locksBySection = useMemo(() => {
+        const entries = AUTHORING_SECTION_NAMES.map((sectionName) => {
+            if (sectionName === AUTHORING_SECTION.SURVEY && linkedSurveyId) {
+                return [sectionName, null] as const;
+            }
+
+            return [
+                sectionName,
+                findSectionLock({
+                    locks: liveLocks,
+                    sectionName,
+                    languageId: selectedLanguageId,
+                }),
+            ] as const;
+        });
+
+        return Object.fromEntries(entries) as Record<
+            (typeof AUTHORING_SECTION_NAMES)[number],
+            ResourceLockRecord | null
+        >;
+    }, [linkedSurveyId, liveLocks, selectedLanguageId]);
+    const { breakLockModal, resolveSectionLockState, requestNavigation } = useAuthoringSectionLockNavigation();
 
     const sectionValues = useMemo(
         () =>
             getDefaultAuthoringTabValues('sections', engagementId ?? '', selectedLanguageCode).map((section) => ({
                 ...section,
-                completed: completionBySection[section.title as AuthoringSectionName] ?? false,
+                completed: completionBySection[section.title] ?? false,
+                lock: locksBySection[section.title] ?? undefined,
             })),
-        [completionBySection, engagementId, selectedLanguageCode],
+        [completionBySection, engagementId, locksBySection, selectedLanguage],
     );
-    const feedbackCompleted = completionBySection['Provide Feedback'];
+
     const feedbackMethods = useMemo(
         () =>
             getDefaultAuthoringTabValues('feedback', engagementId ?? '', selectedLanguageCode).map((method) => ({
                 ...method,
-                completed: feedbackCompleted,
+                link:
+                    method.title === AUTHORING_SECTION.SURVEY && linkedSurveyId
+                        ? getPath(ROUTES.SURVEY_PREVIEW, { surveyId: linkedSurveyId })
+                        : method.link,
+                completed: completionBySection[method.title] ?? false,
+                lock:
+                    method.title === AUTHORING_SECTION.SURVEY && linkedSurveyId
+                        ? undefined
+                        : (locksBySection[method.title] ?? undefined),
             })),
-        [engagementId, feedbackCompleted, selectedLanguageCode],
+        [engagementId, completionBySection, linkedSurveyId, locksBySection, selectedLanguage],
     );
+    const feedbackCompleted = feedbackMethods.some((method) => method.completed);
     const optionalSectionValues = useMemo(() => sectionValues.filter((section) => !section.required), [sectionValues]);
 
-    const availableLanguageOptions =
-        languageOptions.length > 0
-            ? languageOptions
-            : [{ id: 0, code: 'en', name: 'English', right_to_left: false } as Language];
+    const availableLanguageOptions = languageOptions.length > 0 ? languageOptions : [defaultLanguage as Language];
 
     const languageSelectWidthCh = useMemo(() => {
         const longestOptionLength = availableLanguageOptions.reduce((maxLength, language) => {
@@ -157,33 +252,21 @@ export const AuthoringTab = () => {
     };
 
     useEffect(() => {
-        let isMounted = true;
-        void languages.then((resolvedLanguages) => {
-            if (!isMounted) {
-                return;
-            }
-            setLanguageOptions(resolvedLanguages);
-            const hasCurrentSelection = resolvedLanguages.some((language) => language.code === selectedLanguageCode);
-            if (!hasCurrentSelection) {
-                setSelectedLanguageCode('en');
-            }
-        });
-
-        return () => {
-            isMounted = false;
-        };
-    }, [languages, selectedLanguageCode]);
-
-    useEffect(() => {
-        setSelectedLanguageCode(currentLanguageCode);
-    }, [currentLanguageCode]);
+        const hasCurrentSelection = resolvedLanguages.some((language) => language.code === selectedLanguageCode);
+        if (!hasCurrentSelection) {
+            setSelectedLanguage(defaultLanguage);
+        }
+    }, [defaultLanguage, resolvedLanguages, selectedLanguageCode]);
 
     const handleLanguageSelectionChange = (event: SelectChangeEvent<string>) => {
-        setSelectedLanguageCode(event.target.value);
+        setSelectedLanguage(
+            availableLanguageOptions.find((language) => language.code === event.target.value) ?? defaultLanguage,
+        );
     };
 
     return (
         <Grid container id="admin-authoring-section" direction="column" maxWidth={'700px'}>
+            {breakLockModal}
             <Grid container direction="row" justifyContent="space-between" mb="1.5rem" rowGap={1}>
                 <Grid>
                     <Heading2 decorated>Authoring</Heading2>
@@ -264,7 +347,19 @@ export const AuthoringTab = () => {
                     </BodyText>
                     {sectionValues.map((section) =>
                         section.required ? (
-                            <AuthoringButton key={section.id} item={section} isLoading={isLoadingSectionCompletion} />
+                            <AuthoringButton
+                                key={section.id}
+                                item={section}
+                                isLoading={isLoadingSectionCompletion}
+                                isDisabled={resolveSectionLockState(section.lock).isDisabled}
+                                onNavigate={(item) => {
+                                    requestNavigation({
+                                        href: item.link,
+                                        sectionName: item.title,
+                                        lock: item.lock,
+                                    });
+                                }}
+                            />
                         ) : null,
                     )}
                 </Grid>
@@ -273,7 +368,19 @@ export const AuthoringTab = () => {
                         Optional Sections
                     </BodyText>
                     {optionalSectionValues.map((section) => (
-                        <AuthoringButton key={section.id} item={section} isLoading={isLoadingSectionCompletion} />
+                        <AuthoringButton
+                            key={section.id}
+                            item={section}
+                            isLoading={isLoadingSectionCompletion}
+                            isDisabled={resolveSectionLockState(section.lock).isDisabled}
+                            onNavigate={(item) => {
+                                requestNavigation({
+                                    href: item.link,
+                                    sectionName: item.title,
+                                    lock: item.lock,
+                                });
+                            }}
+                        />
                     ))}
                 </Grid>
             </Grid>
@@ -292,7 +399,19 @@ export const AuthoringTab = () => {
                 </BodyText>
                 <Grid size={12} sx={{ width: '100%' }}>
                     {feedbackMethods.map((method) => (
-                        <AuthoringButton item={method} key={method.id} isLoading={isLoadingSectionCompletion} />
+                        <AuthoringButton
+                            item={method}
+                            key={method.id}
+                            isLoading={isLoadingSectionCompletion}
+                            isDisabled={resolveSectionLockState(method.lock).isDisabled}
+                            onNavigate={(item) => {
+                                requestNavigation({
+                                    href: item.link,
+                                    sectionName: item.title,
+                                    lock: item.lock,
+                                });
+                            }}
+                        />
                     ))}
                 </Grid>
             </Grid>

--- a/web/src/components/engagement/admin/view/AuthoringTabElements.tsx
+++ b/web/src/components/engagement/admin/view/AuthoringTabElements.tsx
@@ -1,59 +1,60 @@
-import { AuthoringValue } from './types';
+import { AuthoringTabValue } from './types';
 import { getPath, ROUTES } from 'routes/routes';
+import { AUTHORING_SECTION } from 'components/engagement/admin/create/authoring/useAuthoringSectionCompletion';
 
 export const getDefaultAuthoringTabValues = (
-    type: string,
+    type: 'sections' | 'feedback',
     engagementId: number | string,
     languageCode: string = 'en',
-): AuthoringValue[] => {
+): AuthoringTabValue[] => {
     if ('sections' === type) {
         // Return the default "section" items
         return [
             {
                 id: 1,
-                title: 'Hero Banner',
+                title: AUTHORING_SECTION.HERO_BANNER,
                 link: getPath(ROUTES.AUTHORING_BANNER, { engagementId, languageCode }),
                 required: true,
                 completed: false,
             },
             {
                 id: 2,
-                title: 'Summary',
+                title: AUTHORING_SECTION.SUMMARY,
                 link: getPath(ROUTES.AUTHORING_SUMMARY, { engagementId, languageCode }),
                 required: true,
                 completed: false,
             },
             {
                 id: 3,
-                title: 'Details',
+                title: AUTHORING_SECTION.DETAILS,
                 link: getPath(ROUTES.AUTHORING_DETAILS, { engagementId, languageCode }),
                 required: true,
                 completed: false,
             },
             {
                 id: 4,
-                title: 'Provide Feedback',
+                title: AUTHORING_SECTION.PROVIDE_FEEDBACK,
                 link: getPath(ROUTES.AUTHORING_FEEDBACK, { engagementId, languageCode }),
                 required: true,
                 completed: false,
             },
             {
                 id: 5,
-                title: 'View Results',
+                title: AUTHORING_SECTION.VIEW_RESULTS,
                 link: getPath(ROUTES.AUTHORING_RESULTS, { engagementId, languageCode }),
                 required: false,
                 completed: false,
             },
             {
                 id: 6,
-                title: 'Subscribe',
+                title: AUTHORING_SECTION.SUBSCRIBE,
                 link: getPath(ROUTES.AUTHORING_SUBSCRIBE, { engagementId, languageCode }),
                 required: false,
                 completed: false,
             },
             {
                 id: 7,
-                title: 'More Engagements',
+                title: AUTHORING_SECTION.MORE_ENGAGEMENTS,
                 link: getPath(ROUTES.AUTHORING_MORE, { engagementId, languageCode }),
                 required: false,
                 completed: false,
@@ -64,15 +65,15 @@ export const getDefaultAuthoringTabValues = (
         return [
             {
                 id: 101,
-                title: 'Survey',
-                link: `#`,
+                title: AUTHORING_SECTION.SURVEY,
+                link: getPath(ROUTES.AUTHORING_FEEDBACK, { engagementId, languageCode }) + '#survey',
                 required: true,
                 completed: false,
             },
             {
                 id: 102,
-                title: '3rd Party Feedback Method Link',
-                link: `#`,
+                title: AUTHORING_SECTION.THIRD_PARTY_FEEDBACK_METHOD_LINK,
+                link: getPath(ROUTES.AUTHORING_FEEDBACK, { engagementId, languageCode }) + '#third-party-feedback',
                 required: true,
                 completed: false,
             },

--- a/web/src/components/engagement/admin/view/ConfigSummary.tsx
+++ b/web/src/components/engagement/admin/view/ConfigSummary.tsx
@@ -21,13 +21,28 @@ import { useAppSelector } from 'hooks';
 import { RouterLinkRenderer } from 'components/common/Navigation/Link';
 import { Engagement } from 'models/engagement';
 import { convertToPacific } from 'components/common/dateHelper';
+import useAuthoringSectionLockNavigation from '../create/authoring/useAuthoringSectionLockNavigation';
+import { ResourceLockRecord, SECTION_CONFIG_GENERAL, findScopedSectionLock } from 'services/resourceLockService';
+import LockOwnerAvatar from '../create/authoring/LockOwnerAvatar';
 
 export const ConfigSummary = () => {
     const siteUrl = getBaseUrl();
     const engagementId = useParams().engagementId;
     const language: LanguageState = useAppSelector((state) => state.language);
     const loaderData = useRouteLoaderData('single-engagement') as EngagementLoaderAdminData;
+    const configSectionLock = Promise.all([loaderData.languages, loaderData.locks]).then(([languages, locks]) => {
+        const defaultLanguage = languages.some((lang) => lang.code === 'en');
+        if (!defaultLanguage) {
+            return null;
+        }
+        return findScopedSectionLock({
+            locks,
+            sectionKey: SECTION_CONFIG_GENERAL,
+            languageScoped: false,
+        });
+    });
     const [recentlyCopied, setRecentlyCopied] = React.useState(false);
+    const { resolveSectionLockState, requestNavigation } = useAuthoringSectionLockNavigation();
 
     useEffect(() => {
         if (recentlyCopied) {
@@ -327,13 +342,45 @@ export const ConfigSummary = () => {
                     </OutlineBox>
                 </Grid>
                 <Grid pt={3}>
-                    <Button
-                        href={getPath(ROUTES.ENGAGEMENT_DETAILS_CONFIG_EDIT, { engagementId: Number(engagementId) })}
-                        LinkComponent={RouterLinkRenderer}
-                        icon={<FontAwesomeIcon icon={faPen} />}
+                    <Suspense
+                        fallback={
+                            <Skeleton
+                                variant="rectangular"
+                                height={48}
+                                width={210}
+                                sx={{ borderRadius: '0.5rem' }}
+                            ></Skeleton>
+                        }
                     >
-                        Edit Configuration
-                    </Button>
+                        <Await resolve={configSectionLock}>
+                            {(resolvedLock: ResourceLockRecord | null) => {
+                                const { isDisabled } = resolveSectionLockState(resolvedLock);
+                                return (
+                                    <Button
+                                        href={getPath(ROUTES.ENGAGEMENT_DETAILS_CONFIG_EDIT, {
+                                            engagementId: Number(engagementId),
+                                        })}
+                                        LinkComponent={RouterLinkRenderer}
+                                        icon={<FontAwesomeIcon icon={faPen} />}
+                                        disabled={isDisabled}
+                                        onClick={(event) => {
+                                            event.preventDefault();
+                                            requestNavigation({
+                                                href: getPath(ROUTES.ENGAGEMENT_DETAILS_CONFIG_EDIT, {
+                                                    engagementId: Number(engagementId),
+                                                }),
+                                                sectionName: 'config',
+                                                lock: resolvedLock,
+                                            });
+                                        }}
+                                    >
+                                        Edit Configuration
+                                        <LockOwnerAvatar sx={{ ml: 1 }} lock={resolvedLock ?? undefined} />
+                                    </Button>
+                                );
+                            }}
+                        </Await>
+                    </Suspense>
                 </Grid>
             </Grid>
         </Grid>

--- a/web/src/components/engagement/admin/view/types.tsx
+++ b/web/src/components/engagement/admin/view/types.tsx
@@ -1,9 +1,13 @@
-export interface AuthoringValue {
+import { ResourceLockRecord } from 'services/resourceLockService';
+import { AuthoringSectionName } from 'components/engagement/admin/create/authoring/useAuthoringSectionCompletion';
+
+export interface AuthoringTabValue {
     id: number;
-    title: string;
+    title: AuthoringSectionName;
     link: string;
     required: boolean;
     completed: boolean;
+    lock?: ResourceLockRecord;
 }
 
 export interface StatusCircleProps {
@@ -11,5 +15,5 @@ export interface StatusCircleProps {
 }
 
 export interface AuthoringButtonProps {
-    item: AuthoringValue;
+    item: AuthoringTabValue;
 }

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -20,6 +20,7 @@ const IS_SINGLE_TENANT_ENVIRONMENT = getEnv('REACT_APP_IS_SINGLE_TENANT_ENVIRONM
 const DEFAULT_TENANT = getEnv('REACT_APP_DEFAULT_TENANT');
 const DEFAULT_LANGUAGE_ID = getEnv('REACT_APP_DEFAULT_LANGUAGE_ID');
 const DEFAULT_LANGUAGE_NAME = getEnv('REACT_APP_DEFAULT_LANGUAGE_NAME');
+const DEFAULT_RIGHT_TO_LEFT = getEnv('REACT_APP_DEFAULT_RIGHT_TO_LEFT', 'false') === 'true';
 
 // version config
 const BUILD_COMMIT_HASH = getEnv('REACT_APP_BUILD_COMMIT_HASH', 'dev');
@@ -45,6 +46,7 @@ export const AppConfig = {
     language: {
         defaultLanguageId: DEFAULT_LANGUAGE_ID || 'en',
         defaultLanguageName: DEFAULT_LANGUAGE_NAME || 'English',
+        defaultRightToLeft: DEFAULT_RIGHT_TO_LEFT || false,
     },
     version: {
         commit: BUILD_COMMIT_HASH,

--- a/web/src/services/engagementContentTranslationService/index.ts
+++ b/web/src/services/engagementContentTranslationService/index.ts
@@ -1,7 +1,9 @@
 import Endpoints from 'apiManager/endpoints';
 import http from 'apiManager/httpRequestHandler';
 import { replaceUrl } from 'helper';
+import { Language } from 'models/language';
 import { getLanguages } from 'services/languageService';
+import { RequestHeaders } from 'services/type';
 
 export interface EngagementDetailsTabTranslation {
     id?: number;
@@ -88,8 +90,11 @@ const emptyContentTranslations = (): EngagementContentTranslations => ({
     image_widgets: [],
 });
 
-export const getLanguageIdByCode = async (languageCode: string): Promise<number> => {
-    const languages = await getLanguages();
+export const getLanguageIdByCode = async (
+    languageCode: string,
+    languagesPromise?: Promise<Language[]>,
+): Promise<number> => {
+    const languages = languagesPromise ? await languagesPromise : await getLanguages();
     const language = languages.find((lng) => lng.code === languageCode);
     if (!language) {
         throw new Error(`Invalid language code ${languageCode}`);
@@ -132,9 +137,10 @@ export const syncEngagementContentTranslationsByCode = async (
     engagementId: number,
     languageCode: string,
     data: SyncEngagementContentTranslationsRequest,
+    headers: RequestHeaders = {},
 ): Promise<unknown> => {
     const languageId = await getLanguageIdByCode(languageCode);
     const url = updateByLanguageIdUrl(engagementId, languageId);
-    const response = await http.PutRequest(url, data);
+    const response = await http.PutRequest(url, data, {}, headers);
     return response.data;
 };

--- a/web/src/services/engagementDetailsTabService/index.ts
+++ b/web/src/services/engagementDetailsTabService/index.ts
@@ -2,6 +2,7 @@ import http from 'apiManager/httpRequestHandler';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'helper';
 import { EngagementDetailsTab } from 'models/engagementDetailsTab';
+import { RequestHeaders } from 'services/type';
 
 export const getDetailsTabs = async (engagementId: number): Promise<EngagementDetailsTab[]> => {
     const url = replaceUrl(Endpoints.EngagementDetailsTab.GET_LIST, 'engagement_id', String(engagementId));
@@ -30,6 +31,7 @@ export const postDetailsTabs = async (
 export const patchDetailsTabs = async (
     engagementId: number,
     tabs: EngagementDetailsTab[],
+    headers: RequestHeaders = {},
 ): Promise<EngagementDetailsTab[]> => {
     const url = replaceAllInURL({
         URL: Endpoints.EngagementDetailsTab.UPDATE,
@@ -37,7 +39,7 @@ export const patchDetailsTabs = async (
             engagement_id: String(engagementId),
         },
     });
-    const response = await http.PutRequest<EngagementDetailsTab[]>(url, tabs);
+    const response = await http.PutRequest<EngagementDetailsTab[]>(url, tabs, {}, headers);
     if (response.data) {
         return response.data;
     }

--- a/web/src/services/engagementService/index.ts
+++ b/web/src/services/engagementService/index.ts
@@ -6,7 +6,7 @@ import { Language } from 'models/language';
 import { PatchEngagementRequest, PostEngagementRequest, PutEngagementRequest } from './types';
 import Endpoints from 'apiManager/endpoints';
 import { replaceUrl } from 'helper';
-import { Page } from 'services/type';
+import { Page, RequestHeaders } from 'services/type';
 import axios, { AxiosError } from 'axios';
 import { getLanguages } from 'services/languageService';
 
@@ -173,13 +173,14 @@ export const patchEngagementTranslation = async (
     engagementId: number,
     engagementTranslationId: number,
     data: Partial<EngagementTranslation>,
+    headers: RequestHeaders = {},
 ): Promise<EngagementTranslation> => {
     const url = replaceUrl(
         replaceUrl(Endpoints.EngagementTranslations.PATCH, 'engagement_id', String(engagementId)),
         'engagement_translation_id',
         String(engagementTranslationId),
     );
-    const response = await http.PatchRequest<EngagementTranslation>(url, data);
+    const response = await http.PatchRequest<EngagementTranslation>(url, data, headers);
     if (response.data) {
         return response.data;
     }
@@ -220,8 +221,11 @@ export const putEngagement = async (data: PutEngagementRequest): Promise<Engagem
     throw new Error('Failed to update engagement');
 };
 
-export const patchEngagement = async (data: PatchEngagementRequest): Promise<Engagement> => {
-    const response = await http.PatchRequest<Engagement>(Endpoints.Engagement.UPDATE, data);
+export const patchEngagement = async (
+    data: PatchEngagementRequest,
+    headers: RequestHeaders = {},
+): Promise<Engagement> => {
+    const response = await http.PatchRequest<Engagement>(Endpoints.Engagement.UPDATE, data, headers);
     if (response.data) {
         return response.data;
     }

--- a/web/src/services/resourceLockService/index.ts
+++ b/web/src/services/resourceLockService/index.ts
@@ -1,0 +1,366 @@
+import Endpoints from 'apiManager/endpoints';
+import http from 'apiManager/httpRequestHandler';
+import axios from 'axios';
+import { replaceUrl } from 'helper';
+
+export const LOCK_TOKEN_HEADER = 'X-Resource-Lock-Token';
+export const RESOURCE_TYPE_ENGAGEMENT_SECTION = 'engagement_section';
+
+export const SECTION_AUTHORING_BANNER = 'authoring.banner';
+export const SECTION_AUTHORING_SUMMARY = 'authoring.summary';
+export const SECTION_AUTHORING_DETAILS = 'authoring.details';
+export const SECTION_AUTHORING_FEEDBACK = 'authoring.feedback';
+export const SECTION_AUTHORING_RESULTS = 'authoring.results';
+export const SECTION_AUTHORING_SUBSCRIBE = 'authoring.subscribe';
+export const SECTION_AUTHORING_MORE = 'authoring.more';
+export const SECTION_CONFIG_GENERAL = 'config.general';
+
+const LOCK_SESSION_ID_KEY = 'engagement-lock-session-id';
+
+export interface ResourceLockOwner {
+    user_sub: string;
+    display_name?: string;
+    first_name?: string;
+    last_name?: string;
+}
+
+export interface ResourceLockRecord {
+    lock_token: string;
+    lock_scope: string;
+    resource_type: string;
+    resource_id: number;
+    section_key?: string;
+    language_id?: number;
+    owner: ResourceLockOwner;
+    owner_session_id: string;
+    acquired_at: string;
+    heartbeat_at?: string;
+    expires_at?: string;
+    is_mine: boolean;
+}
+
+export interface ResourceLocksForEngagement {
+    resource_type: string;
+    resource_id: number;
+    locks: ResourceLockRecord[];
+}
+
+export type LockConflictPayload = {
+    code?: string;
+    message?: string;
+    lock_scope?: string;
+    owner?: {
+        user_sub?: string;
+        display_name?: string;
+        first_name?: string;
+        last_name?: string;
+    };
+    expires_at?: string;
+};
+
+type ResourceLockEvent =
+    | {
+          type: 'upsert';
+          lock: ResourceLockRecord;
+      }
+    | {
+          type: 'release';
+          lockToken: string;
+      };
+
+type ResourceLockListener = (event: ResourceLockEvent) => void;
+
+const resourceLockListeners = new Set<ResourceLockListener>();
+
+const emitResourceLockEvent = (event: ResourceLockEvent) => {
+    resourceLockListeners.forEach((listener) => {
+        listener(event);
+    });
+};
+
+export const subscribeToResourceLockEvents = (listener: ResourceLockListener) => {
+    resourceLockListeners.add(listener);
+    return () => {
+        resourceLockListeners.delete(listener);
+    };
+};
+
+export const applyResourceLockEvent = (
+    currentLocks: ResourceLocksForEngagement,
+    event: ResourceLockEvent,
+): ResourceLocksForEngagement => {
+    if (event.type === 'release') {
+        return {
+            ...currentLocks,
+            locks: currentLocks.locks.filter((lock) => lock.lock_token !== event.lockToken),
+        };
+    }
+
+    const nextLocks = currentLocks.locks.filter(
+        (lock) => lock.lock_token !== event.lock.lock_token && lock.lock_scope !== event.lock.lock_scope,
+    );
+
+    return {
+        ...currentLocks,
+        resource_type: event.lock.resource_type,
+        resource_id: event.lock.resource_id,
+        locks: [...nextLocks, event.lock],
+    };
+};
+
+interface AcquireLockRequest {
+    resource_type: string;
+    resource_id: number;
+    section_key: string;
+    owner_session_id: string;
+    owner_display_name?: string;
+    language_id?: number;
+    ttl_seconds?: number;
+}
+
+interface RefreshLockRequest {
+    lock_token: string;
+    owner_session_id: string;
+    ttl_seconds?: number;
+}
+
+interface ReleaseLockRequest {
+    lock_token: string;
+    release_reason?: 'explicit' | 'expired_takeover' | 'logout' | 'navigation' | 'force_takeover';
+}
+
+/**
+ * Gets or creates a unique session ID for the current user session, stored in sessionStorage.
+ * This ID is used to differentiate different sessions started by the same user.
+ * @returns The unique session ID for the current user session.
+ */
+export const getOrCreateLockSessionId = (): string => {
+    const existing = sessionStorage.getItem(LOCK_SESSION_ID_KEY);
+    if (existing) {
+        return existing;
+    }
+
+    const sessionId = crypto.randomUUID();
+    sessionStorage.setItem(LOCK_SESSION_ID_KEY, sessionId);
+    return sessionId;
+};
+
+/**
+ * Acquires a lock for a specific engagement section.
+ * @param engagementId - The ID of the engagement.
+ * @param sectionKey - The key of the section to lock.
+ * @param languageId - Optional. The language ID for the section.
+ * @param ownerDisplayName - Optional. The display name of the lock owner.
+ * @param ttlSeconds - Optional. Time-to-live in seconds for the lock.
+ * @returns A promise that resolves to the acquired ResourceLockRecord.
+ */
+export const acquireEngagementSectionLock = async ({
+    engagementId,
+    sectionKey,
+    languageId,
+    ownerDisplayName,
+    ttlSeconds,
+}: {
+    engagementId: number;
+    sectionKey: string;
+    languageId?: number;
+    ownerDisplayName?: string;
+    ttlSeconds?: number;
+}): Promise<ResourceLockRecord> => {
+    const payload: AcquireLockRequest = {
+        resource_type: RESOURCE_TYPE_ENGAGEMENT_SECTION,
+        resource_id: engagementId,
+        section_key: sectionKey,
+        owner_session_id: getOrCreateLockSessionId(),
+        language_id: languageId,
+        owner_display_name: ownerDisplayName,
+        ttl_seconds: ttlSeconds,
+    };
+
+    const response = await http.PostRequest<ResourceLockRecord>(Endpoints.ResourceLocks.ACQUIRE, payload);
+    if (!response.data) {
+        throw new Error('Failed to acquire lock');
+    }
+    emitResourceLockEvent({ type: 'upsert', lock: response.data });
+    return response.data;
+};
+
+/**
+ * Refreshes an existing lock.
+ * @param lockToken - The token of the lock to refresh.
+ * @param ttlSeconds - Optional. Time-to-live in seconds for the lock.
+ * @returns A promise that resolves to the refreshed ResourceLockRecord.
+ */
+export const refreshLock = async (lockToken: string, ttlSeconds?: number): Promise<ResourceLockRecord> => {
+    const payload: RefreshLockRequest = {
+        lock_token: lockToken,
+        owner_session_id: getOrCreateLockSessionId(),
+        ttl_seconds: ttlSeconds,
+    };
+
+    const response = await http.PostRequest<ResourceLockRecord>(Endpoints.ResourceLocks.REFRESH, payload);
+    if (!response.data) {
+        throw new Error('Failed to refresh lock');
+    }
+    emitResourceLockEvent({ type: 'upsert', lock: response.data });
+    return response.data;
+};
+
+/**
+ * Releases an existing lock.
+ * @param lockToken - The token of the lock to release.
+ * @param releaseReason - Optional. The reason for releasing the lock.
+ * @returns A promise that resolves to an object indicating whether the lock was released and the release timestamp.
+ */
+export const releaseLock = async (
+    lockToken: string,
+    releaseReason: ReleaseLockRequest['release_reason'] = 'explicit',
+): Promise<{ released: boolean; released_at?: string | null }> => {
+    const payload: ReleaseLockRequest = {
+        lock_token: lockToken,
+        release_reason: releaseReason,
+    };
+
+    const response = await http.PostRequest<{ released: boolean; released_at?: string | null }>(
+        Endpoints.ResourceLocks.RELEASE,
+        payload,
+    );
+    if (!response.data) {
+        throw new Error('Failed to release lock');
+    }
+    if (response.data.released) {
+        emitResourceLockEvent({ type: 'release', lockToken });
+    }
+    return response.data;
+};
+
+/**
+ * Gets all locks for a specific engagement.
+ * @param engagementId - The ID of the engagement.
+ * @returns A promise that resolves to the resource locks for the engagement.
+ */
+export const getEngagementLocks = async (engagementId: number): Promise<ResourceLocksForEngagement> => {
+    const url = replaceUrl(Endpoints.Engagement.GET_LOCKS, 'engagement_id', String(engagementId));
+    const response = await http.GetRequest<ResourceLocksForEngagement>(url, {
+        owner_session_id: getOrCreateLockSessionId(),
+    });
+    if (!response.data) {
+        throw new Error('Failed to fetch engagement locks');
+    }
+    return response.data;
+};
+
+/**
+ * Checks if a section is locked.
+ * @param locks - The resource locks for the engagement.
+ * @param sectionKey - The key of the section to check.
+ * @param by - Optional. Specify 'others' to exclude locks owned by the current user,
+ * or 'me' to check *only* locks owned by the current user.
+ * @returns True if the section is locked based on the criteria, false otherwise.
+ */
+export const isSectionLocked = ({
+    locks,
+    sectionKey,
+    by,
+}: {
+    locks: ResourceLocksForEngagement;
+    sectionKey: string;
+    by?: 'me' | 'other';
+}): boolean => {
+    if (by === 'me') {
+        return locks.locks.some((lock) => lock.section_key === sectionKey && lock.is_mine);
+    }
+    if (by === 'other') {
+        return locks.locks.some((lock) => lock.section_key === sectionKey && !lock.is_mine);
+    }
+    return locks.locks.some((lock) => lock.section_key === sectionKey);
+};
+
+export const getLockConflictPayload = (error: unknown): LockConflictPayload | null => {
+    if (!axios.isAxiosError(error)) {
+        return null;
+    }
+
+    const payload = error.response?.data as LockConflictPayload | undefined;
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    if (payload.code !== 'lock_conflict' && payload.code !== 'lock_not_owner') {
+        return null;
+    }
+
+    return payload;
+};
+
+export const getLockOwnerDisplayName = (owner?: ResourceLockOwner): string => {
+    if (!owner) {
+        return 'another editor';
+    }
+
+    const fullName = [owner.first_name, owner.last_name].filter(Boolean).join(' ').trim();
+    if (fullName) {
+        return fullName;
+    }
+
+    if (owner.display_name?.trim()) {
+        return owner.display_name.trim();
+    }
+
+    return 'another editor';
+};
+
+export const findScopedSectionLock = ({
+    locks,
+    sectionKey,
+    languageId,
+    languageScoped = true,
+}: {
+    locks?: ResourceLocksForEngagement | null;
+    sectionKey: string;
+    languageId?: number;
+    languageScoped?: boolean;
+}): ResourceLockRecord | null => {
+    if (!locks?.locks?.length) {
+        return null;
+    }
+
+    const matchingLocks = [...locks.locks]
+        .filter((lock) => {
+            if (lock.section_key !== sectionKey) {
+                return false;
+            }
+
+            if (!languageScoped) {
+                return lock.language_id === null || lock.language_id === undefined;
+            }
+
+            if (lock.language_id === null || lock.language_id === undefined) {
+                return true;
+            }
+
+            if (languageId === undefined) {
+                return true;
+            }
+
+            return lock.language_id === languageId;
+        })
+        .sort((left, right) => {
+            if (left.is_mine !== right.is_mine) {
+                return left.is_mine ? 1 : -1;
+            }
+
+            // Prefer showing the less-specific (unscoped, whole-section) lock over a language-scoped one.
+            const leftUnscoped = left.language_id === null || left.language_id === undefined;
+            const rightUnscoped = right.language_id === null || right.language_id === undefined;
+            if (leftUnscoped !== rightUnscoped) {
+                return leftUnscoped ? -1 : 1;
+            }
+
+            const leftHeartbeat = left.heartbeat_at ? Date.parse(left.heartbeat_at) : 0;
+            const rightHeartbeat = right.heartbeat_at ? Date.parse(right.heartbeat_at) : 0;
+            return rightHeartbeat - leftHeartbeat;
+        });
+
+    return matchingLocks[0] ?? null;
+};

--- a/web/src/services/resourceLockService/useEngagementLocks.ts
+++ b/web/src/services/resourceLockService/useEngagementLocks.ts
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    applyResourceLockEvent,
+    getEngagementLocks,
+    ResourceLocksForEngagement,
+    subscribeToResourceLockEvents,
+} from './index';
+
+const DEFAULT_LOCK_POLL_INTERVAL_MS = 15000;
+
+const EMPTY_LOCKS: ResourceLocksForEngagement = {
+    resource_type: 'engagement_section',
+    resource_id: 0,
+    locks: [],
+};
+
+type LockStoreSnapshot = {
+    locks: ResourceLocksForEngagement;
+    isLoading: boolean;
+};
+
+type EngagementLockStore = {
+    getSnapshot: () => LockStoreSnapshot;
+    subscribe: (listener: () => void) => () => void;
+    retain: (initialLocksPromise?: Promise<ResourceLocksForEngagement>) => void;
+    release: () => boolean;
+    refresh: () => Promise<ResourceLocksForEngagement>;
+    seed: (locks: ResourceLocksForEngagement) => void;
+    setPollIntervalMs: (pollIntervalMs: number) => void;
+};
+
+const engagementLockStores = new Map<number, EngagementLockStore>();
+
+const createEngagementLockStore = ({
+    engagementId,
+    pollIntervalMs,
+}: {
+    engagementId: number;
+    pollIntervalMs: number;
+}): EngagementLockStore => {
+    let snapshot: LockStoreSnapshot = {
+        locks: EMPTY_LOCKS,
+        isLoading: true,
+    };
+    let referenceCount = 0;
+    let hasInitialized = false;
+    let currentPollIntervalMs = pollIntervalMs;
+    let intervalId: ReturnType<typeof globalThis.setInterval> | null = null;
+    let unsubscribeFromEvents: (() => void) | null = null;
+    let inFlightRefresh: Promise<ResourceLocksForEngagement> | null = null;
+    let inFlightInitialize: Promise<void> | null = null;
+    const listeners = new Set<() => void>();
+
+    const emit = () => {
+        listeners.forEach((listener) => {
+            listener();
+        });
+    };
+
+    const updateSnapshot = (nextSnapshot: LockStoreSnapshot | ((current: LockStoreSnapshot) => LockStoreSnapshot)) => {
+        snapshot = typeof nextSnapshot === 'function' ? nextSnapshot(snapshot) : nextSnapshot;
+        emit();
+    };
+
+    const refresh = async () => {
+        if (!Number.isFinite(engagementId) || engagementId <= 0) {
+            updateSnapshot({
+                locks: EMPTY_LOCKS,
+                isLoading: false,
+            });
+            return EMPTY_LOCKS;
+        }
+
+        const activeRefresh = inFlightRefresh;
+        if (activeRefresh !== null) {
+            return activeRefresh;
+        }
+
+        inFlightRefresh = (async () => {
+            try {
+                const fetchedLocks = await getEngagementLocks(engagementId);
+                updateSnapshot({
+                    locks: fetchedLocks,
+                    isLoading: false,
+                });
+                return fetchedLocks;
+            } finally {
+                inFlightRefresh = null;
+            }
+        })();
+
+        return inFlightRefresh;
+    };
+
+    const initialize = (initialLocksPromise?: Promise<ResourceLocksForEngagement>) => {
+        if (hasInitialized) {
+            return inFlightInitialize ?? Promise.resolve();
+        }
+
+        const activeInitialize = inFlightInitialize;
+        if (activeInitialize !== null) {
+            return activeInitialize;
+        }
+
+        updateSnapshot((current) => ({
+            ...current,
+            isLoading: true,
+        }));
+
+        inFlightInitialize = (async () => {
+            const providedInitialLocksPromise = initialLocksPromise;
+            if (providedInitialLocksPromise !== undefined) {
+                try {
+                    const initialLocks = await providedInitialLocksPromise;
+                    updateSnapshot((current) => ({
+                        ...current,
+                        locks: initialLocks,
+                    }));
+                } catch {
+                    // Fall back to direct API refresh below.
+                }
+            }
+
+            try {
+                await refresh();
+            } finally {
+                hasInitialized = true;
+                updateSnapshot((current) => ({
+                    ...current,
+                    isLoading: false,
+                }));
+                inFlightInitialize = null;
+            }
+        })();
+
+        return inFlightInitialize;
+    };
+
+    const startPolling = () => {
+        if (intervalId || !Number.isFinite(engagementId) || engagementId <= 0) {
+            return;
+        }
+
+        intervalId = globalThis.setInterval(() => {
+            void refresh().catch(() => {
+                // Don't let refresh errors bubble up to the store (best-effort refresh)
+            });
+        }, currentPollIntervalMs);
+    };
+
+    const stopPolling = () => {
+        if (!intervalId) {
+            return;
+        }
+
+        globalThis.clearInterval(intervalId);
+        intervalId = null;
+    };
+
+    const startEventSubscription = () => {
+        if (unsubscribeFromEvents) {
+            return;
+        }
+
+        unsubscribeFromEvents = subscribeToResourceLockEvents((event) => {
+            updateSnapshot((current) => {
+                if (event.type === 'upsert' && event.lock.resource_id !== engagementId) {
+                    return current;
+                }
+
+                return {
+                    ...current,
+                    locks: applyResourceLockEvent(current.locks, event),
+                };
+            });
+        });
+    };
+
+    const stopEventSubscription = () => {
+        if (!unsubscribeFromEvents) {
+            return;
+        }
+
+        unsubscribeFromEvents();
+        unsubscribeFromEvents = null;
+    };
+
+    return {
+        getSnapshot: () => snapshot,
+        subscribe: (listener) => {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+        retain: (initialLocksPromise) => {
+            referenceCount += 1;
+            startEventSubscription();
+            startPolling();
+            void initialize(initialLocksPromise);
+        },
+        release: () => {
+            referenceCount = Math.max(0, referenceCount - 1);
+            if (referenceCount > 0) {
+                return false;
+            }
+
+            stopPolling();
+            stopEventSubscription();
+            return true;
+        },
+        refresh,
+        seed: (locks) => {
+            updateSnapshot((current) => ({
+                ...current,
+                locks,
+                isLoading: false,
+            }));
+        },
+        setPollIntervalMs: (nextPollIntervalMs) => {
+            if (currentPollIntervalMs === nextPollIntervalMs) {
+                return;
+            }
+
+            currentPollIntervalMs = nextPollIntervalMs;
+            if (referenceCount > 0) {
+                stopPolling();
+                startPolling();
+            }
+        },
+    };
+};
+
+const getEngagementLockStore = ({ engagementId, pollIntervalMs }: { engagementId: number; pollIntervalMs: number }) => {
+    const existingStore = engagementLockStores.get(engagementId);
+    if (existingStore) {
+        existingStore.setPollIntervalMs(pollIntervalMs);
+        return existingStore;
+    }
+
+    const store = createEngagementLockStore({ engagementId, pollIntervalMs });
+    engagementLockStores.set(engagementId, store);
+    return store;
+};
+
+export const useEngagementLocks = ({
+    engagementId,
+    initialLocksPromise,
+    refreshToken,
+    pollIntervalMs = DEFAULT_LOCK_POLL_INTERVAL_MS,
+}: {
+    engagementId: number;
+    initialLocksPromise?: Promise<ResourceLocksForEngagement>;
+    refreshToken?: unknown;
+    pollIntervalMs?: number;
+}) => {
+    const normalizedEngagementId = Number(engagementId);
+    const store = useMemo(
+        () => getEngagementLockStore({ engagementId: normalizedEngagementId, pollIntervalMs }),
+        [normalizedEngagementId, pollIntervalMs],
+    );
+    const [storeSnapshot, setStoreSnapshot] = useState<LockStoreSnapshot>(() => store.getSnapshot());
+
+    const refreshLocks = useCallback(async () => {
+        return store.refresh();
+    }, [store]);
+
+    useEffect(() => {
+        setStoreSnapshot(store.getSnapshot());
+        return store.subscribe(() => {
+            setStoreSnapshot(store.getSnapshot());
+        });
+    }, [store]);
+
+    useEffect(() => {
+        store.retain(initialLocksPromise);
+
+        return () => {
+            if (store.release()) {
+                engagementLockStores.delete(normalizedEngagementId);
+            }
+        };
+    }, [initialLocksPromise, normalizedEngagementId, store]);
+
+    useEffect(() => {
+        let cancelled = false;
+        if (initialLocksPromise === undefined) {
+            return;
+        }
+
+        void initialLocksPromise
+            .then((resolvedLocks) => {
+                if (!cancelled) {
+                    store.seed(resolvedLocks);
+                }
+            })
+            .catch(() => {
+                // Ignore lock fetch errors here, as the store will attempt to refresh locks on its own.
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [initialLocksPromise, store]);
+
+    useEffect(() => {
+        if (refreshToken === undefined) {
+            return;
+        }
+
+        void refreshLocks().catch(() => {
+            // Don't let refresh errors bubble up to the component (best-effort refresh)
+        });
+    }, [refreshLocks, refreshToken]);
+
+    return {
+        locks: storeSnapshot.locks,
+        isLoading: storeSnapshot.isLoading,
+        refreshLocks,
+    };
+};
+
+export default useEngagementLocks;

--- a/web/src/services/resourceLockService/useEngagementSectionEditLock.ts
+++ b/web/src/services/resourceLockService/useEngagementSectionEditLock.ts
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    acquireEngagementSectionLock,
+    refreshLock,
+    releaseLock,
+    ResourceLockRecord,
+} from 'services/resourceLockService';
+
+const DEFAULT_LOCK_HEARTBEAT_INTERVAL_MS = 30000;
+
+type LockScope = {
+    sectionKey: string;
+    languageId?: number;
+};
+
+export const useEngagementSectionEditLock = ({
+    engagementId,
+    scope,
+    enabled,
+    isDirty,
+    isSubmitting,
+    blockedByLock,
+    heartbeatIntervalMs = DEFAULT_LOCK_HEARTBEAT_INTERVAL_MS,
+    onConflict,
+}: {
+    engagementId: number;
+    scope: LockScope | null;
+    enabled: boolean;
+    isDirty: boolean;
+    isSubmitting: boolean;
+    blockedByLock?: ResourceLockRecord | null;
+    heartbeatIntervalMs?: number;
+    onConflict?: (error: unknown) => Promise<void> | void;
+}) => {
+    const [lockToken, setLockToken] = useState<string | null>(null);
+    const [activeScope, setActiveScope] = useState<LockScope | null>(null);
+    const lockTokenRef = useRef<string | null>(null);
+    const activeScopeRef = useRef<LockScope | null>(null);
+    const isReleasingLockRef = useRef(false);
+
+    useEffect(() => {
+        lockTokenRef.current = lockToken;
+        activeScopeRef.current = activeScope;
+    }, [activeScope, lockToken]);
+
+    const clearLockState = useCallback(() => {
+        lockTokenRef.current = null;
+        activeScopeRef.current = null;
+        setLockToken(null);
+        setActiveScope(null);
+    }, []);
+
+    const releaseActiveLock = useCallback(
+        async (releaseReason: 'explicit' | 'navigation' = 'navigation') => {
+            const token = lockTokenRef.current;
+            if (!token || isReleasingLockRef.current) {
+                return;
+            }
+
+            isReleasingLockRef.current = true;
+            try {
+                await releaseLock(token, releaseReason);
+            } catch (error) {
+                console.warn('Failed to release edit lock', error);
+            } finally {
+                isReleasingLockRef.current = false;
+                clearLockState();
+            }
+        },
+        [clearLockState],
+    );
+
+    useEffect(() => {
+        if (!enabled || !isDirty || isSubmitting || !scope || blockedByLock) {
+            return;
+        }
+
+        let isCancelled = false;
+
+        const acquireLock = async () => {
+            try {
+                const currentToken = lockTokenRef.current;
+                const currentScope = activeScopeRef.current;
+                const hasMatchingLock =
+                    currentToken &&
+                    currentScope?.sectionKey === scope.sectionKey &&
+                    currentScope?.languageId === scope.languageId;
+
+                if (hasMatchingLock) {
+                    return;
+                }
+
+                if (currentToken) {
+                    try {
+                        await releaseLock(currentToken, 'navigation');
+                    } catch (error) {
+                        console.warn('Failed to rotate edit lock', error);
+                    }
+                }
+
+                const lock = await acquireEngagementSectionLock({
+                    engagementId,
+                    sectionKey: scope.sectionKey,
+                    languageId: scope.languageId,
+                });
+
+                if (isCancelled) {
+                    try {
+                        await releaseLock(lock.lock_token, 'navigation');
+                    } catch (error) {
+                        console.warn('Failed to release cancelled edit lock', error);
+                    }
+                    return;
+                }
+
+                setLockToken(lock.lock_token);
+                setActiveScope(scope);
+            } catch (error) {
+                await onConflict?.(error);
+            }
+        };
+
+        void acquireLock();
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [blockedByLock, enabled, engagementId, isDirty, isSubmitting, onConflict, scope]);
+
+    useEffect(() => {
+        if (!lockToken || isSubmitting) {
+            return;
+        }
+
+        const intervalId = globalThis.setInterval(() => {
+            void refreshLock(lockToken).catch((error) => {
+                console.warn('Failed to refresh edit lock', error);
+                clearLockState();
+            });
+        }, heartbeatIntervalMs);
+
+        return () => {
+            globalThis.clearInterval(intervalId);
+        };
+    }, [clearLockState, heartbeatIntervalMs, isSubmitting, lockToken]);
+
+    useEffect(() => {
+        if (!lockToken && !activeScope) {
+            return;
+        }
+
+        if (!enabled || !scope) {
+            void releaseActiveLock('navigation');
+            return;
+        }
+
+        if (scope.sectionKey !== activeScope?.sectionKey) {
+            void releaseActiveLock('navigation');
+            return;
+        }
+
+        if (scope.languageId === undefined || activeScope?.languageId === scope.languageId) {
+            return;
+        }
+
+        void releaseActiveLock('navigation');
+    }, [activeScope, enabled, lockToken, releaseActiveLock, scope]);
+
+    useEffect(() => {
+        if (lockToken && !isDirty && !isSubmitting) {
+            void releaseActiveLock('explicit');
+        }
+    }, [isDirty, isSubmitting, lockToken, releaseActiveLock]);
+
+    useEffect(() => {
+        const bestEffortRelease = () => {
+            const token = lockTokenRef.current;
+            if (!token) {
+                return;
+            }
+
+            void releaseLock(token, 'navigation').catch((error) => {
+                console.warn('Failed best-effort release on page exit', error);
+            });
+        };
+
+        globalThis.addEventListener('beforeunload', bestEffortRelease);
+        globalThis.addEventListener('pagehide', bestEffortRelease);
+
+        return () => {
+            globalThis.removeEventListener('beforeunload', bestEffortRelease);
+            globalThis.removeEventListener('pagehide', bestEffortRelease);
+            void releaseActiveLock('navigation');
+        };
+    }, [releaseActiveLock]);
+
+    return {
+        activeLockToken: lockToken,
+        activeLockScope: activeScope,
+        releaseActiveLock,
+    };
+};
+
+export default useEngagementSectionEditLock;

--- a/web/src/services/type.ts
+++ b/web/src/services/type.ts
@@ -2,3 +2,5 @@ export interface Page<T> {
     items: T[];
     total: number;
 }
+
+export type RequestHeaders = Record<string, string>;


### PR DESCRIPTION
Issue #: [🎟️ DEP-284](https://citz-gdx.atlassian.net/browse/DEP-284)

**Description of changes:**
- **Feature** Added engagement locking UX for Engagements
  - Implemented resource lock related routes, types, and services for components in the DEP web app to consume
  - Updated navigation in the engagement config and authoring pages to check for active locks on the engagement resource before allowing navigation to other sections. If a lock is detected, the user is shown a modal informing them that the engagement is locked by another user and cannot be edited.

**User Guide update ticket (if applicable):**

- - [x] Yes, a user guide update ticket has been created. https://citz-gdx.atlassian.net/browse/DEP-360
- - [ ] No, a user guide update ticket is not required.

**Common component changes:**

- - [ ] Yes, I have updated CONTRIBUTING.md and the docblocks to document any changes to the common components.
- - [x] No, there are no changes to the common components.
